### PR TITLE
Remove maven warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ journal/
 logs/
 script/
 target/
+.checkstyle

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1,6 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -8,9 +7,8 @@
     <artifactId>tachyon-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.tachyonproject</groupId>
+  <packaging>pom</packaging>
   <artifactId>tachyon-assemblies</artifactId>
-  <version>0.6.0-SNAPSHOT</version>
   <name>Tachyon Project Assemblies</name>
   <description>Tachyon Project Assemblies</description>
 
@@ -28,6 +26,24 @@
 
   <build>
     <plugins>
+      <!-- This module is used to build an uber-jar client with all the dependencies included so has 
+        no actual code to be compiled. We override this plugin so we don't bother generating a unnecessary empty 
+        JAR and getting a pointless warning from Maven -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <skipIfEmpty>true</skipIfEmpty>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -7,7 +7,7 @@
     <version>0.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>tachyon-client</artifactId>
-  <packaging>jar</packaging>
+  <packaging>pom</packaging>
   <description>Tachyon Project Client</description>
   <name>Tachyon Project Client</name>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -1,13 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.tachyonproject</groupId>
     <artifactId>tachyon-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.tachyonproject</groupId>
   <artifactId>tachyon-client</artifactId>
-  <version>0.6.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Tachyon Project Client</description>
   <name>Tachyon Project Client</name>
@@ -85,6 +84,25 @@
 
   <build>
     <plugins>
+      <!-- This module is used to build an uber-jar client with all the dependencies included so has 
+        no actual code to be compiled. We override this plugin so we don't bother generating a unnecessary empty 
+        JAR and getting a pointless warning from Maven -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <configuration>
+          <skipIfEmpty>true</skipIfEmpty>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -99,7 +117,7 @@
             <configuration>
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
               <filters>
                 <filter>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,13 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.tachyonproject</groupId>
     <artifactId>tachyon-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.tachyonproject</groupId>
   <artifactId>tachyon</artifactId>
-  <version>0.6.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Tachyon: A Reliable Memory Centric Distributed Storage System</description>
   <name>Tachyon Project Core</name>
@@ -153,13 +152,14 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <ufs/>
+        <ufs />
       </properties>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
+	    <artifactId>maven-compiler-plugin</artifactId>
+	    <version>3.2</version>
             <executions>
               <execution>
                 <id>default-testCompile</id>
@@ -168,6 +168,9 @@
                   <testExcludes>
                     <exclude>**/LocalMiniDFSCluster.java</exclude>
                   </testExcludes>
+                  <compilerArgs>
+                    <arg>-Xlint:-unchecked</arg>
+                  </compilerArgs>
                 </configuration>
                 <goals>
                   <goal>testCompile</goal>
@@ -265,7 +268,8 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
+	    <artifactId>maven-compiler-plugin</artifactId>
+	    <version>3.2</version>
             <executions>
               <execution>
                 <id>default-testCompile</id>
@@ -294,6 +298,25 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-compiler-plugin</artifactId>
+	<version>3.2</version>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <configuration>
+              <compilerArgs>
+                <arg>-Xlint:none</arg>
+              </compilerArgs>
+            </configuration>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -337,7 +360,7 @@
             <configuration>
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
               <filters>
                 <filter>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -158,8 +158,8 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-	    <artifactId>maven-compiler-plugin</artifactId>
-	    <version>3.2</version>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.2</version>
             <executions>
               <execution>
                 <id>default-testCompile</id>
@@ -268,8 +268,8 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-	    <artifactId>maven-compiler-plugin</artifactId>
-	    <version>3.2</version>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.2</version>
             <executions>
               <execution>
                 <id>default-testCompile</id>
@@ -300,8 +300,8 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-compiler-plugin</artifactId>
-	<version>3.2</version>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
         <executions>
           <execution>
             <id>default-compile</id>

--- a/core/src/main/java/tachyon/thrift/ClientFileInfo.java
+++ b/core/src/main/java/tachyon/thrift/ClientFileInfo.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("all")
 public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, ClientFileInfo._Fields>, java.io.Serializable, Cloneable, Comparable<ClientFileInfo> {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("ClientFileInfo");
 

--- a/core/src/main/java/tachyon/thrift/ClientFileInfo.java
+++ b/core/src/main/java/tachyon/thrift/ClientFileInfo.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("all")
 public class ClientFileInfo implements org.apache.thrift.TBase<ClientFileInfo, ClientFileInfo._Fields>, java.io.Serializable, Cloneable, Comparable<ClientFileInfo> {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("ClientFileInfo");
 


### PR DESCRIPTION
This pull requests resolves the root cause of some spurious maven warnings that can be seen during builds.

The first of these is when compiling the core module, depending on your local install of Maven it produces several warnings about unchecked or unsafe operators used in `ClientFileInfo` e.g.

```
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ tachyon ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 159 source files to /Users/rvesse/Documents/Work/Code/tachyon/core/target/classes
[WARNING] /Users/rvesse/Documents/Work/Code/tachyon/core/src/main/java/tachyon/thrift/ClientFileInfo.java: Some input files use unchecked or unsafe operations.
[WARNING] /Users/rvesse/Documents/Work/Code/tachyon/core/src/main/java/tachyon/thrift/ClientFileInfo.java: Recompile with -Xlint:unchecked for details.
```

These "warnings" are in fact only "notes" from the compiler as can be seen if you manually compile the sources with `javac` but Maven reports them as warnings regardless of whether `<showWarnings>` is set to `false` in the plugin configuration.  Since the class in question is Thrift generated we don't care about those "warnings" however with the version of the compiler plugin used by default in a Maven 3.1 install you can't suppress them because they aren't actually warnings.  However moving to the compiler plugin version 3.2 treats these compiler notes only as info level messages thus removing those warnings, therefore the relevant POM is changed to explicitly use version 3.2 of the compiler plugin.

Secondly the client module has `jar` packaging but no actual code with the maven shade plugin being used to package up all the relevant dependencies and other Tachyon modules into an uber-jar.  However this causes the default jar plugin execution to complain about an empty JAR e.g.

```
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ tachyon-client ---
[WARNING] JAR will be empty - no content was marked for inclusion!
```

Since this is intentional (the shade plugin will still build the actual JAR for the module) we can override the default jar plugin execution and set the `<skipIfEmpty>` configuration to `true` to suppress this warning.

Finally unnecessary duplicate `<groupId>` and `<version>` elements were removed from the relevant POMs because these produce warnings when editing the POMs with an IDE like Eclipse and it is only necessary to include these if the modules have different versions than the parent which they don't.

Note that even with these changes you will still get some maven warnings from the shade plugin caused by dependency convergence issues in the Hadoop dependencies however this is not something that can be properly addressed without the Hadoop folks resolving those issues upstream so this pull request does not attempt to address those remaining warnings.