### PR TITLE
Avoid block index out of bound exception in getLocationHosts

### DIFF
--- a/core/src/main/java/tachyon/client/TachyonFile.java
+++ b/core/src/main/java/tachyon/client/TachyonFile.java
@@ -205,14 +205,12 @@ public class TachyonFile implements Comparable<TachyonFile> {
    */
   public List<String> getLocationHosts() throws IOException {
     List<String> ret = new ArrayList<String>();
-    if (getNumberOfBlocks() == 0) {
-      return ret;
-    }
-
-    List<NetAddress> locations = getClientBlockInfo(0).getLocations();
-    if (locations != null) {
-      for (int k = 0; k < locations.size(); k ++) {
-        ret.add(locations.get(k).mHost);
+    if (getNumberOfBlocks() > 0) {
+      List<NetAddress> locations = getClientBlockInfo(0).getLocations();
+      if (locations != null) {
+        for (int k = 0; k < locations.size(); k ++) {
+          ret.add(locations.get(k).mHost);
+        }
       }
     }
 

--- a/core/src/main/java/tachyon/client/TachyonFile.java
+++ b/core/src/main/java/tachyon/client/TachyonFile.java
@@ -204,10 +204,13 @@ public class TachyonFile implements Comparable<TachyonFile> {
    * @throws IOException
    */
   public List<String> getLocationHosts() throws IOException {
+    List<String> ret = new ArrayList<String>();
+    if (getNumberOfBlocks() == 0) {
+      return ret;
+    }
+
     List<NetAddress> locations = getClientBlockInfo(0).getLocations();
-    List<String> ret = null;
     if (locations != null) {
-      ret = new ArrayList<String>(locations.size());
       for (int k = 0; k < locations.size(); k ++) {
         ret.add(locations.get(k).mHost);
       }


### PR DESCRIPTION
When a file has 0 block (i.e. touch a file), calling TachyonFile.getLocationHosts throws a BlockInfoException with message "BlockIndex is out of the boundry: 0". This can be avoid by returnning an empty List in getLocationHosts. This can be reproduced by "bin/tachyon tfs touch /testfile" and "bin/tachyon tfs location /testfile"
In spark code, TachyonStore.scala also calls file.getLocationHosts.size which may through the exception.