### PR TITLE
Fix Jetty hang issue and set Acceptor thread number

### DIFF
--- a/core/src/main/java/tachyon/conf/MasterConf.java
+++ b/core/src/main/java/tachyon/conf/MasterConf.java
@@ -81,7 +81,7 @@ public class MasterConf extends Utils {
         (CommonConf.get().USE_ZOOKEEPER ? Constants.HEADER_FT : Constants.HEADER) + HOSTNAME + ":"
             + PORT;
     WEB_PORT = getIntProperty("tachyon.master.web.port", Constants.DEFAULT_MASTER_WEB_PORT);
-    WEB_THREAD_COUNT = getIntProperty("tachyon.master.web.threads", 9);
+    WEB_THREAD_COUNT = getIntProperty("tachyon.master.web.threads", 1);
     TEMPORARY_FOLDER = getProperty("tachyon.master.temporary.folder", "/tmp");
 
     HEARTBEAT_INTERVAL_MS =

--- a/core/src/test/java/tachyon/master/LocalTachyonCluster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonCluster.java
@@ -170,7 +170,7 @@ public final class LocalTachyonCluster {
     System.setProperty("tachyon.worker.selector.threads", Integer.toString(1));
     System.setProperty("tachyon.worker.server.threads", Integer.toString(2));
     System.setProperty("tachyon.worker.network.netty.worker.threads", Integer.toString(2));
-    System.setProperty("tachyon.master.web.threads", Integer.toString(9));
+    System.setProperty("tachyon.master.web.threads", Integer.toString(1));
 
     CommonConf.clear();
     MasterConf.clear();

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -149,7 +149,7 @@ number.
 </tr>
 <tr>
   <td>tachyon.master.web.threads</td>
-  <td>9</td>
+  <td>1</td>
   <td>How many threads to use for the web server.</td>
 </tr>
 <tr>


### PR DESCRIPTION
On a server with more that 16 cores, the Web server hangs and does not respond because the default tachyon.master.web.threads is set to 9. The setting tachyon.master.web.threads is now actually limit the maximum thread pool size.
When Jetty server starts, it internally creates N acceptor threads and N selector threads by default. Acceptors are threads dedicated to accepting incoming connections, while selectors manage events on connected sockets. N is determined by processor number which equal to (processor number + 3) / 4. So on a server with 48 cores, it by default creates 12 acceptor threads and 12 selector threads. The thread pool max size has to be 25(1+selectors+acceptors) or above, otherwise Jetty does not work with a error message "insufficient threads ...".
For Tachyon Web UI, we don't need so much acceptor and selector threads. So intead of limiting the max thread pool size, we can set the acceptor and selector thread number. This limits the initial thread size that Jetty creates and also avoid hang issue on server with a lot of cores.

