### PR TITLE
Once user calls freePath, remove block location information of the file from master immediately

### DIFF
--- a/core/src/main/java/tachyon/master/BlockInfo.java
+++ b/core/src/main/java/tachyon/master/BlockInfo.java
@@ -184,6 +184,13 @@ public class BlockInfo {
     mLocations.remove(workerId);
   }
 
+  /**
+   * Remove all locations of the block
+   */
+  public synchronized void removeLocations() {
+    mLocations.clear();
+  }
+
   @Override
   public synchronized String toString() {
     StringBuilder sb = new StringBuilder("BlockInfo(mBlockIndex: ");

--- a/core/src/main/java/tachyon/master/BlockInfo.java
+++ b/core/src/main/java/tachyon/master/BlockInfo.java
@@ -185,7 +185,7 @@ public class BlockInfo {
   }
 
   /**
-   * Remove all locations of the block
+   * Remove all in memory locations of the block
    */
   public synchronized void removeLocations() {
     mLocations.clear();

--- a/core/src/main/java/tachyon/master/InodeFile.java
+++ b/core/src/main/java/tachyon/master/InodeFile.java
@@ -382,6 +382,15 @@ public class InodeFile extends Inode {
   }
 
   /**
+   * Remove block locations of the file.
+   */
+  public synchronized void removeLocations() {
+    for (BlockInfo blockInfo : mBlocks) {
+      blockInfo.removeLocations();
+    }
+  }
+
+  /**
    * Set whether the file is cacheable or not.
    * 
    * @param cache If true, the file is cacheable

--- a/core/src/main/java/tachyon/master/InodeFile.java
+++ b/core/src/main/java/tachyon/master/InodeFile.java
@@ -382,7 +382,7 @@ public class InodeFile extends Inode {
   }
 
   /**
-   * Remove block locations of the file.
+   * Remove in memory block locations of the file.
    */
   public synchronized void removeLocations() {
     for (BlockInfo blockInfo : mBlocks) {

--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -2189,6 +2189,7 @@ public class MasterInfo extends ImageWriter {
               }
             }
           }
+          ((InodeFile) freeInode).removeLocations();
         }
       }
     }

--- a/core/src/test/java/tachyon/command/TFsShellTest.java
+++ b/core/src/test/java/tachyon/command/TFsShellTest.java
@@ -41,10 +41,8 @@ import tachyon.client.ReadType;
 import tachyon.client.TachyonFile;
 import tachyon.client.TachyonFS;
 import tachyon.client.WriteType;
-import tachyon.conf.WorkerConf;
 import tachyon.master.LocalTachyonCluster;
 import tachyon.thrift.ClientBlockInfo;
-import tachyon.thrift.ClientFileInfo;
 import tachyon.util.CommonUtils;
 import tachyon.util.NetworkUtils;
 

--- a/core/src/test/java/tachyon/command/TFsShellTest.java
+++ b/core/src/test/java/tachyon/command/TFsShellTest.java
@@ -44,6 +44,7 @@ import tachyon.client.WriteType;
 import tachyon.conf.WorkerConf;
 import tachyon.master.LocalTachyonCluster;
 import tachyon.thrift.ClientBlockInfo;
+import tachyon.thrift.ClientFileInfo;
 import tachyon.util.CommonUtils;
 import tachyon.util.NetworkUtils;
 
@@ -521,7 +522,6 @@ public class TFsShellTest {
   public void freeTest() throws IOException {
     TestUtils.createByteFile(mTfs, "/testFile", WriteType.MUST_CACHE, 10);
     mFsShell.free(new String[]{"free", "/testFile"});
-    CommonUtils.sleepMs(null, WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS *2);;
-    Assert.assertFalse(mTfs.getFile(new TachyonURI("/testFile")).isInMemory()); ;
+    Assert.assertFalse(mTfs.getFile(new TachyonURI("/testFile")).isInMemory());
   }
 }


### PR DESCRIPTION
currently when user calls freePath, Tachyon first delete block files on worker, and then delete location information on master. 
this may cause such issue:
if some user calls freePath to free some file, after that another user wants to read the file, but the location information is not deleted from master yet, then user will get corrupt location information of the block files. 

This change makes Tachyon first delete location information on master, and then delete block files on worker (act like delete). so that once some user calls freePath to free in memory blocks of some file / directory. other users can't get in memory locations of the file / directory any more.

https://tachyon.atlassian.net/browse/TACHYON-256