### PR TITLE
Bash script improvements

### DIFF
--- a/bin/tachyon
+++ b/bin/tachyon
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+LAUNCHER=
+# If debugging is enabled propagate that through to sub-shells
+if [[ "$-" == *x* ]]; then
+  LAUNCHER="bash -x"
+fi
+
 function printUsage {
   echo "Usage: tachyon COMMAND "
   echo "where COMMAND is one of:"
@@ -71,7 +77,7 @@ function runTest {
       exit 1
       ;;
   esac
-  $bin/tachyon tfs rm "$file"
+  $LAUNCHER $bin/tachyon tfs rm "$file"
   $JAVA -cp $CLASSPATH $TACHYON_JAVA_OPTS "$class" tachyon://$MASTER_ADDRESS:19998 "$file" "$args"
 }
 
@@ -176,7 +182,7 @@ if [ "$COMMAND" == "format" ]; then
     TACHYON_MASTER_ADDRESS=localhost
   fi
 
-  $bin/tachyon-workers.sh $bin/tachyon formatWorker
+  $LAUNCHER $bin/tachyon-workers.sh $bin/tachyon formatWorker
 
   echo "Formatting Tachyon Master @ $TACHYON_MASTER_ADDRESS"
   CLASS=tachyon.Format
@@ -203,8 +209,8 @@ elif [ "$COMMAND" == "runTests" ]; then
   do
     for example in Basic BasicRawTable BasicCheckpoint BasicNonByteBuffer
     do
-      echo $bin/tachyon runTest $example $op
-      $bin/tachyon runTest $example $op
+      echo $LAUNCHER $bin/tachyon runTest $example $op
+      $LAUNCHER $bin/tachyon runTest $example $op
       st=$?
       failed=$(( $failed + $st ))
     done

--- a/bin/tachyon-mount.sh
+++ b/bin/tachyon-mount.sh
@@ -4,6 +4,12 @@
 # Starts the master on this node.
 # Starts a worker on each node specified in conf/workers
 
+LAUNCHER=
+# If debugging is enabled propagate that through to sub-shells
+if [[ "$-" == *x* ]]; then
+  LAUNCHER="bash -x"
+fi
+
 Usage="Usage: tachyon-mount.sh [Mount|SudoMount] [MACHINE]
 \nIf omitted, MACHINE is default to be 'local'. MACHINE is one of:\n
   local\t\t\tMount local machine\n
@@ -140,7 +146,7 @@ case "${1}" in
         mount_local $1
         ;;
       workers)
-        $bin/tachyon-workers.sh $bin/tachyon-mount.sh $1
+        $LAUNCHER $bin/tachyon-workers.sh $bin/tachyon-mount.sh $1
         ;;
     esac
     ;;

--- a/bin/tachyon-start.sh
+++ b/bin/tachyon-start.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+LAUNCHER=
+# If debugging is enabled propagate that through to sub-shells
+if [[ "$-" == *x* ]]; then
+  LAUNCHER="bash -x"
+fi
+
 #start up tachyon
 
 Usage="Usage: tachyon-start.sh [-h] WHAT [MOPT] [-f]
@@ -58,11 +64,11 @@ do_mount() {
   MOUNT_FAILED=0
   case "${1}" in
     Mount)
-      $bin/tachyon-mount.sh $1
+      $LAUNCHER $bin/tachyon-mount.sh $1
       MOUNT_FAILED=$?
       ;;
     SudoMount)
-      $bin/tachyon-mount.sh $1
+      $LAUNCHER $bin/tachyon-mount.sh $1
       MOUNT_FAILED=$?
       ;;
     NoMount)
@@ -90,7 +96,7 @@ start_master() {
   fi
 
   if [ "${1}" == "-f" ] ; then
-    $bin/tachyon format
+    $LAUNCHER $bin/tachyon format
   fi
 
   echo "Starting master @ $MASTER_ADDRESS"
@@ -172,12 +178,12 @@ case "${WHAT}" in
     stop $bin
     start_master $3
     sleep 2
-    $bin/tachyon-workers.sh $bin/tachyon-start.sh worker $2
+    $LAUNCHER $bin/tachyon-workers.sh $bin/tachyon-start.sh worker $2
     ;;
   local)
     stop $bin
     sleep 1
