### PR TITLE
TACHYON-270: support 'tfs rmr <directory_path>'

### DIFF
--- a/core/src/main/java/tachyon/command/TFsShell.java
+++ b/core/src/main/java/tachyon/command/TFsShell.java
@@ -449,6 +449,7 @@ public class TFsShell implements Closeable {
     System.out.println("       [lsr <path>]");
     System.out.println("       [mkdir <path>]");
     System.out.println("       [rm <path>]");
+    System.out.println("       [rmr <path>]");
     System.out.println("       [tail <path>]");
     System.out.println("       [touch <path>]");
     System.out.println("       [mv <src> <dst>]");
@@ -513,8 +514,7 @@ public class TFsShell implements Closeable {
   }
 
   /**
-   * Removes the file or directory specified by argv. Will remove all files and directories in the
-   * directory if a directory is specified.
+   * Removes the file specified by argv.
    *
    * @param argv [] Array of arguments given by the user's input from the terminal
    * @return 0 if command is successful, -1 if an error occurred.
@@ -523,6 +523,35 @@ public class TFsShell implements Closeable {
   public int rm(String[] argv) throws IOException {
     if (argv.length != 2) {
       System.out.println("Usage: tfs rm <path>");
+      return -1;
+    }
+    TachyonURI path = new TachyonURI(argv[1]);
+    TachyonFS tachyonClient = createFS(path);
+    TachyonFile tFile = tachyonClient.getFile(path);
+    if (tFile != null && tFile.isDirectory()) {
+      System.out.println("can't remove a directory, please try rmr <path>");
+      return -1;
+    }
+
+    if (tachyonClient.delete(path, false)) {
+      System.out.println(path + " has been removed");
+      return 0;
+    } else {
+      return -1;
+    }
+  }
+
+  /**
+   * Removes the file or directory specified by argv. Will remove all files and directories in the
+   * directory if a directory is specified.
+   *
+   * @param argv [] Array of arguments given by the user's input from the terminal
+   * @return 0 if command is successful, -1 if an error occurred.
+   * @throws IOException
+   */
+  public int rmr(String[] argv) throws IOException {
+    if (argv.length != 2) {
+      System.out.println("Usage: tfs rmr <path>");
       return -1;
     }
     TachyonURI path = new TachyonURI(argv[1]);
@@ -563,6 +592,8 @@ public class TFsShell implements Closeable {
         exitCode = mkdir(argv);
       } else if (cmd.equals("rm")) {
         exitCode = rm(argv);
+      } else if (cmd.equals("rmr")) {
+        exitCode = rmr(argv);
       } else if (cmd.equals("tail")) {
         exitCode = tail(argv);
       } else if (cmd.equals("mv")) {

--- a/core/src/test/java/tachyon/command/TFsShellTest.java
+++ b/core/src/test/java/tachyon/command/TFsShellTest.java
@@ -276,7 +276,7 @@ public class TFsShellTest {
         return null;
       } else if (cmd.equals("mkdir")) {
         return "Successfully created directory " + command[1] + "\n";
-      } else if (cmd.equals("rm")) {
+      } else if (cmd.equals("rm") || cmd.equals("rmr")) {
         return command[1] + " has been removed" + "\n";
       } else if (cmd.equals("touch")) {
         return command[1] + " has been created" + "\n";
@@ -484,9 +484,12 @@ public class TFsShellTest {
   @Test
   public void rmTest() throws IOException {
     StringBuilder toCompare = new StringBuilder();
-    mFsShell.mkdir(new String[] {"mkdir", "/testFolder1/testFolder2/testFile2"});
+    mFsShell.mkdir(new String[] {"mkdir", "/testFolder1/testFolder2"});
     toCompare
-        .append(getCommandOutput(new String[] {"mkdir", "/testFolder1/testFolder2/testFile2"}));
+        .append(getCommandOutput(new String[] {"mkdir", "/testFolder1/testFolder2"}));
+    mFsShell.touch(new String[] {"touch", "/testFolder1/testFolder2/testFile2"});
+    toCompare
+        .append(getCommandOutput(new String[] {"touch", "/testFolder1/testFolder2/testFile2"}));
     TachyonURI testFolder1 = new TachyonURI("/testFolder1");
     TachyonURI testFolder2 = new TachyonURI("/testFolder1/testFolder2");
     TachyonURI testFile2 = new TachyonURI("/testFolder1/testFolder2/testFile2");
@@ -499,8 +502,31 @@ public class TFsShellTest {
     Assert.assertNotNull(mTfs.getFile(testFolder1));
     Assert.assertNotNull(mTfs.getFile(testFolder2));
     Assert.assertNull(mTfs.getFile(testFile2));
-    mFsShell.rm(new String[] {"rm", "/testFolder1"});
-    toCompare.append(getCommandOutput(new String[] {"rm", "/testFolder1"}));
+  }
+
+  @Test
+  public void rmrTest() throws IOException {
+    StringBuilder toCompare = new StringBuilder();
+    mFsShell.mkdir(new String[] {"mkdir", "/testFolder1/testFolder2"});
+    toCompare
+        .append(getCommandOutput(new String[] {"mkdir", "/testFolder1/testFolder2"}));
+    mFsShell.touch(new String[] {"touch", "/testFolder1/testFolder2/testFile2"});
+    toCompare
+        .append(getCommandOutput(new String[] {"touch", "/testFolder1/testFolder2/testFile2"}));
+    TachyonURI testFolder1 = new TachyonURI("/testFolder1");
+    TachyonURI testFolder2 = new TachyonURI("/testFolder1/testFolder2");
+    TachyonURI testFile2 = new TachyonURI("/testFolder1/testFolder2/testFile2");
+    Assert.assertNotNull(mTfs.getFile(testFolder1));
+    Assert.assertNotNull(mTfs.getFile(testFolder2));
+    Assert.assertNotNull(mTfs.getFile(testFile2));
+    mFsShell.rmr(new String[] {"rmr", "/testFolder1/testFolder2/testFile2"});
+    toCompare.append(getCommandOutput(new String[] {"rm", "/testFolder1/testFolder2/testFile2"}));
+    Assert.assertEquals(toCompare.toString(), mOutput.toString());
+    Assert.assertNotNull(mTfs.getFile(testFolder1));
+    Assert.assertNotNull(mTfs.getFile(testFolder2));
+    Assert.assertNull(mTfs.getFile(testFile2));
+    mFsShell.rmr(new String[] {"rmr", "/testFolder1"});
+    toCompare.append(getCommandOutput(new String[] {"rmr", "/testFolder1"}));
     Assert.assertEquals(toCompare.toString(), mOutput.toString());
     Assert.assertNull(mTfs.getFile(testFolder1));
     Assert.assertNull(mTfs.getFile(testFolder2));

--- a/docs/Command-Line-Interface.md
+++ b/docs/Command-Line-Interface.md
@@ -48,6 +48,11 @@ Or, if no header is provided, the default hostname and port (set in the env file
   <tr>
     <td>rm</td>
     <td>rm "path"</td>
+    <td>Remove a file. Will fail if the path is a directory.</td>
+  </tr>
+  <tr>
+    <td>rmr</td>
+    <td>rmr "path"</td>
     <td>Remove a file or directory and all folders and files under that directory.</td>
   </tr>
   <tr>


### PR DESCRIPTION
Currently "tfs rm <path>" will remove a file or a directory.
But many file system separate remove a file and a directory to two commands.
e.g. linux, "rm" will remove a file and can't remove a directory, "rm -r" will remove a directory.
       hdfs, "dfs rm" will remove a file and can't remove a directory, "dfs rmr" will remove a directory.

For better customer usage and file system standard, we should change "tfs rm <path>" to remove a file, and add "tfs rmr <path>" to remove a directory.
