### PR TITLE
Replace ByteBuffer with byte[] in InodeRawTable

### DIFF
--- a/core/src/main/java/tachyon/master/RawTables.java
+++ b/core/src/main/java/tachyon/master/RawTables.java
@@ -126,7 +126,8 @@ public class RawTables extends ImageWriter {
    */
   public synchronized Pair<Integer, ByteBuffer> getTableInfo(int tableId) {
     Pair<Integer, byte[]> retVal = mData.get(tableId);
-    Pair<Integer, ByteBuffer> ret = new Pair<Integer, ByteBuffer>(retVal.getFirst(), ByteBuffer.wrap(retVal.getSecond()));
+    Pair<Integer, ByteBuffer> ret = new Pair<Integer, ByteBuffer>(retVal.getFirst(), 
+        ByteBuffer.wrap(retVal.getSecond()));
     return ret;
   }
 
@@ -172,11 +173,6 @@ public class RawTables extends ImageWriter {
       throw new TachyonException("The raw table " + tableId + " does not exist.");
     }
     Pair<Integer, ByteBuffer> data = new Pair<Integer, ByteBuffer>(dataBytes.getFirst(), null);
-    /*if (null == oldMetadata) {
-      data = new Pair<Integer, ByteBuffer>(dataBytes.getFirst(), ByteBuffer.allocate(0));
-    } else {
-      data = new Pair<Integer, ByteBuffer>(dataBytes.getFirst(), ByteBuffer.wrap(oldMetadata.clone()));
-    }*/
     if (metadata == null) {
       dataBytes.setSecond(new byte[]{});
     } else {


### PR DESCRIPTION
This is a PR in response to TACHYON-6 jira.
ByteBuffer is still needed in other parts of the code because eventually it serializes into ByteBuffer. 

