### PR TITLE
License headers enforcement and fixes

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -15,6 +15,7 @@
   <description>Tachyon Project Assemblies</description>
 
   <properties>
+    <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 

--- a/build/license/HEADER.txt
+++ b/build/license/HEADER.txt
@@ -1,0 +1,12 @@
+Licensed to the University of California, Berkeley under one or more contributor license
+agreements. See the NOTICE file distributed with this work for additional information regarding
+copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance with the License. You may obtain a
+copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -13,6 +13,7 @@
   <name>Tachyon Project Client</name>
 
   <properties>
+    <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,6 +11,9 @@
   <description>Tachyon: A Reliable Memory Centric Distributed Storage System</description>
   <name>Tachyon Project Core</name>
 
+  <properties>
+    <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
+  </properties>
   <dependencies>
     <dependency>
       <!-- using older version to map dependency version from Hadoop -->

--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -4,7 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/core/src/main/java/tachyon/util/ThreadFactoryUtils.java
+++ b/core/src/main/java/tachyon/util/ThreadFactoryUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package tachyon.util;
 
 import java.util.concurrent.ThreadFactory;

--- a/core/src/test/java/tachyon/hadoop/HdfsFileInputStreamTest.java
+++ b/core/src/test/java/tachyon/hadoop/HdfsFileInputStreamTest.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package tachyon.hadoop;
 
 import java.io.IOException;

--- a/core/src/test/java/tachyon/hadoop/fs/AccumulatingReducer.java
+++ b/core/src/test/java/tachyon/hadoop/fs/AccumulatingReducer.java
@@ -1,7 +1,7 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
  * 

--- a/core/src/test/java/tachyon/hadoop/fs/IOMapperBase.java
+++ b/core/src/test/java/tachyon/hadoop/fs/IOMapperBase.java
@@ -1,7 +1,7 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
  * 

--- a/core/src/test/java/tachyon/hadoop/fs/TestDFSIO.java
+++ b/core/src/test/java/tachyon/hadoop/fs/TestDFSIO.java
@@ -1,7 +1,7 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
  * 

--- a/core/src/test/java/tachyon/retry/ExponentialBackoffRetryTest.java
+++ b/core/src/test/java/tachyon/retry/ExponentialBackoffRetryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package tachyon.retry;
 
 import org.junit.Assert;

--- a/core/src/test/java/tachyon/worker/hierarchy/HierarchyStoreTest.java
+++ b/core/src/test/java/tachyon/worker/hierarchy/HierarchyStoreTest.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package tachyon.worker.hierarchy;
 
 import java.io.IOException;

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
     <powermock.version>1.5.4</powermock.version>
     <log4j.version>1.2.17</log4j.version>
     <apache.curator.version>2.1.0-incubating</apache.curator.version>
+    <license.header.path>build/license/</license.header.path>
   </properties>
 
   <modules>
@@ -210,6 +211,56 @@
             <id>attach-javadoc</id>
             <goals>
               <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- License Plugin -->
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>2.9</version>
+        <configuration>
+          <header>${license.header.path}HEADER.txt</header>
+          <failIfMissing>true</failIfMissing>
+          <aggregate>false</aggregate>
+          <excludes>
+            <!-- Code Exclusions -->
+            <exclude>**/src/main/resources/version.properties</exclude>
+            <exclude>**/src/main/java/tachyon/thrift/*</exclude>
+            <exclude>**/src/main/webapp/**/*</exclude>
+            <exclude>**/src/thrift/*</exclude>
+            <exclude>**/src/deb/**/*</exclude>
+            <exclude>**/src/test/resources/*</exclude>
+            <exclude>**/package-info.java</exclude>
+            
+            <!-- Build and Packaging Exclusions -->
+            <exclude>**/pom.xml</exclude>
+            <exclude>**/logs/*</exclude>
+            <exclude>**/deploy/**/*</exclude>
+            <exclude>**/bin/*</exclude>
+            <exclude>**/conf/*</exclude>
+            <exclude>**/libexec/*</exclude>
+            <exclude>**/src/main/findbugs/*</exclude>
+            <exclude>**/src/main/resources/tachyon_checks*</exclude>
+            <exclude>**/src/main/assembly/*</exclude>
+            
+            <!-- Documentation Exclusions -->
+            <exclude>**/docs/**/*</exclude>
+            <exclude>LICENSE</exclude>
+            <exclude>NOTICE</exclude>
+          </excludes>
+          <mapping>
+            <java>SLASHSTAR_STYLE</java>
+          </mapping>
+          <useDefaultMapping>true</useDefaultMapping>
+          <strictCheck>true</strictCheck>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
As requested in PR #647 this pull request pulls out the fixes to license headers and adds license header enforcement to the build.

This is improved upon the approach in #647 as it simply defines the plugin and its excludes once in the parent POM.  In order for this to work correctly in the child POMs if you are building individual modules it is necessary to override the property that provides the path to the header file in those child POMs as well.

I have added what seemed like sensible excludes:

- Build, Packing and Deployment
- Configuration scripts, files and resources
- Documentation
- Thrift Generated Code