-    $bin/tachyon-mount.sh SudoMount
+    $LAUNCHER $bin/tachyon-mount.sh SudoMount
     stat=$?
     if [ $stat -ne 0 ] ; then
       echo "Mount failed, not starting"
@@ -199,13 +205,13 @@ case "${WHAT}" in
     ;;
   workers)
     check_mount_mode $2
-    $bin/tachyon-workers.sh $bin/tachyon-start.sh worker $2 $TACHYON_MASTER_ADDRESS
+    $LAUNCHER $bin/tachyon-workers.sh $bin/tachyon-start.sh worker $2 $TACHYON_MASTER_ADDRESS
     ;;
   restart_worker)
     restart_worker
     ;;
   restart_workers)
-    $bin/tachyon-workers.sh $bin/tachyon-start.sh restart_worker
+    $LAUNCHER $bin/tachyon-workers.sh $bin/tachyon-start.sh restart_worker
     ;;
   *)
     echo "Error: Invalid WHAT: $WHAT"

--- a/bin/tachyon-stop.sh
+++ b/bin/tachyon-stop.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+LAUNCHER=
+# If debugging is enabled propagate that through to sub-shells
+if [[ "$-" == *x* ]]; then
+  LAUNCHER="bash -x"
+fi
+
 Usage="Usage: tachyon-stop.sh [-h] [component] 
 Where component is one of:
   all\t\t\tStop local master/worker and remote workers. Default.
@@ -11,15 +17,15 @@ Where component is one of:
 bin=`cd "$( dirname "$0" )"; pwd`
 
 kill_master() {
-  $bin/tachyon killAll tachyon.master.TachyonMaster
+  $LAUNCHER $bin/tachyon killAll tachyon.master.TachyonMaster
 }
 
 kill_worker() {
-  $bin/tachyon killAll tachyon.worker.TachyonWorker
+  $LAUNCHER $bin/tachyon killAll tachyon.worker.TachyonWorker
 }
 
 kill_remote_workers() {
-  $bin/tachyon-workers.sh $bin/tachyon killAll tachyon.worker.TachyonWorker
+  $LAUNCHER $bin/tachyon-workers.sh $bin/tachyon killAll tachyon.worker.TachyonWorker
 }
 
 WHAT=${1:-all}

--- a/bin/tachyon-workers.sh
+++ b/bin/tachyon-workers.sh
@@ -22,7 +22,7 @@ TACHYON_LIBEXEC_DIR=${TACHYON_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
 HOSTLIST=$TACHYON_CONF_DIR/workers
 
 for worker in `cat "$HOSTLIST"|sed  "s/#.*$//;/^$/d"`; do
-  echo -n "Connection to $worker... "
+  echo -n "Connection to $worker as $USER... "
   ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t $worker $LAUNCHER $"${@// /\\ }" 2>&1
   sleep 0.02
 done

--- a/bin/tachyon-workers.sh
+++ b/bin/tachyon-workers.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+LAUNCHER=
+# If debugging is enabled propagate that through to sub-shells
+if [[ "$-" == *x* ]]; then
+  LAUNCHER="bash -x"
+fi
+
 usage="Usage: tachyon-workers.sh command..."
 
 # if no args specified, show usage
@@ -17,7 +23,7 @@ HOSTLIST=$TACHYON_CONF_DIR/workers
 
 for worker in `cat "$HOSTLIST"|sed  "s/#.*$//;/^$/d"`; do
   echo -n "Connection to $worker... "
-  ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t $worker $"${@// /\\ }" 2>&1
+  ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t $worker $LAUNCHER $"${@// /\\ }" 2>&1
   sleep 0.02
 done
 


### PR DESCRIPTION
This pull request includes a couple of useful improvements to the Bash scripts.

Firstly it modifies the scripts to allow better debugging when using `bash -x` to launch the scripts.  Currently this is not so helpful because many of the scripts actually launch other Tachyon scripts and the debugging mode is not propagated to those sub-shells.  With these changes the debugging mode is now propagated to any sub-shells that the scripts launch (both to local and remote)

Secondly it makes a minor but useful tweak to `tachyon-workers.sh` to echo which user we are SSH'ing as because in some environments and situations this might not be the user who owns the terminal that launches the script e.g. when launching via `sudo` 