### PR TITLE
handle non-existent path in TFsShell

### DIFF
--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -556,7 +556,8 @@ public class TachyonFS extends AbstractTachyonFS {
    */
   public synchronized int getFileId(TachyonURI path) throws IOException {
     try {
-      return getFileStatus(-1, path, false).getId();
+      ClientFileInfo fileInfo = getFileStatus(-1, path, false);
+      return fileInfo == null ? -1 : fileInfo.getId();
     } catch (IOException e) {
       return -1;
     }

--- a/core/src/main/java/tachyon/command/TFsShell.java
+++ b/core/src/main/java/tachyon/command/TFsShell.java
@@ -39,6 +39,7 @@ import tachyon.client.WriteType;
 import tachyon.conf.UserConf;
 import tachyon.thrift.ClientBlockInfo;
 import tachyon.thrift.ClientFileInfo;
+import tachyon.thrift.FileDoesNotExistException;
 import tachyon.util.CommonUtils;
 
 /**
@@ -224,16 +225,24 @@ public class TFsShell implements Closeable {
       return -1;
     }
     TachyonURI path = new TachyonURI(argv[1]);
-    long[] values = countHelper(path);
-    String format = "%-25s%-25s%-15s%n";
-    System.out.format(format, "File Count", "Folder Count", "Total Bytes");
-    System.out.format(format, values[0], values[1], values[2]);
+    try {
+      long[] values = countHelper(path);
+      String format = "%-25s%-25s%-15s%n";
+      System.out.format(format, "File Count", "Folder Count", "Total Bytes");
+      System.out.format(format, values[0], values[1], values[2]);
+    } catch (FileDoesNotExistException e) {
+      System.out.println(e.getMessage() + " does not exist.");
+      return -1;
+    }
     return 0;
   }
 
-  private long[] countHelper(TachyonURI path) throws IOException {
+  private long[] countHelper(TachyonURI path) throws FileDoesNotExistException, IOException {
     TachyonFS tachyonClient = createFS(path);
     TachyonFile tFile = tachyonClient.getFile(path);
+    if (tFile == null) {
+      throw new FileDoesNotExistException(path.toString());
+    }
 
     if (tFile.isFile()) {
       return new long[] {1L, 0L, tFile.length()};
@@ -267,6 +276,10 @@ public class TFsShell implements Closeable {
     TachyonURI path = new TachyonURI(argv[1]);
     TachyonFS tachyonClient = createFS(path);
     int fileId = tachyonClient.getFileId(path);
+    if (fileId == -1) {
+      System.out.println(path + " does not exist.");
+      return -1;
+    }
     List<ClientBlockInfo> blocks = tachyonClient.getFileBlocks(fileId);
     System.out.println(path + " with file id " + fileId + " has the following blocks: ");
     for (ClientBlockInfo block : blocks) {
@@ -290,6 +303,10 @@ public class TFsShell implements Closeable {
     TachyonURI path = new TachyonURI(argv[1]);
     TachyonFS tachyonClient = createFS(path);
     int fileId = tachyonClient.getFileId(path);
+    if (fileId == -1) {
+      System.out.println(path + " does not exist.");
+      return -1;
+    }
     List<String> hosts = tachyonClient.getFile(fileId).getLocationHosts();
     System.out.println(path + " with file id " + fileId + " is on nodes: ");
     for (String host : hosts) {

--- a/core/src/test/java/tachyon/command/TFsShellTest.java
+++ b/core/src/test/java/tachyon/command/TFsShellTest.java
@@ -197,6 +197,13 @@ public class TFsShellTest {
   }
 
   @Test
+  public void countNotExistTest() throws IOException {
+    int ret = mFsShell.count(new String[] {"count", "/NotExistFile"});
+    Assert.assertEquals("/NotExistFile does not exist.\n", mOutput.toString());
+    Assert.assertEquals(-1, ret);
+  }
+
+  @Test
   public void countTest() throws IOException {
     TestUtils.createByteFile(mTfs, "/testRoot/testFileA", WriteType.MUST_CACHE, 10);
     TestUtils.createByteFile(mTfs, "/testRoot/testDir/testFileB", WriteType.MUST_CACHE, 20);
@@ -207,6 +214,13 @@ public class TFsShellTest {
     expected += String.format(format, "File Count", "Folder Count", "Total Bytes");
     expected += String.format(format, 3, 2, 60);
     Assert.assertEquals(expected, mOutput.toString());
+  }
+
+  @Test
+  public void fileinfoNotExistTest() throws IOException {
+    int ret = mFsShell.fileinfo(new String[] {"fileinfo", "/NotExistFile"});
+    Assert.assertEquals("/NotExistFile does not exist.\n", mOutput.toString());
+    Assert.assertEquals(-1, ret);
   }
 
   @Test
@@ -277,6 +291,13 @@ public class TFsShellTest {
       }
     }
     return null;
+  }
+
+  @Test
+  public void locationNotExistTest() throws IOException {
+    int ret = mFsShell.location(new String[] {"location", "/NotExistFile"});
+    Assert.assertEquals("/NotExistFile does not exist.\n", mOutput.toString());
+    Assert.assertEquals(-1, ret);
   }
 
   @Test


### PR DESCRIPTION
The methods location, fileinfo and count in TFsShell do not work well with non-existent path. It displays a NullPointerException message because TachyonFS.getFileId may throw it. The fix is to address this issue.