### PR TITLE
Fix maven compiler warnings

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,13 +1,12 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.tachyonproject</groupId>
     <artifactId>tachyon-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.tachyonproject</groupId>
   <artifactId>tachyon</artifactId>
-  <version>0.6.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <description>Tachyon: A Reliable Memory Centric Distributed Storage System</description>
   <name>Tachyon Project Core</name>
@@ -153,13 +152,14 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <ufs/>
+        <ufs />
       </properties>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.2</version>
             <executions>
               <execution>
                 <id>default-testCompile</id>
@@ -168,6 +168,9 @@
                   <testExcludes>
                     <exclude>**/LocalMiniDFSCluster.java</exclude>
                   </testExcludes>
+                  <compilerArgs>
+                    <arg>-Xlint:-unchecked</arg>
+                  </compilerArgs>
                 </configuration>
                 <goals>
                   <goal>testCompile</goal>
@@ -266,6 +269,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.2</version>
             <executions>
               <execution>
                 <id>default-testCompile</id>
@@ -294,6 +298,25 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <configuration>
+              <compilerArgs>
+                <arg>-Xlint:none</arg>
+              </compilerArgs>
+            </configuration>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -337,7 +360,7 @@
             <configuration>
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
               <filters>
                 <filter>


### PR DESCRIPTION
This is a follow up to https://github.com/amplab/tachyon/pull/631 reduced to only resolve the compiler related warnings since resolving the other warnings has proved to be less than trivial

During compilation several spurious warnings would be seen in the logs
about the use of unchecked/unsafe methods:

```
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ tachyon ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 159 source files to /Users/rvesse/Documents/Work/Code/tachyon/core/target/classes
[WARNING] /Users/rvesse/Documents/Work/Code/tachyon/core/src/main/java/tachyon/thrift/ClientFileInfo.java: Some input files use unchecked or unsafe operations.
[WARNING] /Users/rvesse/Documents/Work/Code/tachyon/core/src/main/java/tachyon/thrift/ClientFileInfo.java: Recompile with -Xlint:unchecked for details.
```

These methods are actually part of the Thrift generated code and so can be safely ignored.

However ignoring them proved to be awkward as they aren't actually warnings so
`<showWarnings>false</showWarnings>` in the compiler plugin conflict had
no effect and neither did adding `-Xlint:-unchecked` though both are
done anyway since they are useful to suppress these kinds of warnings.

The root cause of the problem was that the specific warnings seen were
actually compiler notes rather than warnings but older versions of the
compiler plugin interpreted these incorrectly.  Forcing the version for
the compiler plugin to be the latest (3.2) changes these warnings into
info messages.

Additionally unecessary <groupId> and <version> attributes are removed
from the POM since they duplicate the info defined in the parent and
produce IDE warnings.