### PR TITLE
Decouple cancel and close in BlockOutStream and fix and refactor recache in TachyonFile

### DIFF
--- a/core/src/main/java/tachyon/client/BlockOutStream.java
+++ b/core/src/main/java/tachyon/client/BlockOutStream.java
@@ -139,10 +139,10 @@ public class BlockOutStream extends OutStream {
 
   @Override
   public void close() throws IOException {
-    if (canWrite() && mBuffer.position() > 0) {
-      appendCurrentBuffer(mBuffer.array(), 0, mBuffer.position());
-    }
     if (!mClosed) {
+      if (mBuffer.position() > 0) {
+        appendCurrentBuffer(mBuffer.array(), 0, mBuffer.position());
+      }
       mCloser.close();
       mTachyonFS.cacheBlock(mBlockId);
       mClosed = true;

--- a/core/src/main/java/tachyon/client/TachyonFile.java
+++ b/core/src/main/java/tachyon/client/TachyonFile.java
@@ -478,16 +478,17 @@ public class TachyonFile implements Comparable<TachyonFile> {
     String path = getUfsPath();
     UnderFileSystem underFsClient = UnderFileSystem.get(path);
 
+    InputStream inputStream = null;
     BlockOutStream bos = null;
     try {
-      InputStream inputStream = underFsClient.open(path);
+      inputStream = underFsClient.open(path);
 
       long length = getBlockSizeByte();
       long offset = blockIndex * length;
       inputStream.skip(offset);
 
-      bos = new BlockOutStream(this, WriteType.TRY_CACHE, blockIndex);
       byte[] buffer = new byte[mUserConf.FILE_BUFFER_BYTES * 4];
+      bos = new BlockOutStream(this, WriteType.TRY_CACHE, blockIndex);
       int limit;
       while (length > 0 && ((limit = inputStream.read(buffer)) >= 0)) {
         if (limit != 0) {
@@ -507,6 +508,10 @@ public class TachyonFile implements Comparable<TachyonFile> {
         bos.cancel();
       }
       return false;
+    } finally {
+      if (inputStream != null) {
+        inputStream.close();
+      }
     }
 
     return true;

--- a/core/src/test/java/tachyon/client/TachyonFileTest.java
+++ b/core/src/test/java/tachyon/client/TachyonFileTest.java
@@ -36,6 +36,7 @@ import tachyon.util.CommonUtils;
 public class TachyonFileTest {
   private static final int WORKER_CAPACITY_BYTES = 1000;
   private static final int USER_QUOTA_UNIT_BYTES = 100;
+  private static final int FILE_BUFFER_BYTES = WORKER_CAPACITY_BYTES / 4;
   private static final int WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS =
       WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS;
   private static final int MAX_FILES = WORKER_CAPACITY_BYTES / USER_QUOTA_UNIT_BYTES;
@@ -51,11 +52,13 @@ public class TachyonFileTest {
   public final void after() throws Exception {
     mLocalTachyonCluster.stop();
     System.clearProperty("tachyon.user.quota.unit.bytes");
+    System.clearProperty("tachyon.user.file.buffer.bytes");
   }
 
   @Before
   public final void before() throws IOException {
     System.setProperty("tachyon.user.quota.unit.bytes", USER_QUOTA_UNIT_BYTES + "");
+    System.setProperty("tachyon.user.file.buffer.bytes", FILE_BUFFER_BYTES + "");
     mLocalTachyonCluster = new LocalTachyonCluster(WORKER_CAPACITY_BYTES);
     mLocalTachyonCluster.start();
     mTfs = mLocalTachyonCluster.getClient();


### PR DESCRIPTION
1. decoupling cancel and close in BlockOutStream, because cancel and close actually runs different code path. and close method calls appendCurrentBuffer, which means it also write data,  if exception happens during appendCurrentBuffer in close, caller will not be able to cancel the block, it is a bug. for example recache operation in TachyonFile. 

2. fix bug and refactor recache method in TacyonFile .