### PR TITLE
TACHYON-269: simplify logic of 'getFile(int, boolean)'

### DIFF
--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -72,7 +72,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a TachyonFS handler.
-   * 
+   *
    * @param tachyonURI a Tachyon URI contains master address. e.g., tachyon://localhost:19998,
    *        tachyon://localhost:19998/ab/c.txt
    * @return the corresponding TachyonFS handler
@@ -95,11 +95,11 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a TachyonFS handler.
-   * 
+   *
    * @param masterHost master host details
    * @param masterPort port master listens on
    * @param zookeeperMode use zookeeper
-   * 
+   *
    * @return the corresponding TachyonFS hanlder
    * @throws IOException
    */
@@ -165,7 +165,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Update the latest block access time on the worker.
-   * 
+   *
    * @param blockId the local block's id
    * @throws IOException
    */
@@ -177,7 +177,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Notify the worker that the checkpoint file of the file mFileId has been added.
-   * 
+   *
    * @param fid the file id
    * @throws IOException
    */
@@ -187,7 +187,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Notify the worker to checkpoint the file asynchronously
-   * 
+   *
    * @param fid the file id
    * @return true if succeed, false otherwise
    * @throws IOException
@@ -198,7 +198,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Notify the worker the block is cached.
-   * 
+   *
    * @param blockId the block id
    * @throws IOException
    */
@@ -208,7 +208,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Close the client. Close the connections to both to master and worker
-   * 
+   *
    * @throws IOException
    */
   @Override
@@ -225,7 +225,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * The file is complete.
-   * 
+   *
    * @param fid the file id
    * @throws IOException
    */
@@ -235,7 +235,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a user local temporary folder and return it
-   * 
+   *
    * @return the local temporary folder for the user or null if unable to allocate one.
    * @throws IOException
    */
@@ -263,7 +263,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a user UnderFileSystem temporary folder and return it
-   * 
+   *
    * @param ufsConf the configuration of UnderFileSystem
    * @return the UnderFileSystem temporary folder
    * @throws IOException
@@ -285,7 +285,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a Dependency
-   * 
+   *
    * @param parents the dependency's input files
    * @param children the dependency's output files
    * @param commandPrefix
@@ -307,7 +307,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Creates a new file in the file system.
-   * 
+   *
    * @param path The path of the file
    * @param ufsPath The path of the file in the under file system. If this is empty, the file does
    *        not exist in the under file system yet.
@@ -338,7 +338,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a RawTable and return its id
-   * 
+   *
    * @param path the RawTable's path
    * @param columns number of columns it has
    * @return the id if succeed, -1 otherwise
@@ -350,7 +350,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a RawTable and return its id
-   * 
+   *
    * @param path the RawTable's path
    * @param columns number of columns it has
    * @param metadata the meta data of the RawTable
@@ -402,7 +402,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Return whether the file exists or not
-   * 
+   *
    * @param path the file's path in Tachyon file system
    * @return true if it exists, false otherwise
    * @throws IOException
