### PR TITLE
Improve how old RAM FS is unmounted on OS X

### DIFF
--- a/bin/tachyon-mount.sh
+++ b/bin/tachyon-mount.sh
@@ -111,8 +111,13 @@ function mount_ramfs_mac() {
   mem_size_to_bytes
   NUM_SECTORS=$((BYTE_SIZE / 512))
 
+  # Format the RAM FS
+  # We may have a pre-existing RAM FS which we need to throw away
   echo "Formatting RamFS: $F $NUM_SECTORS sectors ($MEM_SIZE)."
-  diskutil unmount force /Volumes/$F
+  DEVICE=`df -l | grep $F | cut -d " " -f 1`
+  if [[ -n "${DEVICE}" ]]; then
+    hdiutil detach -force $DEVICE
+  fi
   diskutil erasevolume HFS+ $F `hdiutil attach -nomount ram://$NUM_SECTORS`
 }
 


### PR DESCRIPTION
On OS X a RAM FS is used and each time Tachyon is started the old RAM FS
(if any) is unmounted and then a brand new one is formatted and mounted.
However because of the way in which the RAM FS is unmounted we end up
endlessly incrementing the device ID so after you've run Tachyon a bunch
of times you end up with a device ID like `/dev/disk22` and a huge list
of unused disks if you run `diskutil list`

This commit changes how the old RAM FS is unmounted to instead determine
the actual device ID behind the RAM FS volume and if present detach it
rather than unmounting it.  This causes OS X to unmount and throw away
the disk so it doesn't clutter the list of devices and we simply reuse
the device ID when we create the new disk rather than endlessly
incrementing it.