### PR TITLE
TACHYON-265: UnderFileSystemCluster may get wrong cluster with different...

### DIFF
--- a/core/src/test/java/tachyon/UnderFileSystemCluster.java
+++ b/core/src/test/java/tachyon/UnderFileSystemCluster.java
@@ -15,6 +15,8 @@
 package tachyon;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.google.common.base.Throwables;
 
@@ -51,8 +53,12 @@ public abstract class UnderFileSystemCluster {
    * @throws InterruptedException
    */
   public static synchronized UnderFileSystemCluster get(String baseDir) throws IOException {
-    if (null == mUnderFSCluster || !mUnderFSCluster.mBaseDir.equals(baseDir)) {
+    UnderFileSystemCluster mUnderFSCluster;
+    if (!mDirToUfsCluster.containsKey(baseDir)) {
       mUnderFSCluster = getUnderFilesystemCluster(baseDir);
+      mDirToUfsCluster.put(baseDir, mUnderFSCluster);
+    } else {
+      mUnderFSCluster = mDirToUfsCluster.get(baseDir);
     }
 
     if (!mUnderFSCluster.isStarted()) {
@@ -83,7 +89,8 @@ public abstract class UnderFileSystemCluster {
 
   protected String mBaseDir;
 
-  private static UnderFileSystemCluster mUnderFSCluster = null;
+  private static final Map<String, UnderFileSystemCluster> mDirToUfsCluster =
+      new HashMap<String, UnderFileSystemCluster>();
 
   /**
    * This method is only for unit-test {@link tachyon.client.FileOutStreamTest} temporally

--- a/core/src/test/java/tachyon/UnderFileSystemCluster.java
+++ b/core/src/test/java/tachyon/UnderFileSystemCluster.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -46,12 +46,12 @@ public abstract class UnderFileSystemCluster {
 
   /**
    * To start the underfs test bed and register the shutdown hook
-   * 
+   *
    * @throws IOException
    * @throws InterruptedException
    */
   public static synchronized UnderFileSystemCluster get(String baseDir) throws IOException {
-    if (null == mUnderFSCluster) {
+    if (null == mUnderFSCluster || !mUnderFSCluster.mBaseDir.equals(baseDir)) {
       mUnderFSCluster = getUnderFilesystemCluster(baseDir);
     }
 
@@ -87,7 +87,7 @@ public abstract class UnderFileSystemCluster {
 
   /**
    * This method is only for unit-test {@link tachyon.client.FileOutStreamTest} temporally
-   * 
+   *
    * @return
    */
   public static boolean isUFSHDFS() {
@@ -103,7 +103,7 @@ public abstract class UnderFileSystemCluster {
    * system for the next test round instead of turning on/off it from time to time. This function is
    * expected to be called either before or after each test case which avoids certain overhead from
    * the bootstrap.
-   * 
+   *
    * @throws IOException
    */
   public void cleanup() throws IOException {
@@ -120,7 +120,7 @@ public abstract class UnderFileSystemCluster {
 
   /**
    * Check if the cluster started.
-   * 
+   *
    * @return
    */
   public abstract boolean isStarted();
@@ -128,7 +128,7 @@ public abstract class UnderFileSystemCluster {
   /**
    * Add a shutdown hook. The {@link #shutdown} phase will be automatically called while the process
    * exists.
-   * 
+   *
    * @throws InterruptedException
    */
   public void registerJVMOnExistHook() throws IOException {
@@ -137,14 +137,14 @@ public abstract class UnderFileSystemCluster {
 
   /**
    * To stop the underfs cluster system
-   * 
+   *
    * @throws IOException
    */
   public abstract void shutdown() throws IOException;
 
   /**
    * To start the underfs cluster system
-   * 
+   *
    * @throws IOException
    */
   public abstract void start() throws IOException;

--- a/core/src/test/java/tachyon/UnderFileSystemClusterTest.java
+++ b/core/src/test/java/tachyon/UnderFileSystemClusterTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package tachyon;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link UnderFileSystemCluster}
+ */
+public class UnderFileSystemClusterTest {
+
+  @Test
+  public void getUnderFilesystemAddressTest() throws IOException {
+    String mTachyon1Dir = "/tmp/mTachyonHome1/dfs";
+    String mTachyon2Dir = "/tmp/mTachyonHome2/dfs";
+    UnderFileSystemCluster mUnderFSCluster1 = UnderFileSystemCluster.get(mTachyon1Dir);
+    UnderFileSystemCluster mUnderFSCluster2 = UnderFileSystemCluster.get(mTachyon2Dir);
+    Assert.assertEquals(mUnderFSCluster1.getUnderFilesystemAddress(), mTachyon1Dir);
+    Assert.assertEquals(mUnderFSCluster2.getUnderFilesystemAddress(), mTachyon2Dir);
+  }
+}

--- a/core/src/test/java/tachyon/UnderFileSystemClusterTest.java
+++ b/core/src/test/java/tachyon/UnderFileSystemClusterTest.java
@@ -30,7 +30,7 @@ public class UnderFileSystemClusterTest {
     String mTachyon2Dir = "/tmp/mTachyonHome2/dfs";
     UnderFileSystemCluster mUnderFSCluster1 = UnderFileSystemCluster.get(mTachyon1Dir);
     UnderFileSystemCluster mUnderFSCluster2 = UnderFileSystemCluster.get(mTachyon2Dir);
-    Assert.assertEquals(mUnderFSCluster1.getUnderFilesystemAddress(), mTachyon1Dir);
-    Assert.assertEquals(mUnderFSCluster2.getUnderFilesystemAddress(), mTachyon2Dir);
+    Assert.assertEquals(mUnderFSCluster1.mBaseDir, mTachyon1Dir);
+    Assert.assertEquals(mUnderFSCluster2.mBaseDir, mTachyon2Dir);
   }
 }


### PR DESCRIPTION
"mUnderFSCluster" is static value, firstly if baseDir is "/tmp/dir1", we get a cluster(e.g. cluster1). Secondly, even though baseDir is different(e.g. "/tmp/dir2"), it also return the instance of cluster1. But as for different baseDir, it will return different cluster.