### PR TITLE
Simplify WorkerClient

### DIFF
--- a/core/src/main/java/tachyon/worker/WorkerClient.java
+++ b/core/src/main/java/tachyon/worker/WorkerClient.java
@@ -18,6 +18,7 @@ package tachyon.worker;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -195,7 +196,10 @@ public class WorkerClient implements Closeable {
         LOG.info("Trying to get local worker host : " + localHostName);
         workerNetAddress = mMasterClient.user_getWorker(false, localHostName);
         mIsLocal = true;
-      } catch (Exception e) {
+      } catch (NoWorkerException e) {
+        LOG.info(e.getMessage());
+        workerNetAddress = null;
+      } catch (UnknownHostException e) {
         LOG.info(e.getMessage());
         workerNetAddress = null;
       }


### PR DESCRIPTION
Just because I found `WorkerClient:connect` has a better look in this way, no logic changed in `connect`.

Logic changed in `accessBlock`, I wonder why original code didn't try to reconnect if `connect()` fail once.