@@ -414,7 +414,7 @@ public class TachyonFS extends AbstractTachyonFS {
   /**
    * Get the block id by the file id and block index. it will check whether the file and the block
    * exist.
-   * 
+   *
    * @param fileId the file id
    * @param blockIndex The index of the block in the file.
    * @return the block id if exists
@@ -443,7 +443,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get a ClientBlockInfo by blockId
-   * 
+   *
    * @param blockId the id of the block
    * @return the ClientBlockInfo of the specified block
    * @throws IOException
@@ -454,7 +454,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get a ClientDependencyInfo by the dependency id
-   * 
+   *
    * @param depId the dependency id
    * @return the ClientDependencyInfo of the specified dependency
    * @throws IOException
@@ -465,11 +465,11 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get <code>TachyonFile</code> based on the file id.
-   * 
+   *
    * NOTE: This *will* use cached file metadata, and so will not see changes to dynamic properties,
    * such as the pinned flag. This is also different from the behavior of getFile(path), which by
    * default will not use cached metadata.
-   * 
+   *
    * @param fid file id.
    * @return TachyonFile of the file id, or null if the file does not exist.
    */
@@ -480,23 +480,20 @@ public class TachyonFS extends AbstractTachyonFS {
   /**
    * Get <code>TachyonFile</code> based on the file id. If useCachedMetadata, this will not see
    * changes to the file's pin setting, or other dynamic properties.
-   * 
+   *
    * @return TachyonFile of the file id, or null if the file does not exist.
    */
   public synchronized TachyonFile getFile(int fid, boolean useCachedMetadata) throws IOException {
-    if (!useCachedMetadata || !mIdToClientFileInfo.containsKey(fid)) {
-      ClientFileInfo clientFileInfo = getFileStatus(fid, TachyonURI.EMPTY_URI);
-      if (clientFileInfo == null) {
-        return null;
-      }
-      mIdToClientFileInfo.put(fid, clientFileInfo);
+    ClientFileInfo clientFileInfo = getFileStatus(fid, TachyonURI.EMPTY_URI, useCachedMetadata);
+    if (clientFileInfo == null) {
+      return null;
     }
     return new TachyonFile(this, fid);
   }
 
   /**
    * Get <code>TachyonFile</code> based on the path. Does not utilize the file metadata cache.
-   * 
+   *
    * @param path file path.
    * @return TachyonFile of the path, or null if the file does not exist.
    * @throws IOException
@@ -544,7 +541,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get all the blocks' info of the file
-   * 
+   *
    * @param fid the file id
    * @return the list of the blocks' info
    * @throws IOException
@@ -556,7 +553,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get file id by the path. It will check if the path exists.
-   * 
+   *
    * @param path the path in Tachyon file system
    * @return the file id if exists, -1 otherwise
    */
@@ -571,7 +568,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Gets file status.
-   * 
+   *
    * @param cache ClientFileInfo cache.
    * @param key the key in the cache.
    * @param fileId the id of the queried file. If it is -1, uses path.
@@ -607,9 +604,9 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Advanced API.
-   * 
+   *
    * Gets the ClientFileInfo object that represents the fileId, or the path if fileId is -1.
-   * 
+   *
    * @param fileId the file id of the file or folder.
    * @param path the path of the file or folder. valid iff fileId is -1.
    * @param useCachedMetadata if true use the local cached meta data
@@ -635,7 +632,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get ClientFileInfo object based on fileId.
-   * 
+   *
    * @param fileId the file id of the file or folder.
    * @param useCachedMetadata if true use the local cached meta data
    * @return the ClientFileInfo of the file. null if the file does not exist.
@@ -648,7 +645,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get the RawTable by id
-   * 
+   *
    * @param id the id of the raw table
    * @return the RawTable
    * @throws IOException
@@ -660,7 +657,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get the RawTable by path
-   * 
+   *
    * @param path the path of the raw table
    * @return the RawTable
    * @throws IOException
@@ -698,7 +695,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Returns the userId of the master client. This is only used for testing.
-   * 
+   *
    * @return the userId of the master client
    * @throws IOException
    */
@@ -740,7 +737,7 @@ public class TachyonFS extends AbstractTachyonFS {
   /**
    * If the <code>path</code> is a directory, return all the direct entries in it. If the
    * <code>path</code> is a file, return its ClientFileInfo.
-   * 
+   *
    * @param path the target directory/file path
    * @return A list of ClientFileInfo, null if the file or folder does not exist.
    * @throws IOException
@@ -753,7 +750,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Lock a block in the current TachyonFS.
-   * 
+   *
    * @param blockId The id of the block to lock. <code>blockId</code> must be positive.
    * @param blockLockId The block lock id of the block of lock. <code>blockLockId</code> must be
    *        non-negative.
@@ -782,7 +779,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Creates a folder.
-   * 
+   *
    * @param path the path of the folder to be created
    * @param recursive Creates necessary parent folders if true, not otherwise.
    * @return true if the folder is created successfully or already existing. false otherwise.
@@ -823,7 +820,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Renames a file or folder to another path.
-   * 
+   *
    * @param fileId The id of the source file / folder. If it is not -1, path parameter is ignored.
    *        Otherwise, the method uses the srcPath parameter.
    * @param srcPath The path of the source file / folder. It could be empty iff id is not -1.
@@ -841,7 +838,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Report the lost file to master
-   * 
+   *
    * @param fileId the lost file id
    * @throws IOException
    */
@@ -851,7 +848,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Request the dependency's needed files
-   * 
+   *
    * @param depId the dependency id
    * @throws IOException
    */
@@ -861,7 +858,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Try to request space from worker. Only works when a local worker exists.
-   * 
+   *
    * @param requestSpaceBytes the space size in bytes
    * @return true if succeed, false otherwise
    * @throws IOException
@@ -893,7 +890,7 @@ public class TachyonFS extends AbstractTachyonFS {
   /**
    * Sets the "pinned" flag for the given file. Pinned files are never evicted by Tachyon until they
    * are unpinned.
-   * 
+   *
    * Calling setPinned() on a folder will recursively set the "pinned" flag on all of that folder's
    * children. This may be an expensive operation for folders with many files/subfolders.
    */
@@ -903,7 +900,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Print out the string representation of this Tachyon server address.
-   * 
+   *
    * @return the string representation like tachyon://host:port or tachyon-ft://host:port
    */
   @Override
@@ -913,7 +910,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Unlock a block in the current TachyonFS.
-   * 
+   *
    * @param blockId The id of the block to unlock. <code>blockId</code> must be positive.
    * @param blockLockId The block lock id of the block of unlock. <code>blockLockId</code> must be
    *        non-negative.
@@ -951,7 +948,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Update the RawTable's meta data
-   * 
+   *
    * @param id the raw table's id
    * @param metadata the new meta data
    * @throws IOException
@@ -962,7 +959,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Validates the given uri, throwing an IOException if the uri is invalid.
-   * 
+   *
    * @param uri The uri to validate
    */
   private void validateUri(TachyonURI uri) throws IOException {

--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -72,7 +72,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a TachyonFS handler.
-   *
+   * 
    * @param tachyonURI a Tachyon URI contains master address. e.g., tachyon://localhost:19998,
    *        tachyon://localhost:19998/ab/c.txt
    * @return the corresponding TachyonFS handler
@@ -95,11 +95,11 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a TachyonFS handler.
-   *
+   * 
    * @param masterHost master host details
    * @param masterPort port master listens on
    * @param zookeeperMode use zookeeper
-   *
+   * 
    * @return the corresponding TachyonFS hanlder
    * @throws IOException
    */
@@ -165,7 +165,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Update the latest block access time on the worker.
-   *
+   * 
    * @param blockId the local block's id
    * @throws IOException
    */
@@ -177,7 +177,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Notify the worker that the checkpoint file of the file mFileId has been added.
-   *
+   * 
    * @param fid the file id
    * @throws IOException
    */
@@ -187,7 +187,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Notify the worker to checkpoint the file asynchronously
-   *
+   * 
    * @param fid the file id
    * @return true if succeed, false otherwise
    * @throws IOException
@@ -198,7 +198,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Notify the worker the block is cached.
-   *
+   * 
    * @param blockId the block id
    * @throws IOException
    */
@@ -208,7 +208,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Close the client. Close the connections to both to master and worker
-   *
+   * 
    * @throws IOException
    */
   @Override
@@ -225,7 +225,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * The file is complete.
-   *
+   * 
    * @param fid the file id
    * @throws IOException
    */
@@ -235,7 +235,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a user local temporary folder and return it
-   *
+   * 
    * @return the local temporary folder for the user or null if unable to allocate one.
    * @throws IOException
    */
@@ -263,7 +263,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a user UnderFileSystem temporary folder and return it
-   *
+   * 
    * @param ufsConf the configuration of UnderFileSystem
    * @return the UnderFileSystem temporary folder
    * @throws IOException
@@ -285,7 +285,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a Dependency
-   *
+   * 
    * @param parents the dependency's input files
    * @param children the dependency's output files
    * @param commandPrefix
@@ -307,7 +307,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Creates a new file in the file system.
-   *
+   * 
    * @param path The path of the file
    * @param ufsPath The path of the file in the under file system. If this is empty, the file does
    *        not exist in the under file system yet.
@@ -338,7 +338,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a RawTable and return its id
-   *
+   * 
    * @param path the RawTable's path
    * @param columns number of columns it has
    * @return the id if succeed, -1 otherwise
@@ -350,7 +350,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Create a RawTable and return its id
-   *
+   * 
    * @param path the RawTable's path
    * @param columns number of columns it has
    * @param metadata the meta data of the RawTable
@@ -402,7 +402,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Return whether the file exists or not
-   *
+   * 
    * @param path the file's path in Tachyon file system
    * @return true if it exists, false otherwise
    * @throws IOException
@@ -414,7 +414,7 @@ public class TachyonFS extends AbstractTachyonFS {
   /**
    * Get the block id by the file id and block index. it will check whether the file and the block
    * exist.
-   *
+   * 
    * @param fileId the file id
    * @param blockIndex The index of the block in the file.
    * @return the block id if exists
@@ -443,7 +443,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get a ClientBlockInfo by blockId
-   *
+   * 
    * @param blockId the id of the block
    * @return the ClientBlockInfo of the specified block
    * @throws IOException
@@ -454,7 +454,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get a ClientDependencyInfo by the dependency id
-   *
+   * 
    * @param depId the dependency id
    * @return the ClientDependencyInfo of the specified dependency
    * @throws IOException
@@ -465,11 +465,11 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get <code>TachyonFile</code> based on the file id.
-   *
+   * 
    * NOTE: This *will* use cached file metadata, and so will not see changes to dynamic properties,
    * such as the pinned flag. This is also different from the behavior of getFile(path), which by
    * default will not use cached metadata.
-   *
+   * 
    * @param fid file id.
    * @return TachyonFile of the file id, or null if the file does not exist.
    */
@@ -480,7 +480,7 @@ public class TachyonFS extends AbstractTachyonFS {
   /**
    * Get <code>TachyonFile</code> based on the file id. If useCachedMetadata, this will not see
    * changes to the file's pin setting, or other dynamic properties.
-   *
+   * 
    * @return TachyonFile of the file id, or null if the file does not exist.
    */
   public synchronized TachyonFile getFile(int fid, boolean useCachedMetadata) throws IOException {
@@ -493,7 +493,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get <code>TachyonFile</code> based on the path. Does not utilize the file metadata cache.
-   *
+   * 
    * @param path file path.
    * @return TachyonFile of the path, or null if the file does not exist.
    * @throws IOException
@@ -541,7 +541,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get all the blocks' info of the file
-   *
+   * 
    * @param fid the file id
    * @return the list of the blocks' info
    * @throws IOException
@@ -553,7 +553,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get file id by the path. It will check if the path exists.
-   *
+   * 
    * @param path the path in Tachyon file system
    * @return the file id if exists, -1 otherwise
    */
@@ -568,7 +568,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Gets file status.
-   *
+   * 
    * @param cache ClientFileInfo cache.
    * @param key the key in the cache.
    * @param fileId the id of the queried file. If it is -1, uses path.
@@ -604,9 +604,9 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Advanced API.
-   *
+   * 
    * Gets the ClientFileInfo object that represents the fileId, or the path if fileId is -1.
-   *
+   * 
    * @param fileId the file id of the file or folder.
    * @param path the path of the file or folder. valid iff fileId is -1.
    * @param useCachedMetadata if true use the local cached meta data
@@ -632,7 +632,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get ClientFileInfo object based on fileId.
-   *
+   * 
    * @param fileId the file id of the file or folder.
    * @param useCachedMetadata if true use the local cached meta data
    * @return the ClientFileInfo of the file. null if the file does not exist.
@@ -645,7 +645,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get the RawTable by id
-   *
+   * 
    * @param id the id of the raw table
    * @return the RawTable
    * @throws IOException
@@ -657,7 +657,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Get the RawTable by path
-   *
+   * 
    * @param path the path of the raw table
    * @return the RawTable
    * @throws IOException
@@ -695,7 +695,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Returns the userId of the master client. This is only used for testing.
-   *
+   * 
    * @return the userId of the master client
    * @throws IOException
    */
@@ -737,7 +737,7 @@ public class TachyonFS extends AbstractTachyonFS {
   /**
    * If the <code>path</code> is a directory, return all the direct entries in it. If the
    * <code>path</code> is a file, return its ClientFileInfo.
-   *
+   * 
    * @param path the target directory/file path
    * @return A list of ClientFileInfo, null if the file or folder does not exist.
    * @throws IOException
@@ -750,7 +750,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Lock a block in the current TachyonFS.
-   *
+   * 
    * @param blockId The id of the block to lock. <code>blockId</code> must be positive.
    * @param blockLockId The block lock id of the block of lock. <code>blockLockId</code> must be
    *        non-negative.
@@ -779,7 +779,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Creates a folder.
-   *
+   * 
    * @param path the path of the folder to be created
    * @param recursive Creates necessary parent folders if true, not otherwise.
    * @return true if the folder is created successfully or already existing. false otherwise.
@@ -820,7 +820,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Renames a file or folder to another path.
-   *
+   * 
    * @param fileId The id of the source file / folder. If it is not -1, path parameter is ignored.
    *        Otherwise, the method uses the srcPath parameter.
    * @param srcPath The path of the source file / folder. It could be empty iff id is not -1.
@@ -838,7 +838,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Report the lost file to master
-   *
+   * 
    * @param fileId the lost file id
    * @throws IOException
    */
@@ -848,7 +848,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Request the dependency's needed files
-   *
+   * 
    * @param depId the dependency id
    * @throws IOException
    */
@@ -858,7 +858,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Try to request space from worker. Only works when a local worker exists.
-   *
+   * 
    * @param requestSpaceBytes the space size in bytes
    * @return true if succeed, false otherwise
    * @throws IOException
@@ -890,7 +890,7 @@ public class TachyonFS extends AbstractTachyonFS {
   /**
    * Sets the "pinned" flag for the given file. Pinned files are never evicted by Tachyon until they
    * are unpinned.
-   *
+   * 
    * Calling setPinned() on a folder will recursively set the "pinned" flag on all of that folder's
    * children. This may be an expensive operation for folders with many files/subfolders.
    */
@@ -900,7 +900,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Print out the string representation of this Tachyon server address.
-   *
+   * 
    * @return the string representation like tachyon://host:port or tachyon-ft://host:port
    */
   @Override
@@ -910,7 +910,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Unlock a block in the current TachyonFS.
-   *
+   * 
    * @param blockId The id of the block to unlock. <code>blockId</code> must be positive.
    * @param blockLockId The block lock id of the block of unlock. <code>blockLockId</code> must be
    *        non-negative.
@@ -948,7 +948,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Update the RawTable's meta data
-   *
+   * 
    * @param id the raw table's id
    * @param metadata the new meta data
    * @throws IOException
@@ -959,7 +959,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * Validates the given uri, throwing an IOException if the uri is invalid.
-   *
+   * 
    * @param uri The uri to validate
    */
   private void validateUri(TachyonURI uri) throws IOException {


### PR DESCRIPTION
Currently code following:
public synchronized TachyonFile getFile(int fid, boolean useCachedMetadata) throws IOException {
    if (!useCachedMetadata || !mIdToClientFileInfo.containsKey(fid)) {
      ClientFileInfo clientFileInfo = getFileStatus(fid, TachyonURI.EMPTY_URI);   ==> (1)
      if (clientFileInfo == null) {
        return null;
      }
      mIdToClientFileInfo.put(fid, clientFileInfo);  ==> (2)
      ==> (3)
    }
    return new TachyonFile(this, fid);  ==> (4)
  }

There are three issues:
1. If useCachedMetadata is false, and fid is valid, (1) will cache mIdToClientFileInfo, but (2) cache duplicated.
2. If we duplicated cache fid in (2), why not cache mPathToClientFileInfo in (3)?
3. If useCachedMetadata is true, and fid is -1 or invalid, then will return new TachyonFile(this, fid), but should return null.

I think we don't need to handle cache logic in this API, we can following the logic of "TachyonFile getFile(TachyonURI path, boolean useCachedMetadata)" like following:
public synchronized TachyonFile getFile(TachyonURI path, boolean useCachedMetadata)
      throws IOException {
    validateUri(path);
    ClientFileInfo clientFileInfo = getFileStatus(-1, path, useCachedMetadata);
    if (clientFileInfo == null) {
      return null;
    }
    return new TachyonFile(this, clientFileInfo.getId());
  }