### PR TITLE
Added slaves file back since it was breaking bigtop rpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ tests.log*
 .metadata/
 .settings/
 conf/tachyon-env.sh
-conf/slaves
 core/dependency-reduced-pom.xml
 data/
 deploy/vagrant/conf/

--- a/conf/slaves
+++ b/conf/slaves
@@ -1,0 +1,2 @@
+# A Tachyon Worker will be started on each of the machines listed below.
+localhost


### PR DESCRIPTION
In order to have the bigtop RPM generated off master, need to add the slaves file back.