### PR TITLE
fix under fs and glusterfs configuration issues

### DIFF
--- a/core/src/main/java/tachyon/UnderFileSystemHdfs.java
+++ b/core/src/main/java/tachyon/UnderFileSystemHdfs.java
@@ -64,17 +64,24 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
     mUfsPrefix = fsDefaultName;
     Configuration tConf;
     if (conf != null) {
-      tConf = (Configuration) conf;
+      tConf = new Configuration((Configuration) conf);
     } else {
       tConf = new Configuration();
     }
     String glusterfsPrefix = "glusterfs:///";
+    tConf.set("fs.defaultFS", fsDefaultName);
     if (fsDefaultName.startsWith(glusterfsPrefix)) {
-      tConf.set("fs.glusterfs.impl", CommonConf.get().UNDERFS_GLUSTERFS_IMPL);
-      tConf.set("mapred.system.dir", CommonConf.get().UNDERFS_GLUSTERFS_MR_DIR);
-      tConf.set("fs.glusterfs.volumes", CommonConf.get().UNDERFS_GLUSTERFS_VOLUMES);
-      tConf.set("fs.glusterfs.volume.fuse." + CommonConf.get().UNDERFS_GLUSTERFS_VOLUMES,
-          CommonConf.get().UNDERFS_GLUSTERFS_MOUNTS);
+      if (tConf.get("fs.glusterfs.impl") == null) {
+        tConf.set("fs.glusterfs.impl", CommonConf.get().UNDERFS_GLUSTERFS_IMPL);
+      }
+      if (tConf.get("mapred.system.dir") == null) {
+        tConf.set("mapred.system.dir", CommonConf.get().UNDERFS_GLUSTERFS_MR_DIR);
+      }
+      if (tConf.get("fs.glusterfs.volumes") == null) {
+        tConf.set("fs.glusterfs.volumes", CommonConf.get().UNDERFS_GLUSTERFS_VOLUMES);
+        tConf.set("fs.glusterfs.volume.fuse." + CommonConf.get().UNDERFS_GLUSTERFS_VOLUMES,
+                  CommonConf.get().UNDERFS_GLUSTERFS_MOUNTS);
+      }
     } else {
       tConf.set("fs.hdfs.impl", CommonConf.get().UNDERFS_HDFS_IMPL);
 

--- a/core/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/core/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -228,7 +228,9 @@ abstract class AbstractTFS extends FileSystem {
   private void fromHdfsToTachyon(TachyonURI path) throws IOException {
     if (!mTFS.exist(path)) {
       Path hdfsPath = Utils.getHDFSPath(path, mUnderFSAddress);
-      FileSystem fs = hdfsPath.getFileSystem(getConf());
+      Configuration conf = new Configuration(getConf());
+      conf.set("fs.defaultFS", mUnderFSAddress);
+      FileSystem fs = hdfsPath.getFileSystem(conf);
       if (fs.exists(hdfsPath)) {
         TachyonURI ufsUri = new TachyonURI(mUnderFSAddress);
         TachyonURI ufsAddrPath = new TachyonURI(ufsUri.getScheme(), ufsUri.getAuthority(),

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.6</java.version>
     <hadoop.version>1.0.4</hadoop.version>
-    <glusterfs-hadoop.version>2.3.5</glusterfs-hadoop.version>
+    <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
     <libthrift.version>0.9.1</libthrift.version>
     <cxf.version>2.7.0</cxf.version>
     <jetty.version>7.6.15.v20140411</jetty.version>


### PR DESCRIPTION
When tachyon is used for MapReduce jobs, under fs may not be properly initialized.
This fix is to set those properties before under fs initialize() is called. If the properties are already set in core-site.xml, then don't overwrite them.

On my glutster setup, a wordcount test was run to validate this patch. Separately, @pfxuan validated part of the fix on his setup using orangefs as under fs.

The core-site.xml in use can be found at http://pastebin.com/SMpP6VXa

The wordcount test output can be found at http://pastebin.com/XXRPQRFt