### PR TITLE
These changes add support for checkstyle in Eclipse.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -401,9 +401,7 @@
           <!-- TODO: This is needed to excuse Tachyon Configuration members' name from being -->
           <!-- checked because the members are define using all upper case. -->
           <!-- Once the new configuration is implemented we wil remove this exception -->
-          <suppressionsLocation>
-            ${project.basedir}/src/main/resources/tachyon_checkstyle_suppressions.xml
-          </suppressionsLocation>
+          <propertyExpansion>basedir=${basedir}</propertyExpansion>
           <encoding>UTF-8</encoding>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -404,7 +404,6 @@
           <suppressionsLocation>
             ${project.basedir}/src/main/resources/tachyon_checkstyle_suppressions.xml
           </suppressionsLocation>
-          <excludes>**/tachyon/thrift/**</excludes>
           <encoding>UTF-8</encoding>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
@@ -427,6 +426,30 @@
           </dependency>
         </dependencies>
       </plugin>
+             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-eclipse-plugin</artifactId>
+                <configuration>
+                        <additionalBuildcommands>
+                                <buildcommand>net.sf.eclipsecs.core.CheckstyleBuilder</buildcommand>
+                        </additionalBuildcommands>
+                        <additionalProjectnatures>
+                                <projectnature>net.sf.eclipsecs.core.CheckstyleNature</projectnature>
+                        </additionalProjectnatures>
+                        <additionalConfig>
+                                <file>
+                                        <name>.checkstyle</name>
+                                        <location>src/main/resources/eclipse-checkstyle.xml</location>
+                                </file>
+                                <file>
+                                        <name>.tachyon_checks.xml</name>
+                                        <location>src/main/resources/tachyon_checks.xml</location>
+                                </file>
+                        </additionalConfig>
+                </configuration>
+
+        </plugin>
+
     </plugins>
   </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -425,29 +425,27 @@
         </dependencies>
       </plugin>
       <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-eclipse-plugin</artifactId>
-                <configuration>
-                        <additionalBuildcommands>
-                                <buildcommand>net.sf.eclipsecs.core.CheckstyleBuilder</buildcommand>
-                        </additionalBuildcommands>
-                        <additionalProjectnatures>
-                                <projectnature>net.sf.eclipsecs.core.CheckstyleNature</projectnature>
-                        </additionalProjectnatures>
-                        <additionalConfig>
-                                <file>
-                                        <name>.checkstyle</name>
-                                        <location>src/main/resources/eclipse-checkstyle.xml</location>
-                                </file>
-                                <file>
-                                        <name>.tachyon_checks.xml</name>
-                                        <location>src/main/resources/tachyon_checks.xml</location>
-                                </file>
-                        </additionalConfig>
-                </configuration>
-
-        </plugin>
-
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-eclipse-plugin</artifactId>
+        <configuration>
+          <additionalBuildcommands>
+            <buildcommand>net.sf.eclipsecs.core.CheckstyleBuilder</buildcommand>
+          </additionalBuildcommands>
+          <additionalProjectnatures>
+            <projectnature>net.sf.eclipsecs.core.CheckstyleNature</projectnature>
+          </additionalProjectnatures>
+          <additionalConfig>
+           <file>
+             <name>.checkstyle</name>
+             <location>src/main/resources/eclipse-checkstyle.xml</location>
+           </file>
+           <file>
+             <name>.tachyon_checks.xml</name>
+             <location>src/main/resources/tachyon_checks.xml</location>
+           </file>
+          </additionalConfig>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -424,7 +424,7 @@
           </dependency>
         </dependencies>
       </plugin>
-             <plugin>
+      <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-eclipse-plugin</artifactId>
                 <configuration>

--- a/core/src/main/resources/eclipse-checkstyle.xml
+++ b/core/src/main/resources/eclipse-checkstyle.xml
@@ -1,0 +1,8 @@
+<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="true">
+    <local-check-config name="tachyon.checkstyle" location=".tachyon_checks.xml" type="project" description="tachyon style">
+        <additional-data name="protect-config-file" value="false"/>
+    </local-check-config>
+    <fileset name="all" enabled="true" check-config-name="tachyon.checkstyle" local="true">
+        <file-match-pattern match-pattern="." include-pattern="true"/>
+    </fileset>
+</fileset-config>

--- a/core/src/main/resources/tachyon_checks.xml
+++ b/core/src/main/resources/tachyon_checks.xml
@@ -172,4 +172,8 @@
                value="Static member name ''{0}'' must match pattern ''{1}''."/>
     </module>
   </module>
+  <module name="SuppressionFilter">
+    <property name="file" value="${basedir}/src/main/resources/tachyon_checkstyle_suppressions.xml"/>
+  </module>
+    
 </module>

--- a/core/src/main/resources/tachyon_checkstyle_suppressions.xml
+++ b/core/src/main/resources/tachyon_checkstyle_suppressions.xml
@@ -10,4 +10,8 @@
 <suppressions>
   <suppress checks="MemberNameCheck"
             files=".*Conf.java"/>
+
+  <suppress checks="."  
+            files="tachyon[\\/]thrift[\\/]"/>
+
 </suppressions>


### PR DESCRIPTION
* Removed eclipse formatter settings
* Added configuration for Eclipse Checkstyle plugin
* Generate Eclipse code format rules based on checkstyle settings

Build should work as before.  Install the Eclipse Checkstyle plugin to take advantage of the configuration and formatter. 

