### PR TITLE
[TACHYON-274] WebUI Improvement about Hierarchy

### DIFF
--- a/core/src/main/java/tachyon/master/MasterClient.java
+++ b/core/src/main/java/tachyon/master/MasterClient.java
@@ -732,14 +732,14 @@ public final class MasterClient implements Closeable {
     return false;
   }
 
-  public synchronized void worker_cacheBlock(long workerId, long workerUsedBytes,
+  public synchronized void worker_cacheBlock(long workerId, long storageTierUsedBytes,
       long storageDirId, long blockId, long length) throws IOException, FileDoesNotExistException,
       SuspectedFileSizeException, BlockInfoException {
     while (!mIsShutdown) {
       connect();
 
       try {
-        mClient.worker_cacheBlock(workerId, workerUsedBytes, storageDirId, blockId, length);
+        mClient.worker_cacheBlock(workerId, storageTierUsedBytes, storageDirId, blockId, length);
         return;
       } catch (FileDoesNotExistException e) {
         throw e;
@@ -781,7 +781,7 @@ public final class MasterClient implements Closeable {
     return new ArrayList<Integer>();
   }
 
-  public synchronized Command worker_heartbeat(long workerId, long usedBytes,
+  public synchronized Command worker_heartbeat(long workerId, List<Long> usedBytes,
       List<Long> removedBlockIds, Map<Long, List<Long>> addedBlockIds)
       throws IOException {
     while (!mIsShutdown) {
@@ -803,22 +803,26 @@ public final class MasterClient implements Closeable {
    * Register the worker to the master.
    * 
    * @param workerNetAddress Worker's NetAddress
-   * @param totalBytes Worker's capacity
-   * @param usedBytes Worker's used storage
+   * @param storage levels storage levels of workers
+   * @param storage level alias values of workers
+   * @param totalBytes capacity of each storage level in the work in bytes
+   * @param usedBytes the number of bytes of each storage level in the work
    * @param currentBlockList Blocks in worker's space.
    * @return the worker id assigned by the master.
    * @throws BlockInfoException
    * @throws TException
    */
-  public synchronized long worker_register(NetAddress workerNetAddress, long totalBytes,
-      long usedBytes, Map<Long, List<Long>> currentBlockList)
+  public synchronized long worker_register(NetAddress workerNetAddress, 
+      List<Integer> storageLevels, List<Integer> storageLevelAliasValues, List<Long> totalBytes,
+      List<Long> usedBytes, Map<Long, List<Long>> currentBlockList)
       throws BlockInfoException, IOException {
     while (!mIsShutdown) {
       connect();
 
       try {
         long ret =
-            mClient.worker_register(workerNetAddress, totalBytes, usedBytes, currentBlockList);
+            mClient.worker_register(workerNetAddress, storageLevels, storageLevelAliasValues, 
+                totalBytes, usedBytes, currentBlockList);
         LOG.info("Registered at the master " + mMasterAddress + " from worker " + workerNetAddress
             + " , got WorkerId " + ret);
         return ret;

--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -52,6 +52,7 @@ import tachyon.HeartbeatExecutor;
 import tachyon.HeartbeatThread;
 import tachyon.Pair;
 import tachyon.PrefixList;
+import tachyon.StorageDirId;
 import tachyon.TachyonURI;
 import tachyon.UnderFileSystem;
 import tachyon.UnderFileSystem.SpaceType;
@@ -897,7 +898,7 @@ public class MasterInfo extends ImageWriter {
    * A worker cache a block in its memory.
    * 
    * @param workerId
-   * @param workerUsedBytes
+   * @param storageTierUsedBytes
    * @param blockId
    * @param length
    * @return the dependency id of the file if it has not been checkpointed. -1 means the file either
@@ -906,15 +907,17 @@ public class MasterInfo extends ImageWriter {
    * @throws SuspectedFileSizeException
    * @throws BlockInfoException
    */
-  public int cacheBlock(long workerId, long workerUsedBytes, long storageDirId, long blockId,
+  public int cacheBlock(long workerId, long storageTierUsedBytes, long storageDirId, long blockId,
       long length)
       throws FileDoesNotExistException, SuspectedFileSizeException, BlockInfoException {
     LOG.debug("Cache block: {}",
-        CommonUtils.parametersToString(workerId, workerUsedBytes, blockId, length));
-
+        CommonUtils.parametersToString(workerId, storageTierUsedBytes, blockId, length));
+    
     MasterWorkerInfo tWorkerInfo = getWorkerInfo(workerId);
+    int storageLevel = StorageDirId.getStorageLevel(storageDirId);
+    int storageLevelAlias = StorageDirId.getStorageLevelAliasValue(storageDirId);
     tWorkerInfo.updateBlock(true, blockId);
-    tWorkerInfo.updateUsedBytes(workerUsedBytes);
+    tWorkerInfo.updateUsedBytes(storageLevel, storageLevelAlias, storageTierUsedBytes);
     tWorkerInfo.updateLastUpdatedTimeMs();
 
     int fileId = BlockInfo.computeInodeId(blockId);
@@ -1373,6 +1376,80 @@ public class MasterInfo extends ImageWriter {
       }
     } else {
       ret.add(inode.generateClientFileInfo(path.toString()));
+    }
+    return ret;
+  }
+  
+  /**
+   * @return the capacities of each storage level in all workers in bytes.
+   */
+  public List<Long> getHierarchyCapacityBytes() {
+    List<Long> ret = new ArrayList<Long>();
+    synchronized (mWorkers) {
+      boolean first = true;
+      for (MasterWorkerInfo worker : mWorkers.values()) {
+        if (first) {
+          for (long t : worker.getTotalCapacityBytes()) {
+            ret.add(t);
+          }
+          first = false;
+        } else {
+          for (int i = 0; i < worker.getTotalCapacityBytes().size(); i++) {
+            ret.set(i, ret.get(i) + worker.getTotalCapacityBytes().get(i));
+          }
+        }
+      }
+    }
+    return ret;
+  }
+  
+  /**
+   * @return the number of bytes used of each storage level in all workers.
+   */
+  public List<Long> getHierarchyUsedBytes() {
+    List<Long> ret = new ArrayList<Long>();
+    synchronized (mWorkers) {
+      boolean first = true;
+      for (MasterWorkerInfo worker : mWorkers.values()) {
+        if (first) {
+          for (long t : worker.getUsedCapacityBytes()) {
+            ret.add(t);
+          }
+          first = false;
+        } else {
+          for (int i = 0; i < worker.getUsedCapacityBytes().size(); i++) {
+            ret.set(i, ret.get(i) + worker.getUsedCapacityBytes().get(i));
+          }
+        }
+      }
+    }
+    return ret;
+  }
+  
+  /**
+   * @return the storage levels of workers
+   */
+  public List<Integer> getHierarchyStorageLevels() {
+    List<Integer> ret = new ArrayList<Integer>();
+    synchronized (mWorkers) {
+      for (MasterWorkerInfo worker : mWorkers.values()) {
+        ret.addAll(worker.getStorageLevels());
+        return ret;
+      }
+    }
+    return ret;
+  }
+  
+  /**
+   * @return the storage level alias values of workers
+   */
+  public List<Integer> getHierarchyStorageLevelAliasValues() {
+    List<Integer> ret = new ArrayList<Integer>();
+    synchronized (mWorkers) {
+      for (MasterWorkerInfo worker : mWorkers.values()) {
+        ret.addAll(worker.getStorageLevelAliasValues());
+        return ret;
+      }
     }
     return ret;
   }
@@ -1987,15 +2064,19 @@ public class MasterInfo extends ImageWriter {
    * blocks.
    * 
    * @param workerNetAddress The address of the worker to register
-   * @param totalBytes The capacity of the worker in bytes
-   * @param usedBytes The number of bytes already used in the worker
+   * @param storageLevels The storage levels of the worker to register
+   * @param storageLevelAliasValues The storage level alias values of the worker to register
+   * @param totalBytes The capacity of each storage level in the worker in bytes
+   * @param usedBytes The number of bytes already used of each storage level in the worker
    * @param currentBlockIds Mapping from id of the StorageDir to id list of the blocks
    * @return the new id of the registered worker
    * @throws BlockInfoException
    */
-  public long registerWorker(NetAddress workerNetAddress, long totalBytes, long usedBytes,
+  public long registerWorker(NetAddress workerNetAddress, List<Integer> storageLevels,
+      List<Integer> storageLevelAliasValues, List<Long> totalBytes, List<Long> usedBytes,
       Map<Long, List<Long>> currentBlockIds) throws BlockInfoException {
     long id = 0;
+    long capacityBytes = 0;
     NetAddress workerAddress = new NetAddress(workerNetAddress);
     LOG.info("registerWorker(): WorkerNetAddress: " + workerAddress);
 
@@ -2012,8 +2093,13 @@ public class MasterInfo extends ImageWriter {
         LOG.warn("The worker with id " + id + " has been removed.");
       }
       id = mStartTimeNSPrefix + mWorkerCounter.incrementAndGet();
-      MasterWorkerInfo tWorkerInfo = new MasterWorkerInfo(id, workerAddress, totalBytes);
-      tWorkerInfo.updateUsedBytes(usedBytes);
+      for (long b : totalBytes) {
+        capacityBytes += b;
+      }
+      MasterWorkerInfo tWorkerInfo =
+          new MasterWorkerInfo(id, workerAddress, storageLevels, storageLevelAliasValues, 
+              totalBytes, capacityBytes);
+      tWorkerInfo.updateUsedBytes(usedBytes); 
       for (List<Long> blockIds : currentBlockIds.values()) {
         tWorkerInfo.updateBlocks(true, blockIds);
       }
@@ -2142,14 +2228,14 @@ public class MasterInfo extends ImageWriter {
     }
   }
 
- /**
-  * Free the file/folder based on the files' ID
-  *
-  * @param fileId the file/folder to be freed.
-  * @param recursive whether free the folder recursively or not
-  * @return succeed or not
-  * @throws TachyonException
-  */
+  /**
+   * Free the file/folder based on the files' ID
+   *
+   * @param fileId the file/folder to be freed.
+   * @param recursive whether free the folder recursively or not
+   * @return succeed or not
+   * @throws TachyonException
+   */
   boolean freepath(int fileId, boolean recursive) throws TachyonException {
     LOG.info("free(" + fileId + ")");
     synchronized (mRootLock) {
@@ -2197,14 +2283,14 @@ public class MasterInfo extends ImageWriter {
     return true;
   }
 
- /**
-  * Frees files based on the path
-  *
-  * @param path The file to be freed.
-  * @param recursive whether delete the file recursively or not.
-  * @return succeed or not
-  * @throws TachyonException
-  */
+  /**
+   * Frees files based on the path
+   *
+   * @param path The file to be freed.
+   * @param recursive whether delete the file recursively or not.
+   * @return succeed or not
+   * @throws TachyonException
+   */
   public boolean freepath(TachyonURI path, boolean recursive) throws TachyonException {
     LOG.info("free(" + path + ")");
     synchronized (mRootLock) {
@@ -2324,15 +2410,14 @@ public class MasterInfo extends ImageWriter {
    * block id's.
    * 
    * @param workerId The id of the worker to deal with
-   * @param usedBytes The number of bytes used in the worker
+   * @param usedBytes The number of bytes used of each storage level in the worker
    * @param removedBlockIds The list of removed block ids
    * @param addedBlockIds Mapping from id of the StorageDir and id list of blocks evicted in
    * @return a command specifying an action to take
    * @throws BlockInfoException
    */
-  public Command workerHeartbeat(long workerId, long usedBytes, List<Long> removedBlockIds,
-      Map<Long, List<Long>> addedBlockIds)
-      throws BlockInfoException {
+  public Command workerHeartbeat(long workerId, List<Long> usedBytes, List<Long> removedBlockIds,
+      Map<Long, List<Long>> addedBlockIds) throws BlockInfoException {
     LOG.debug("WorkerId: {}", workerId);
     synchronized (mRootLock) {
       synchronized (mWorkers) {

--- a/core/src/main/java/tachyon/master/MasterServiceHandler.java
+++ b/core/src/main/java/tachyon/master/MasterServiceHandler.java
@@ -296,10 +296,10 @@ public class MasterServiceHandler implements MasterService.Iface {
   }
 
   @Override
-  public void worker_cacheBlock(long workerId, long workerUsedBytes, long storageDirId,
+  public void worker_cacheBlock(long workerId, long storageTierUsedBytes, long storageDirId,
       long blockId, long length) throws FileDoesNotExistException, SuspectedFileSizeException,
       BlockInfoException, TException {
-    mMasterInfo.cacheBlock(workerId, workerUsedBytes, storageDirId, blockId, length);
+    mMasterInfo.cacheBlock(workerId, storageTierUsedBytes, storageDirId, blockId, length);
   }
 
   @Override
@@ -314,15 +314,16 @@ public class MasterServiceHandler implements MasterService.Iface {
   }
 
   @Override
-  public Command worker_heartbeat(long workerId, long usedBytes,
-      List<Long> removedBlockIds, Map<Long, List<Long>> addedBlockIds)
-      throws BlockInfoException, TException {
+  public Command worker_heartbeat(long workerId, List<Long> usedBytes, List<Long> removedBlockIds,
+      Map<Long, List<Long>> addedBlockIds) throws BlockInfoException, TException {
     return mMasterInfo.workerHeartbeat(workerId, usedBytes, removedBlockIds, addedBlockIds);
   }
 
   @Override
-  public long worker_register(NetAddress workerNetAddress, long totalBytes, long usedBytes,
+  public long worker_register(NetAddress workerNetAddress, List<Integer> storageLevels,
+      List<Integer> storageLevelAliasValues, List<Long> totalBytes, List<Long> usedBytes,
       Map<Long, List<Long>> currentBlockIds) throws BlockInfoException, TException {
-    return mMasterInfo.registerWorker(workerNetAddress, totalBytes, usedBytes, currentBlockIds);
+    return mMasterInfo.registerWorker(workerNetAddress, storageLevels, storageLevelAliasValues,
+        totalBytes, usedBytes, currentBlockIds);
   }
 }

--- a/core/src/main/java/tachyon/thrift/MasterService.java
+++ b/core/src/main/java/tachyon/thrift/MasterService.java
@@ -49,11 +49,13 @@ public class MasterService {
      * contains.
      * 
      * @param workerNetAddress
+     * @param storageLevels
+     * @param storageLevelAliasValues
      * @param totalBytes
      * @param usedBytes
      * @param currentBlocks
      */
-    public long worker_register(NetAddress workerNetAddress, long totalBytes, long usedBytes, Map<Long,List<Long>> currentBlocks) throws BlockInfoException, org.apache.thrift.TException;
+    public long worker_register(NetAddress workerNetAddress, List<Integer> storageLevels, List<Integer> storageLevelAliasValues, List<Long> totalBytes, List<Long> usedBytes, Map<Long,List<Long>> currentBlocks) throws BlockInfoException, org.apache.thrift.TException;
 
     /**
      * Heart beat between worker and master, worker update used Tachyon space in bytes, removed
@@ -66,7 +68,7 @@ public class MasterService {
      * @param removedBlockIds
      * @param addedBlockIds
      */
-    public Command worker_heartbeat(long workerId, long usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds) throws BlockInfoException, org.apache.thrift.TException;
+    public Command worker_heartbeat(long workerId, List<Long> usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds) throws BlockInfoException, org.apache.thrift.TException;
 
     /**
      * Update information of the block newly cached to master, including used Tachyon space size in
@@ -74,12 +76,12 @@ public class MasterService {
      * of the block in bytes.
      * 
      * @param workerId
-     * @param workerUsedBytes
+     * @param storageTierUsedBytes
      * @param storageDirId
      * @param blockId
      * @param length
      */
-    public void worker_cacheBlock(long workerId, long workerUsedBytes, long storageDirId, long blockId, long length) throws FileDoesNotExistException, SuspectedFileSizeException, BlockInfoException, org.apache.thrift.TException;
+    public void worker_cacheBlock(long workerId, long storageTierUsedBytes, long storageDirId, long blockId, long length) throws FileDoesNotExistException, SuspectedFileSizeException, BlockInfoException, org.apache.thrift.TException;
 
     public Set<Integer> worker_getPinIdList() throws org.apache.thrift.TException;
 
@@ -183,11 +185,11 @@ public class MasterService {
 
     public void liststatus(String path, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
 
-    public void worker_register(NetAddress workerNetAddress, long totalBytes, long usedBytes, Map<Long,List<Long>> currentBlocks, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
+    public void worker_register(NetAddress workerNetAddress, List<Integer> storageLevels, List<Integer> storageLevelAliasValues, List<Long> totalBytes, List<Long> usedBytes, Map<Long,List<Long>> currentBlocks, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
 
-    public void worker_heartbeat(long workerId, long usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
+    public void worker_heartbeat(long workerId, List<Long> usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
 
-    public void worker_cacheBlock(long workerId, long workerUsedBytes, long storageDirId, long blockId, long length, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
+    public void worker_cacheBlock(long workerId, long storageTierUsedBytes, long storageDirId, long blockId, long length, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
 
     public void worker_getPinIdList(org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException;
 
@@ -349,16 +351,18 @@ public class MasterService {
       throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "liststatus failed: unknown result");
     }
 
-    public long worker_register(NetAddress workerNetAddress, long totalBytes, long usedBytes, Map<Long,List<Long>> currentBlocks) throws BlockInfoException, org.apache.thrift.TException
+    public long worker_register(NetAddress workerNetAddress, List<Integer> storageLevels, List<Integer> storageLevelAliasValues, List<Long> totalBytes, List<Long> usedBytes, Map<Long,List<Long>> currentBlocks) throws BlockInfoException, org.apache.thrift.TException
     {
-      send_worker_register(workerNetAddress, totalBytes, usedBytes, currentBlocks);
+      send_worker_register(workerNetAddress, storageLevels, storageLevelAliasValues, totalBytes, usedBytes, currentBlocks);
       return recv_worker_register();
     }
 
-    public void send_worker_register(NetAddress workerNetAddress, long totalBytes, long usedBytes, Map<Long,List<Long>> currentBlocks) throws org.apache.thrift.TException
+    public void send_worker_register(NetAddress workerNetAddress, List<Integer> storageLevels, List<Integer> storageLevelAliasValues, List<Long> totalBytes, List<Long> usedBytes, Map<Long,List<Long>> currentBlocks) throws org.apache.thrift.TException
     {
       worker_register_args args = new worker_register_args();
       args.setWorkerNetAddress(workerNetAddress);
+      args.setStorageLevels(storageLevels);
+      args.setStorageLevelAliasValues(storageLevelAliasValues);
       args.setTotalBytes(totalBytes);
       args.setUsedBytes(usedBytes);
       args.setCurrentBlocks(currentBlocks);
@@ -378,13 +382,13 @@ public class MasterService {
       throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "worker_register failed: unknown result");
     }
 
-    public Command worker_heartbeat(long workerId, long usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds) throws BlockInfoException, org.apache.thrift.TException
+    public Command worker_heartbeat(long workerId, List<Long> usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds) throws BlockInfoException, org.apache.thrift.TException
     {
       send_worker_heartbeat(workerId, usedBytes, removedBlockIds, addedBlockIds);
       return recv_worker_heartbeat();
     }
 
-    public void send_worker_heartbeat(long workerId, long usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds) throws org.apache.thrift.TException
+    public void send_worker_heartbeat(long workerId, List<Long> usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds) throws org.apache.thrift.TException
     {
       worker_heartbeat_args args = new worker_heartbeat_args();
       args.setWorkerId(workerId);
@@ -407,17 +411,17 @@ public class MasterService {
       throw new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.MISSING_RESULT, "worker_heartbeat failed: unknown result");
     }
 
-    public void worker_cacheBlock(long workerId, long workerUsedBytes, long storageDirId, long blockId, long length) throws FileDoesNotExistException, SuspectedFileSizeException, BlockInfoException, org.apache.thrift.TException
+    public void worker_cacheBlock(long workerId, long storageTierUsedBytes, long storageDirId, long blockId, long length) throws FileDoesNotExistException, SuspectedFileSizeException, BlockInfoException, org.apache.thrift.TException
     {
-      send_worker_cacheBlock(workerId, workerUsedBytes, storageDirId, blockId, length);
+      send_worker_cacheBlock(workerId, storageTierUsedBytes, storageDirId, blockId, length);
       recv_worker_cacheBlock();
     }
 
-    public void send_worker_cacheBlock(long workerId, long workerUsedBytes, long storageDirId, long blockId, long length) throws org.apache.thrift.TException
+    public void send_worker_cacheBlock(long workerId, long storageTierUsedBytes, long storageDirId, long blockId, long length) throws org.apache.thrift.TException
     {
       worker_cacheBlock_args args = new worker_cacheBlock_args();
       args.setWorkerId(workerId);
-      args.setWorkerUsedBytes(workerUsedBytes);
+      args.setStorageTierUsedBytes(storageTierUsedBytes);
       args.setStorageDirId(storageDirId);
       args.setBlockId(blockId);
       args.setLength(length);
@@ -1282,21 +1286,25 @@ public class MasterService {
       }
     }
 
-    public void worker_register(NetAddress workerNetAddress, long totalBytes, long usedBytes, Map<Long,List<Long>> currentBlocks, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException {
+    public void worker_register(NetAddress workerNetAddress, List<Integer> storageLevels, List<Integer> storageLevelAliasValues, List<Long> totalBytes, List<Long> usedBytes, Map<Long,List<Long>> currentBlocks, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException {
       checkReady();
-      worker_register_call method_call = new worker_register_call(workerNetAddress, totalBytes, usedBytes, currentBlocks, resultHandler, this, ___protocolFactory, ___transport);
+      worker_register_call method_call = new worker_register_call(workerNetAddress, storageLevels, storageLevelAliasValues, totalBytes, usedBytes, currentBlocks, resultHandler, this, ___protocolFactory, ___transport);
       this.___currentMethod = method_call;
       ___manager.call(method_call);
     }
 
     public static class worker_register_call extends org.apache.thrift.async.TAsyncMethodCall {
       private NetAddress workerNetAddress;
-      private long totalBytes;
-      private long usedBytes;
+      private List<Integer> storageLevels;
+      private List<Integer> storageLevelAliasValues;
+      private List<Long> totalBytes;
+      private List<Long> usedBytes;
       private Map<Long,List<Long>> currentBlocks;
-      public worker_register_call(NetAddress workerNetAddress, long totalBytes, long usedBytes, Map<Long,List<Long>> currentBlocks, org.apache.thrift.async.AsyncMethodCallback resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
+      public worker_register_call(NetAddress workerNetAddress, List<Integer> storageLevels, List<Integer> storageLevelAliasValues, List<Long> totalBytes, List<Long> usedBytes, Map<Long,List<Long>> currentBlocks, org.apache.thrift.async.AsyncMethodCallback resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
         super(client, protocolFactory, transport, resultHandler, false);
         this.workerNetAddress = workerNetAddress;
+        this.storageLevels = storageLevels;
+        this.storageLevelAliasValues = storageLevelAliasValues;
         this.totalBytes = totalBytes;
         this.usedBytes = usedBytes;
         this.currentBlocks = currentBlocks;
@@ -1306,6 +1314,8 @@ public class MasterService {
         prot.writeMessageBegin(new org.apache.thrift.protocol.TMessage("worker_register", org.apache.thrift.protocol.TMessageType.CALL, 0));
         worker_register_args args = new worker_register_args();
         args.setWorkerNetAddress(workerNetAddress);
+        args.setStorageLevels(storageLevels);
+        args.setStorageLevelAliasValues(storageLevelAliasValues);
         args.setTotalBytes(totalBytes);
         args.setUsedBytes(usedBytes);
         args.setCurrentBlocks(currentBlocks);
@@ -1323,7 +1333,7 @@ public class MasterService {
       }
     }
 
-    public void worker_heartbeat(long workerId, long usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException {
+    public void worker_heartbeat(long workerId, List<Long> usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException {
       checkReady();
       worker_heartbeat_call method_call = new worker_heartbeat_call(workerId, usedBytes, removedBlockIds, addedBlockIds, resultHandler, this, ___protocolFactory, ___transport);
       this.___currentMethod = method_call;
@@ -1332,10 +1342,10 @@ public class MasterService {
 
     public static class worker_heartbeat_call extends org.apache.thrift.async.TAsyncMethodCall {
       private long workerId;
-      private long usedBytes;
+      private List<Long> usedBytes;
       private List<Long> removedBlockIds;
       private Map<Long,List<Long>> addedBlockIds;
-      public worker_heartbeat_call(long workerId, long usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds, org.apache.thrift.async.AsyncMethodCallback resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
+      public worker_heartbeat_call(long workerId, List<Long> usedBytes, List<Long> removedBlockIds, Map<Long,List<Long>> addedBlockIds, org.apache.thrift.async.AsyncMethodCallback resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
         super(client, protocolFactory, transport, resultHandler, false);
         this.workerId = workerId;
         this.usedBytes = usedBytes;
@@ -1364,23 +1374,23 @@ public class MasterService {
       }
     }
 
-    public void worker_cacheBlock(long workerId, long workerUsedBytes, long storageDirId, long blockId, long length, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException {
+    public void worker_cacheBlock(long workerId, long storageTierUsedBytes, long storageDirId, long blockId, long length, org.apache.thrift.async.AsyncMethodCallback resultHandler) throws org.apache.thrift.TException {
       checkReady();
-      worker_cacheBlock_call method_call = new worker_cacheBlock_call(workerId, workerUsedBytes, storageDirId, blockId, length, resultHandler, this, ___protocolFactory, ___transport);
+      worker_cacheBlock_call method_call = new worker_cacheBlock_call(workerId, storageTierUsedBytes, storageDirId, blockId, length, resultHandler, this, ___protocolFactory, ___transport);
       this.___currentMethod = method_call;
       ___manager.call(method_call);
     }
 
     public static class worker_cacheBlock_call extends org.apache.thrift.async.TAsyncMethodCall {
       private long workerId;
-      private long workerUsedBytes;
+      private long storageTierUsedBytes;
       private long storageDirId;
       private long blockId;
       private long length;
-      public worker_cacheBlock_call(long workerId, long workerUsedBytes, long storageDirId, long blockId, long length, org.apache.thrift.async.AsyncMethodCallback resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
+      public worker_cacheBlock_call(long workerId, long storageTierUsedBytes, long storageDirId, long blockId, long length, org.apache.thrift.async.AsyncMethodCallback resultHandler, org.apache.thrift.async.TAsyncClient client, org.apache.thrift.protocol.TProtocolFactory protocolFactory, org.apache.thrift.transport.TNonblockingTransport transport) throws org.apache.thrift.TException {
         super(client, protocolFactory, transport, resultHandler, false);
         this.workerId = workerId;
-        this.workerUsedBytes = workerUsedBytes;
+        this.storageTierUsedBytes = storageTierUsedBytes;
         this.storageDirId = storageDirId;
         this.blockId = blockId;
         this.length = length;
@@ -1390,7 +1400,7 @@ public class MasterService {
         prot.writeMessageBegin(new org.apache.thrift.protocol.TMessage("worker_cacheBlock", org.apache.thrift.protocol.TMessageType.CALL, 0));
         worker_cacheBlock_args args = new worker_cacheBlock_args();
         args.setWorkerId(workerId);
-        args.setWorkerUsedBytes(workerUsedBytes);
+        args.setStorageTierUsedBytes(storageTierUsedBytes);
         args.setStorageDirId(storageDirId);
         args.setBlockId(blockId);
         args.setLength(length);
@@ -2445,7 +2455,7 @@ public class MasterService {
       public worker_register_result getResult(I iface, worker_register_args args) throws org.apache.thrift.TException {
         worker_register_result result = new worker_register_result();
         try {
-          result.success = iface.worker_register(args.workerNetAddress, args.totalBytes, args.usedBytes, args.currentBlocks);
+          result.success = iface.worker_register(args.workerNetAddress, args.storageLevels, args.storageLevelAliasValues, args.totalBytes, args.usedBytes, args.currentBlocks);
           result.setSuccessIsSet(true);
         } catch (BlockInfoException e) {
           result.e = e;
@@ -2494,7 +2504,7 @@ public class MasterService {
       public worker_cacheBlock_result getResult(I iface, worker_cacheBlock_args args) throws org.apache.thrift.TException {
         worker_cacheBlock_result result = new worker_cacheBlock_result();
         try {
-          iface.worker_cacheBlock(args.workerId, args.workerUsedBytes, args.storageDirId, args.blockId, args.length);
+          iface.worker_cacheBlock(args.workerId, args.storageTierUsedBytes, args.storageDirId, args.blockId, args.length);
         } catch (FileDoesNotExistException eP) {
           result.eP = eP;
         } catch (SuspectedFileSizeException eS) {
@@ -3442,7 +3452,7 @@ public class MasterService {
       }
 
       public void start(I iface, worker_register_args args, org.apache.thrift.async.AsyncMethodCallback<Long> resultHandler) throws TException {
-        iface.worker_register(args.workerNetAddress, args.totalBytes, args.usedBytes, args.currentBlocks,resultHandler);
+        iface.worker_register(args.workerNetAddress, args.storageLevels, args.storageLevelAliasValues, args.totalBytes, args.usedBytes, args.currentBlocks,resultHandler);
       }
     }
 
@@ -3565,7 +3575,7 @@ public class MasterService {
       }
 
       public void start(I iface, worker_cacheBlock_args args, org.apache.thrift.async.AsyncMethodCallback<Void> resultHandler) throws TException {
-        iface.worker_cacheBlock(args.workerId, args.workerUsedBytes, args.storageDirId, args.blockId, args.length,resultHandler);
+        iface.worker_cacheBlock(args.workerId, args.storageTierUsedBytes, args.storageDirId, args.blockId, args.length,resultHandler);
       }
     }
 
@@ -8047,9 +8057,11 @@ public class MasterService {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("worker_register_args");
 
     private static final org.apache.thrift.protocol.TField WORKER_NET_ADDRESS_FIELD_DESC = new org.apache.thrift.protocol.TField("workerNetAddress", org.apache.thrift.protocol.TType.STRUCT, (short)1);
-    private static final org.apache.thrift.protocol.TField TOTAL_BYTES_FIELD_DESC = new org.apache.thrift.protocol.TField("totalBytes", org.apache.thrift.protocol.TType.I64, (short)2);
-    private static final org.apache.thrift.protocol.TField USED_BYTES_FIELD_DESC = new org.apache.thrift.protocol.TField("usedBytes", org.apache.thrift.protocol.TType.I64, (short)3);
-    private static final org.apache.thrift.protocol.TField CURRENT_BLOCKS_FIELD_DESC = new org.apache.thrift.protocol.TField("currentBlocks", org.apache.thrift.protocol.TType.MAP, (short)4);
+    private static final org.apache.thrift.protocol.TField STORAGE_LEVELS_FIELD_DESC = new org.apache.thrift.protocol.TField("storageLevels", org.apache.thrift.protocol.TType.LIST, (short)2);
+    private static final org.apache.thrift.protocol.TField STORAGE_LEVEL_ALIAS_VALUES_FIELD_DESC = new org.apache.thrift.protocol.TField("storageLevelAliasValues", org.apache.thrift.protocol.TType.LIST, (short)3);
+    private static final org.apache.thrift.protocol.TField TOTAL_BYTES_FIELD_DESC = new org.apache.thrift.protocol.TField("totalBytes", org.apache.thrift.protocol.TType.LIST, (short)4);
+    private static final org.apache.thrift.protocol.TField USED_BYTES_FIELD_DESC = new org.apache.thrift.protocol.TField("usedBytes", org.apache.thrift.protocol.TType.LIST, (short)5);
+    private static final org.apache.thrift.protocol.TField CURRENT_BLOCKS_FIELD_DESC = new org.apache.thrift.protocol.TField("currentBlocks", org.apache.thrift.protocol.TType.MAP, (short)6);
 
     private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
     static {
@@ -8058,16 +8070,20 @@ public class MasterService {
     }
 
     public NetAddress workerNetAddress; // required
-    public long totalBytes; // required
-    public long usedBytes; // required
+    public List<Integer> storageLevels; // required
+    public List<Integer> storageLevelAliasValues; // required
+    public List<Long> totalBytes; // required
+    public List<Long> usedBytes; // required
     public Map<Long,List<Long>> currentBlocks; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
       WORKER_NET_ADDRESS((short)1, "workerNetAddress"),
-      TOTAL_BYTES((short)2, "totalBytes"),
-      USED_BYTES((short)3, "usedBytes"),
-      CURRENT_BLOCKS((short)4, "currentBlocks");
+      STORAGE_LEVELS((short)2, "storageLevels"),
+      STORAGE_LEVEL_ALIAS_VALUES((short)3, "storageLevelAliasValues"),
+      TOTAL_BYTES((short)4, "totalBytes"),
+      USED_BYTES((short)5, "usedBytes"),
+      CURRENT_BLOCKS((short)6, "currentBlocks");
 
       private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -8084,11 +8100,15 @@ public class MasterService {
         switch(fieldId) {
           case 1: // WORKER_NET_ADDRESS
             return WORKER_NET_ADDRESS;
-          case 2: // TOTAL_BYTES
+          case 2: // STORAGE_LEVELS
+            return STORAGE_LEVELS;
+          case 3: // STORAGE_LEVEL_ALIAS_VALUES
+            return STORAGE_LEVEL_ALIAS_VALUES;
+          case 4: // TOTAL_BYTES
             return TOTAL_BYTES;
-          case 3: // USED_BYTES
+          case 5: // USED_BYTES
             return USED_BYTES;
-          case 4: // CURRENT_BLOCKS
+          case 6: // CURRENT_BLOCKS
             return CURRENT_BLOCKS;
           default:
             return null;
@@ -8130,18 +8150,23 @@ public class MasterService {
     }
 
     // isset id assignments
-    private static final int __TOTALBYTES_ISSET_ID = 0;
-    private static final int __USEDBYTES_ISSET_ID = 1;
-    private byte __isset_bitfield = 0;
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
       tmpMap.put(_Fields.WORKER_NET_ADDRESS, new org.apache.thrift.meta_data.FieldMetaData("workerNetAddress", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, NetAddress.class)));
+      tmpMap.put(_Fields.STORAGE_LEVELS, new org.apache.thrift.meta_data.FieldMetaData("storageLevels", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
+              new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32))));
+      tmpMap.put(_Fields.STORAGE_LEVEL_ALIAS_VALUES, new org.apache.thrift.meta_data.FieldMetaData("storageLevelAliasValues", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
+              new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32))));
       tmpMap.put(_Fields.TOTAL_BYTES, new org.apache.thrift.meta_data.FieldMetaData("totalBytes", org.apache.thrift.TFieldRequirementType.DEFAULT, 
-          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
+          new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
+              new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64))));
       tmpMap.put(_Fields.USED_BYTES, new org.apache.thrift.meta_data.FieldMetaData("usedBytes", org.apache.thrift.TFieldRequirementType.DEFAULT, 
-          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
+          new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
+              new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64))));
       tmpMap.put(_Fields.CURRENT_BLOCKS, new org.apache.thrift.meta_data.FieldMetaData("currentBlocks", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.MapMetaData(org.apache.thrift.protocol.TType.MAP, 
               new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64), 
@@ -8156,16 +8181,18 @@ public class MasterService {
 
     public worker_register_args(
       NetAddress workerNetAddress,
-      long totalBytes,
-      long usedBytes,
+      List<Integer> storageLevels,
+      List<Integer> storageLevelAliasValues,
+      List<Long> totalBytes,
+      List<Long> usedBytes,
       Map<Long,List<Long>> currentBlocks)
     {
       this();
       this.workerNetAddress = workerNetAddress;
+      this.storageLevels = storageLevels;
+      this.storageLevelAliasValues = storageLevelAliasValues;
       this.totalBytes = totalBytes;
-      setTotalBytesIsSet(true);
       this.usedBytes = usedBytes;
-      setUsedBytesIsSet(true);
       this.currentBlocks = currentBlocks;
     }
 
@@ -8173,12 +8200,25 @@ public class MasterService {
      * Performs a deep copy on <i>other</i>.
      */
     public worker_register_args(worker_register_args other) {
-      __isset_bitfield = other.__isset_bitfield;
       if (other.isSetWorkerNetAddress()) {
         this.workerNetAddress = new NetAddress(other.workerNetAddress);
       }
-      this.totalBytes = other.totalBytes;
-      this.usedBytes = other.usedBytes;
+      if (other.isSetStorageLevels()) {
+        List<Integer> __this__storageLevels = new ArrayList<Integer>(other.storageLevels);
+        this.storageLevels = __this__storageLevels;
+      }
+      if (other.isSetStorageLevelAliasValues()) {
+        List<Integer> __this__storageLevelAliasValues = new ArrayList<Integer>(other.storageLevelAliasValues);
+        this.storageLevelAliasValues = __this__storageLevelAliasValues;
+      }
+      if (other.isSetTotalBytes()) {
+        List<Long> __this__totalBytes = new ArrayList<Long>(other.totalBytes);
+        this.totalBytes = __this__totalBytes;
+      }
+      if (other.isSetUsedBytes()) {
+        List<Long> __this__usedBytes = new ArrayList<Long>(other.usedBytes);
+        this.usedBytes = __this__usedBytes;
+      }
       if (other.isSetCurrentBlocks()) {
         Map<Long,List<Long>> __this__currentBlocks = new HashMap<Long,List<Long>>(other.currentBlocks.size());
         for (Map.Entry<Long, List<Long>> other_element : other.currentBlocks.entrySet()) {
@@ -8203,10 +8243,10 @@ public class MasterService {
     @Override
     public void clear() {
       this.workerNetAddress = null;
-      setTotalBytesIsSet(false);
-      this.totalBytes = 0;
-      setUsedBytesIsSet(false);
-      this.usedBytes = 0;
+      this.storageLevels = null;
+      this.storageLevelAliasValues = null;
+      this.totalBytes = null;
+      this.usedBytes = null;
       this.currentBlocks = null;
     }
 
@@ -8234,50 +8274,160 @@ public class MasterService {
       }
     }
 
-    public long getTotalBytes() {
+    public int getStorageLevelsSize() {
+      return (this.storageLevels == null) ? 0 : this.storageLevels.size();
+    }
+
+    public java.util.Iterator<Integer> getStorageLevelsIterator() {
+      return (this.storageLevels == null) ? null : this.storageLevels.iterator();
+    }
+
+    public void addToStorageLevels(int elem) {
+      if (this.storageLevels == null) {
+        this.storageLevels = new ArrayList<Integer>();
+      }
+      this.storageLevels.add(elem);
+    }
+
+    public List<Integer> getStorageLevels() {
+      return this.storageLevels;
+    }
+
+    public worker_register_args setStorageLevels(List<Integer> storageLevels) {
+      this.storageLevels = storageLevels;
+      return this;
+    }
+
+    public void unsetStorageLevels() {
+      this.storageLevels = null;
+    }
+
+    /** Returns true if field storageLevels is set (has been assigned a value) and false otherwise */
+    public boolean isSetStorageLevels() {
+      return this.storageLevels != null;
+    }
+
+    public void setStorageLevelsIsSet(boolean value) {
+      if (!value) {
+        this.storageLevels = null;
+      }
+    }
+
+    public int getStorageLevelAliasValuesSize() {
+      return (this.storageLevelAliasValues == null) ? 0 : this.storageLevelAliasValues.size();
+    }
+
+    public java.util.Iterator<Integer> getStorageLevelAliasValuesIterator() {
+      return (this.storageLevelAliasValues == null) ? null : this.storageLevelAliasValues.iterator();
+    }
+
+    public void addToStorageLevelAliasValues(int elem) {
+      if (this.storageLevelAliasValues == null) {
+        this.storageLevelAliasValues = new ArrayList<Integer>();
+      }
+      this.storageLevelAliasValues.add(elem);
+    }
+
+    public List<Integer> getStorageLevelAliasValues() {
+      return this.storageLevelAliasValues;
+    }
+
+    public worker_register_args setStorageLevelAliasValues(List<Integer> storageLevelAliasValues) {
+      this.storageLevelAliasValues = storageLevelAliasValues;
+      return this;
+    }
+
+    public void unsetStorageLevelAliasValues() {
+      this.storageLevelAliasValues = null;
+    }
+
+    /** Returns true if field storageLevelAliasValues is set (has been assigned a value) and false otherwise */
+    public boolean isSetStorageLevelAliasValues() {
+      return this.storageLevelAliasValues != null;
+    }
+
+    public void setStorageLevelAliasValuesIsSet(boolean value) {
+      if (!value) {
+        this.storageLevelAliasValues = null;
+      }
+    }
+
+    public int getTotalBytesSize() {
+      return (this.totalBytes == null) ? 0 : this.totalBytes.size();
+    }
+
+    public java.util.Iterator<Long> getTotalBytesIterator() {
+      return (this.totalBytes == null) ? null : this.totalBytes.iterator();
+    }
+
+    public void addToTotalBytes(long elem) {
+      if (this.totalBytes == null) {
+        this.totalBytes = new ArrayList<Long>();
+      }
+      this.totalBytes.add(elem);
+    }
+
+    public List<Long> getTotalBytes() {
       return this.totalBytes;
     }
 
-    public worker_register_args setTotalBytes(long totalBytes) {
+    public worker_register_args setTotalBytes(List<Long> totalBytes) {
       this.totalBytes = totalBytes;
-      setTotalBytesIsSet(true);
       return this;
     }
 
     public void unsetTotalBytes() {
-      __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __TOTALBYTES_ISSET_ID);
+      this.totalBytes = null;
     }
 
     /** Returns true if field totalBytes is set (has been assigned a value) and false otherwise */
     public boolean isSetTotalBytes() {
-      return EncodingUtils.testBit(__isset_bitfield, __TOTALBYTES_ISSET_ID);
+      return this.totalBytes != null;
     }
 
     public void setTotalBytesIsSet(boolean value) {
-      __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __TOTALBYTES_ISSET_ID, value);
+      if (!value) {
+        this.totalBytes = null;
+      }
     }
 
-    public long getUsedBytes() {
+    public int getUsedBytesSize() {
+      return (this.usedBytes == null) ? 0 : this.usedBytes.size();
+    }
+
+    public java.util.Iterator<Long> getUsedBytesIterator() {
+      return (this.usedBytes == null) ? null : this.usedBytes.iterator();
+    }
+
+    public void addToUsedBytes(long elem) {
+      if (this.usedBytes == null) {
+        this.usedBytes = new ArrayList<Long>();
+      }
+      this.usedBytes.add(elem);
+    }
+
+    public List<Long> getUsedBytes() {
       return this.usedBytes;
     }
 
-    public worker_register_args setUsedBytes(long usedBytes) {
+    public worker_register_args setUsedBytes(List<Long> usedBytes) {
       this.usedBytes = usedBytes;
-      setUsedBytesIsSet(true);
       return this;
     }
 
     public void unsetUsedBytes() {
-      __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __USEDBYTES_ISSET_ID);
+      this.usedBytes = null;
     }
 
     /** Returns true if field usedBytes is set (has been assigned a value) and false otherwise */
     public boolean isSetUsedBytes() {
-      return EncodingUtils.testBit(__isset_bitfield, __USEDBYTES_ISSET_ID);
+      return this.usedBytes != null;
     }
 
     public void setUsedBytesIsSet(boolean value) {
-      __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __USEDBYTES_ISSET_ID, value);
+      if (!value) {
+        this.usedBytes = null;
+      }
     }
 
     public int getCurrentBlocksSize() {
@@ -8325,11 +8475,27 @@ public class MasterService {
         }
         break;
 
+      case STORAGE_LEVELS:
+        if (value == null) {
+          unsetStorageLevels();
+        } else {
+          setStorageLevels((List<Integer>)value);
+        }
+        break;
+
+      case STORAGE_LEVEL_ALIAS_VALUES:
+        if (value == null) {
+          unsetStorageLevelAliasValues();
+        } else {
+          setStorageLevelAliasValues((List<Integer>)value);
+        }
+        break;
+
       case TOTAL_BYTES:
         if (value == null) {
           unsetTotalBytes();
         } else {
-          setTotalBytes((Long)value);
+          setTotalBytes((List<Long>)value);
         }
         break;
 
@@ -8337,7 +8503,7 @@ public class MasterService {
         if (value == null) {
           unsetUsedBytes();
         } else {
-          setUsedBytes((Long)value);
+          setUsedBytes((List<Long>)value);
         }
         break;
 
@@ -8357,11 +8523,17 @@ public class MasterService {
       case WORKER_NET_ADDRESS:
         return getWorkerNetAddress();
 
+      case STORAGE_LEVELS:
+        return getStorageLevels();
+
+      case STORAGE_LEVEL_ALIAS_VALUES:
+        return getStorageLevelAliasValues();
+
       case TOTAL_BYTES:
-        return Long.valueOf(getTotalBytes());
+        return getTotalBytes();
 
       case USED_BYTES:
-        return Long.valueOf(getUsedBytes());
+        return getUsedBytes();
 
       case CURRENT_BLOCKS:
         return getCurrentBlocks();
@@ -8379,6 +8551,10 @@ public class MasterService {
       switch (field) {
       case WORKER_NET_ADDRESS:
         return isSetWorkerNetAddress();
+      case STORAGE_LEVELS:
+        return isSetStorageLevels();
+      case STORAGE_LEVEL_ALIAS_VALUES:
+        return isSetStorageLevelAliasValues();
       case TOTAL_BYTES:
         return isSetTotalBytes();
       case USED_BYTES:
@@ -8411,21 +8587,39 @@ public class MasterService {
           return false;
       }
 
-      boolean this_present_totalBytes = true;
-      boolean that_present_totalBytes = true;
-      if (this_present_totalBytes || that_present_totalBytes) {
-        if (!(this_present_totalBytes && that_present_totalBytes))
+      boolean this_present_storageLevels = true && this.isSetStorageLevels();
+      boolean that_present_storageLevels = true && that.isSetStorageLevels();
+      if (this_present_storageLevels || that_present_storageLevels) {
+        if (!(this_present_storageLevels && that_present_storageLevels))
           return false;
-        if (this.totalBytes != that.totalBytes)
+        if (!this.storageLevels.equals(that.storageLevels))
           return false;
       }
 
-      boolean this_present_usedBytes = true;
-      boolean that_present_usedBytes = true;
+      boolean this_present_storageLevelAliasValues = true && this.isSetStorageLevelAliasValues();
+      boolean that_present_storageLevelAliasValues = true && that.isSetStorageLevelAliasValues();
+      if (this_present_storageLevelAliasValues || that_present_storageLevelAliasValues) {
+        if (!(this_present_storageLevelAliasValues && that_present_storageLevelAliasValues))
+          return false;
+        if (!this.storageLevelAliasValues.equals(that.storageLevelAliasValues))
+          return false;
+      }
+
+      boolean this_present_totalBytes = true && this.isSetTotalBytes();
+      boolean that_present_totalBytes = true && that.isSetTotalBytes();
+      if (this_present_totalBytes || that_present_totalBytes) {
+        if (!(this_present_totalBytes && that_present_totalBytes))
+          return false;
+        if (!this.totalBytes.equals(that.totalBytes))
+          return false;
+      }
+
+      boolean this_present_usedBytes = true && this.isSetUsedBytes();
+      boolean that_present_usedBytes = true && that.isSetUsedBytes();
       if (this_present_usedBytes || that_present_usedBytes) {
         if (!(this_present_usedBytes && that_present_usedBytes))
           return false;
-        if (this.usedBytes != that.usedBytes)
+        if (!this.usedBytes.equals(that.usedBytes))
           return false;
       }
 
@@ -8460,6 +8654,26 @@ public class MasterService {
       }
       if (isSetWorkerNetAddress()) {
         lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.workerNetAddress, other.workerNetAddress);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = Boolean.valueOf(isSetStorageLevels()).compareTo(other.isSetStorageLevels());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetStorageLevels()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.storageLevels, other.storageLevels);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = Boolean.valueOf(isSetStorageLevelAliasValues()).compareTo(other.isSetStorageLevelAliasValues());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (isSetStorageLevelAliasValues()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.storageLevelAliasValues, other.storageLevelAliasValues);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -8522,12 +8736,36 @@ public class MasterService {
       }
       first = false;
       if (!first) sb.append(", ");
+      sb.append("storageLevels:");
+      if (this.storageLevels == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.storageLevels);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("storageLevelAliasValues:");
+      if (this.storageLevelAliasValues == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.storageLevelAliasValues);
+      }
+      first = false;
+      if (!first) sb.append(", ");
       sb.append("totalBytes:");
-      sb.append(this.totalBytes);
+      if (this.totalBytes == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.totalBytes);
+      }
       first = false;
       if (!first) sb.append(", ");
       sb.append("usedBytes:");
-      sb.append(this.usedBytes);
+      if (this.usedBytes == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.usedBytes);
+      }
       first = false;
       if (!first) sb.append(", ");
       sb.append("currentBlocks:");
@@ -8559,8 +8797,6 @@ public class MasterService {
 
     private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
       try {
-        // it doesn't seem like you should have to do this, but java serialization is wacky, and doesn't call the default constructor.
-        __isset_bitfield = 0;
         read(new org.apache.thrift.protocol.TCompactProtocol(new org.apache.thrift.transport.TIOStreamTransport(in)));
       } catch (org.apache.thrift.TException te) {
         throw new java.io.IOException(te);
@@ -8594,44 +8830,100 @@ public class MasterService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
-            case 2: // TOTAL_BYTES
-              if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
-                struct.totalBytes = iprot.readI64();
+            case 2: // STORAGE_LEVELS
+              if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
+                {
+                  org.apache.thrift.protocol.TList _list64 = iprot.readListBegin();
+                  struct.storageLevels = new ArrayList<Integer>(_list64.size);
+                  for (int _i65 = 0; _i65 < _list64.size; ++_i65)
+                  {
+                    int _elem66;
+                    _elem66 = iprot.readI32();
+                    struct.storageLevels.add(_elem66);
+                  }
+                  iprot.readListEnd();
+                }
+                struct.setStorageLevelsIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            case 3: // STORAGE_LEVEL_ALIAS_VALUES
+              if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
+                {
+                  org.apache.thrift.protocol.TList _list67 = iprot.readListBegin();
+                  struct.storageLevelAliasValues = new ArrayList<Integer>(_list67.size);
+                  for (int _i68 = 0; _i68 < _list67.size; ++_i68)
+                  {
+                    int _elem69;
+                    _elem69 = iprot.readI32();
+                    struct.storageLevelAliasValues.add(_elem69);
+                  }
+                  iprot.readListEnd();
+                }
+                struct.setStorageLevelAliasValuesIsSet(true);
+              } else { 
+                org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+              }
+              break;
+            case 4: // TOTAL_BYTES
+              if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
+                {
+                  org.apache.thrift.protocol.TList _list70 = iprot.readListBegin();
+                  struct.totalBytes = new ArrayList<Long>(_list70.size);
+                  for (int _i71 = 0; _i71 < _list70.size; ++_i71)
+                  {
+                    long _elem72;
+                    _elem72 = iprot.readI64();
+                    struct.totalBytes.add(_elem72);
+                  }
+                  iprot.readListEnd();
+                }
                 struct.setTotalBytesIsSet(true);
               } else { 
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
-            case 3: // USED_BYTES
-              if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
-                struct.usedBytes = iprot.readI64();
+            case 5: // USED_BYTES
+              if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
+                {
+                  org.apache.thrift.protocol.TList _list73 = iprot.readListBegin();
+                  struct.usedBytes = new ArrayList<Long>(_list73.size);
+                  for (int _i74 = 0; _i74 < _list73.size; ++_i74)
+                  {
+                    long _elem75;
+                    _elem75 = iprot.readI64();
+                    struct.usedBytes.add(_elem75);
+                  }
+                  iprot.readListEnd();
+                }
                 struct.setUsedBytesIsSet(true);
               } else { 
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
-            case 4: // CURRENT_BLOCKS
+            case 6: // CURRENT_BLOCKS
               if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
                 {
-                  org.apache.thrift.protocol.TMap _map64 = iprot.readMapBegin();
-                  struct.currentBlocks = new HashMap<Long,List<Long>>(2*_map64.size);
-                  for (int _i65 = 0; _i65 < _map64.size; ++_i65)
+                  org.apache.thrift.protocol.TMap _map76 = iprot.readMapBegin();
+                  struct.currentBlocks = new HashMap<Long,List<Long>>(2*_map76.size);
+                  for (int _i77 = 0; _i77 < _map76.size; ++_i77)
                   {
-                    long _key66;
-                    List<Long> _val67;
-                    _key66 = iprot.readI64();
+                    long _key78;
+                    List<Long> _val79;
+                    _key78 = iprot.readI64();
                     {
-                      org.apache.thrift.protocol.TList _list68 = iprot.readListBegin();
-                      _val67 = new ArrayList<Long>(_list68.size);
-                      for (int _i69 = 0; _i69 < _list68.size; ++_i69)
+                      org.apache.thrift.protocol.TList _list80 = iprot.readListBegin();
+                      _val79 = new ArrayList<Long>(_list80.size);
+                      for (int _i81 = 0; _i81 < _list80.size; ++_i81)
                       {
-                        long _elem70;
-                        _elem70 = iprot.readI64();
-                        _val67.add(_elem70);
+                        long _elem82;
+                        _elem82 = iprot.readI64();
+                        _val79.add(_elem82);
                       }
                       iprot.readListEnd();
                     }
-                    struct.currentBlocks.put(_key66, _val67);
+                    struct.currentBlocks.put(_key78, _val79);
                   }
                   iprot.readMapEnd();
                 }
@@ -8660,24 +8952,66 @@ public class MasterService {
           struct.workerNetAddress.write(oprot);
           oprot.writeFieldEnd();
         }
-        oprot.writeFieldBegin(TOTAL_BYTES_FIELD_DESC);
-        oprot.writeI64(struct.totalBytes);
-        oprot.writeFieldEnd();
-        oprot.writeFieldBegin(USED_BYTES_FIELD_DESC);
-        oprot.writeI64(struct.usedBytes);
-        oprot.writeFieldEnd();
+        if (struct.storageLevels != null) {
+          oprot.writeFieldBegin(STORAGE_LEVELS_FIELD_DESC);
+          {
+            oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, struct.storageLevels.size()));
+            for (int _iter83 : struct.storageLevels)
+            {
+              oprot.writeI32(_iter83);
+            }
+            oprot.writeListEnd();
+          }
+          oprot.writeFieldEnd();
+        }
+        if (struct.storageLevelAliasValues != null) {
+          oprot.writeFieldBegin(STORAGE_LEVEL_ALIAS_VALUES_FIELD_DESC);
+          {
+            oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, struct.storageLevelAliasValues.size()));
+            for (int _iter84 : struct.storageLevelAliasValues)
+            {
+              oprot.writeI32(_iter84);
+            }
+            oprot.writeListEnd();
+          }
+          oprot.writeFieldEnd();
+        }
+        if (struct.totalBytes != null) {
+          oprot.writeFieldBegin(TOTAL_BYTES_FIELD_DESC);
+          {
+            oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.totalBytes.size()));
+            for (long _iter85 : struct.totalBytes)
+            {
+              oprot.writeI64(_iter85);
+            }
+            oprot.writeListEnd();
+          }
+          oprot.writeFieldEnd();
+        }
+        if (struct.usedBytes != null) {
+          oprot.writeFieldBegin(USED_BYTES_FIELD_DESC);
+          {
+            oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.usedBytes.size()));
+            for (long _iter86 : struct.usedBytes)
+            {
+              oprot.writeI64(_iter86);
+            }
+            oprot.writeListEnd();
+          }
+          oprot.writeFieldEnd();
+        }
         if (struct.currentBlocks != null) {
           oprot.writeFieldBegin(CURRENT_BLOCKS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.LIST, struct.currentBlocks.size()));
-            for (Map.Entry<Long, List<Long>> _iter71 : struct.currentBlocks.entrySet())
+            for (Map.Entry<Long, List<Long>> _iter87 : struct.currentBlocks.entrySet())
             {
-              oprot.writeI64(_iter71.getKey());
+              oprot.writeI64(_iter87.getKey());
               {
-                oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, _iter71.getValue().size()));
-                for (long _iter72 : _iter71.getValue())
+                oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, _iter87.getValue().size()));
+                for (long _iter88 : _iter87.getValue())
                 {
-                  oprot.writeI64(_iter72);
+                  oprot.writeI64(_iter88);
                 }
                 oprot.writeListEnd();
               }
@@ -8707,36 +9041,72 @@ public class MasterService {
         if (struct.isSetWorkerNetAddress()) {
           optionals.set(0);
         }
-        if (struct.isSetTotalBytes()) {
+        if (struct.isSetStorageLevels()) {
           optionals.set(1);
         }
-        if (struct.isSetUsedBytes()) {
+        if (struct.isSetStorageLevelAliasValues()) {
           optionals.set(2);
         }
-        if (struct.isSetCurrentBlocks()) {
+        if (struct.isSetTotalBytes()) {
           optionals.set(3);
         }
-        oprot.writeBitSet(optionals, 4);
+        if (struct.isSetUsedBytes()) {
+          optionals.set(4);
+        }
+        if (struct.isSetCurrentBlocks()) {
+          optionals.set(5);
+        }
+        oprot.writeBitSet(optionals, 6);
         if (struct.isSetWorkerNetAddress()) {
           struct.workerNetAddress.write(oprot);
         }
+        if (struct.isSetStorageLevels()) {
+          {
+            oprot.writeI32(struct.storageLevels.size());
+            for (int _iter89 : struct.storageLevels)
+            {
+              oprot.writeI32(_iter89);
+            }
+          }
+        }
+        if (struct.isSetStorageLevelAliasValues()) {
+          {
+            oprot.writeI32(struct.storageLevelAliasValues.size());
+            for (int _iter90 : struct.storageLevelAliasValues)
+            {
+              oprot.writeI32(_iter90);
+            }
+          }
+        }
         if (struct.isSetTotalBytes()) {
-          oprot.writeI64(struct.totalBytes);
+          {
+            oprot.writeI32(struct.totalBytes.size());
+            for (long _iter91 : struct.totalBytes)
+            {
+              oprot.writeI64(_iter91);
+            }
+          }
         }
         if (struct.isSetUsedBytes()) {
-          oprot.writeI64(struct.usedBytes);
+          {
+            oprot.writeI32(struct.usedBytes.size());
+            for (long _iter92 : struct.usedBytes)
+            {
+              oprot.writeI64(_iter92);
+            }
+          }
         }
         if (struct.isSetCurrentBlocks()) {
           {
             oprot.writeI32(struct.currentBlocks.size());
-            for (Map.Entry<Long, List<Long>> _iter73 : struct.currentBlocks.entrySet())
+            for (Map.Entry<Long, List<Long>> _iter93 : struct.currentBlocks.entrySet())
             {
-              oprot.writeI64(_iter73.getKey());
+              oprot.writeI64(_iter93.getKey());
               {
-                oprot.writeI32(_iter73.getValue().size());
-                for (long _iter74 : _iter73.getValue())
+                oprot.writeI32(_iter93.getValue().size());
+                for (long _iter94 : _iter93.getValue())
                 {
-                  oprot.writeI64(_iter74);
+                  oprot.writeI64(_iter94);
                 }
               }
             }
@@ -8747,40 +9117,84 @@ public class MasterService {
       @Override
       public void read(org.apache.thrift.protocol.TProtocol prot, worker_register_args struct) throws org.apache.thrift.TException {
         TTupleProtocol iprot = (TTupleProtocol) prot;
-        BitSet incoming = iprot.readBitSet(4);
+        BitSet incoming = iprot.readBitSet(6);
         if (incoming.get(0)) {
           struct.workerNetAddress = new NetAddress();
           struct.workerNetAddress.read(iprot);
           struct.setWorkerNetAddressIsSet(true);
         }
         if (incoming.get(1)) {
-          struct.totalBytes = iprot.readI64();
-          struct.setTotalBytesIsSet(true);
+          {
+            org.apache.thrift.protocol.TList _list95 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
+            struct.storageLevels = new ArrayList<Integer>(_list95.size);
+            for (int _i96 = 0; _i96 < _list95.size; ++_i96)
+            {
+              int _elem97;
+              _elem97 = iprot.readI32();
+              struct.storageLevels.add(_elem97);
+            }
+          }
+          struct.setStorageLevelsIsSet(true);
         }
         if (incoming.get(2)) {
-          struct.usedBytes = iprot.readI64();
-          struct.setUsedBytesIsSet(true);
+          {
+            org.apache.thrift.protocol.TList _list98 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
+            struct.storageLevelAliasValues = new ArrayList<Integer>(_list98.size);
+            for (int _i99 = 0; _i99 < _list98.size; ++_i99)
+            {
+              int _elem100;
+              _elem100 = iprot.readI32();
+              struct.storageLevelAliasValues.add(_elem100);
+            }
+          }
+          struct.setStorageLevelAliasValuesIsSet(true);
         }
         if (incoming.get(3)) {
           {
-            org.apache.thrift.protocol.TMap _map75 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.LIST, iprot.readI32());
-            struct.currentBlocks = new HashMap<Long,List<Long>>(2*_map75.size);
-            for (int _i76 = 0; _i76 < _map75.size; ++_i76)
+            org.apache.thrift.protocol.TList _list101 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+            struct.totalBytes = new ArrayList<Long>(_list101.size);
+            for (int _i102 = 0; _i102 < _list101.size; ++_i102)
             {
-              long _key77;
-              List<Long> _val78;
-              _key77 = iprot.readI64();
+              long _elem103;
+              _elem103 = iprot.readI64();
+              struct.totalBytes.add(_elem103);
+            }
+          }
+          struct.setTotalBytesIsSet(true);
+        }
+        if (incoming.get(4)) {
+          {
+            org.apache.thrift.protocol.TList _list104 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+            struct.usedBytes = new ArrayList<Long>(_list104.size);
+            for (int _i105 = 0; _i105 < _list104.size; ++_i105)
+            {
+              long _elem106;
+              _elem106 = iprot.readI64();
+              struct.usedBytes.add(_elem106);
+            }
+          }
+          struct.setUsedBytesIsSet(true);
+        }
+        if (incoming.get(5)) {
+          {
+            org.apache.thrift.protocol.TMap _map107 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.LIST, iprot.readI32());
+            struct.currentBlocks = new HashMap<Long,List<Long>>(2*_map107.size);
+            for (int _i108 = 0; _i108 < _map107.size; ++_i108)
+            {
+              long _key109;
+              List<Long> _val110;
+              _key109 = iprot.readI64();
               {
-                org.apache.thrift.protocol.TList _list79 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-                _val78 = new ArrayList<Long>(_list79.size);
-                for (int _i80 = 0; _i80 < _list79.size; ++_i80)
+                org.apache.thrift.protocol.TList _list111 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+                _val110 = new ArrayList<Long>(_list111.size);
+                for (int _i112 = 0; _i112 < _list111.size; ++_i112)
                 {
-                  long _elem81;
-                  _elem81 = iprot.readI64();
-                  _val78.add(_elem81);
+                  long _elem113;
+                  _elem113 = iprot.readI64();
+                  _val110.add(_elem113);
                 }
               }
-              struct.currentBlocks.put(_key77, _val78);
+              struct.currentBlocks.put(_key109, _val110);
             }
           }
           struct.setCurrentBlocksIsSet(true);
@@ -9250,7 +9664,7 @@ public class MasterService {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("worker_heartbeat_args");
 
     private static final org.apache.thrift.protocol.TField WORKER_ID_FIELD_DESC = new org.apache.thrift.protocol.TField("workerId", org.apache.thrift.protocol.TType.I64, (short)1);
-    private static final org.apache.thrift.protocol.TField USED_BYTES_FIELD_DESC = new org.apache.thrift.protocol.TField("usedBytes", org.apache.thrift.protocol.TType.I64, (short)2);
+    private static final org.apache.thrift.protocol.TField USED_BYTES_FIELD_DESC = new org.apache.thrift.protocol.TField("usedBytes", org.apache.thrift.protocol.TType.LIST, (short)2);
     private static final org.apache.thrift.protocol.TField REMOVED_BLOCK_IDS_FIELD_DESC = new org.apache.thrift.protocol.TField("removedBlockIds", org.apache.thrift.protocol.TType.LIST, (short)3);
     private static final org.apache.thrift.protocol.TField ADDED_BLOCK_IDS_FIELD_DESC = new org.apache.thrift.protocol.TField("addedBlockIds", org.apache.thrift.protocol.TType.MAP, (short)4);
 
@@ -9261,7 +9675,7 @@ public class MasterService {
     }
 
     public long workerId; // required
-    public long usedBytes; // required
+    public List<Long> usedBytes; // required
     public List<Long> removedBlockIds; // required
     public Map<Long,List<Long>> addedBlockIds; // required
 
@@ -9334,7 +9748,6 @@ public class MasterService {
 
     // isset id assignments
     private static final int __WORKERID_ISSET_ID = 0;
-    private static final int __USEDBYTES_ISSET_ID = 1;
     private byte __isset_bitfield = 0;
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
@@ -9342,7 +9755,8 @@ public class MasterService {
       tmpMap.put(_Fields.WORKER_ID, new org.apache.thrift.meta_data.FieldMetaData("workerId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       tmpMap.put(_Fields.USED_BYTES, new org.apache.thrift.meta_data.FieldMetaData("usedBytes", org.apache.thrift.TFieldRequirementType.DEFAULT, 
-          new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
+          new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
+              new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64))));
       tmpMap.put(_Fields.REMOVED_BLOCK_IDS, new org.apache.thrift.meta_data.FieldMetaData("removedBlockIds", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
               new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64))));
@@ -9360,7 +9774,7 @@ public class MasterService {
 
     public worker_heartbeat_args(
       long workerId,
-      long usedBytes,
+      List<Long> usedBytes,
       List<Long> removedBlockIds,
       Map<Long,List<Long>> addedBlockIds)
     {
@@ -9368,7 +9782,6 @@ public class MasterService {
       this.workerId = workerId;
       setWorkerIdIsSet(true);
       this.usedBytes = usedBytes;
-      setUsedBytesIsSet(true);
       this.removedBlockIds = removedBlockIds;
       this.addedBlockIds = addedBlockIds;
     }
@@ -9379,7 +9792,10 @@ public class MasterService {
     public worker_heartbeat_args(worker_heartbeat_args other) {
       __isset_bitfield = other.__isset_bitfield;
       this.workerId = other.workerId;
-      this.usedBytes = other.usedBytes;
+      if (other.isSetUsedBytes()) {
+        List<Long> __this__usedBytes = new ArrayList<Long>(other.usedBytes);
+        this.usedBytes = __this__usedBytes;
+      }
       if (other.isSetRemovedBlockIds()) {
         List<Long> __this__removedBlockIds = new ArrayList<Long>(other.removedBlockIds);
         this.removedBlockIds = __this__removedBlockIds;
@@ -9409,8 +9825,7 @@ public class MasterService {
     public void clear() {
       setWorkerIdIsSet(false);
       this.workerId = 0;
-      setUsedBytesIsSet(false);
-      this.usedBytes = 0;
+      this.usedBytes = null;
       this.removedBlockIds = null;
       this.addedBlockIds = null;
     }
@@ -9438,27 +9853,43 @@ public class MasterService {
       __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __WORKERID_ISSET_ID, value);
     }
 
-    public long getUsedBytes() {
+    public int getUsedBytesSize() {
+      return (this.usedBytes == null) ? 0 : this.usedBytes.size();
+    }
+
+    public java.util.Iterator<Long> getUsedBytesIterator() {
+      return (this.usedBytes == null) ? null : this.usedBytes.iterator();
+    }
+
+    public void addToUsedBytes(long elem) {
+      if (this.usedBytes == null) {
+        this.usedBytes = new ArrayList<Long>();
+      }
+      this.usedBytes.add(elem);
+    }
+
+    public List<Long> getUsedBytes() {
       return this.usedBytes;
     }
 
-    public worker_heartbeat_args setUsedBytes(long usedBytes) {
+    public worker_heartbeat_args setUsedBytes(List<Long> usedBytes) {
       this.usedBytes = usedBytes;
-      setUsedBytesIsSet(true);
       return this;
     }
 
     public void unsetUsedBytes() {
-      __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __USEDBYTES_ISSET_ID);
+      this.usedBytes = null;
     }
 
     /** Returns true if field usedBytes is set (has been assigned a value) and false otherwise */
     public boolean isSetUsedBytes() {
-      return EncodingUtils.testBit(__isset_bitfield, __USEDBYTES_ISSET_ID);
+      return this.usedBytes != null;
     }
 
     public void setUsedBytesIsSet(boolean value) {
-      __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __USEDBYTES_ISSET_ID, value);
+      if (!value) {
+        this.usedBytes = null;
+      }
     }
 
     public int getRemovedBlockIdsSize() {
@@ -9549,7 +9980,7 @@ public class MasterService {
         if (value == null) {
           unsetUsedBytes();
         } else {
-          setUsedBytes((Long)value);
+          setUsedBytes((List<Long>)value);
         }
         break;
 
@@ -9578,7 +10009,7 @@ public class MasterService {
         return Long.valueOf(getWorkerId());
 
       case USED_BYTES:
-        return Long.valueOf(getUsedBytes());
+        return getUsedBytes();
 
       case REMOVED_BLOCK_IDS:
         return getRemovedBlockIds();
@@ -9631,12 +10062,12 @@ public class MasterService {
           return false;
       }
 
-      boolean this_present_usedBytes = true;
-      boolean that_present_usedBytes = true;
+      boolean this_present_usedBytes = true && this.isSetUsedBytes();
+      boolean that_present_usedBytes = true && that.isSetUsedBytes();
       if (this_present_usedBytes || that_present_usedBytes) {
         if (!(this_present_usedBytes && that_present_usedBytes))
           return false;
-        if (this.usedBytes != that.usedBytes)
+        if (!this.usedBytes.equals(that.usedBytes))
           return false;
       }
 
@@ -9739,7 +10170,11 @@ public class MasterService {
       first = false;
       if (!first) sb.append(", ");
       sb.append("usedBytes:");
-      sb.append(this.usedBytes);
+      if (this.usedBytes == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.usedBytes);
+      }
       first = false;
       if (!first) sb.append(", ");
       sb.append("removedBlockIds:");
@@ -9811,8 +10246,18 @@ public class MasterService {
               }
               break;
             case 2: // USED_BYTES
-              if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
-                struct.usedBytes = iprot.readI64();
+              if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
+                {
+                  org.apache.thrift.protocol.TList _list114 = iprot.readListBegin();
+                  struct.usedBytes = new ArrayList<Long>(_list114.size);
+                  for (int _i115 = 0; _i115 < _list114.size; ++_i115)
+                  {
+                    long _elem116;
+                    _elem116 = iprot.readI64();
+                    struct.usedBytes.add(_elem116);
+                  }
+                  iprot.readListEnd();
+                }
                 struct.setUsedBytesIsSet(true);
               } else { 
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
@@ -9821,13 +10266,13 @@ public class MasterService {
             case 3: // REMOVED_BLOCK_IDS
               if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
                 {
-                  org.apache.thrift.protocol.TList _list82 = iprot.readListBegin();
-                  struct.removedBlockIds = new ArrayList<Long>(_list82.size);
-                  for (int _i83 = 0; _i83 < _list82.size; ++_i83)
+                  org.apache.thrift.protocol.TList _list117 = iprot.readListBegin();
+                  struct.removedBlockIds = new ArrayList<Long>(_list117.size);
+                  for (int _i118 = 0; _i118 < _list117.size; ++_i118)
                   {
-                    long _elem84;
-                    _elem84 = iprot.readI64();
-                    struct.removedBlockIds.add(_elem84);
+                    long _elem119;
+                    _elem119 = iprot.readI64();
+                    struct.removedBlockIds.add(_elem119);
                   }
                   iprot.readListEnd();
                 }
@@ -9839,25 +10284,25 @@ public class MasterService {
             case 4: // ADDED_BLOCK_IDS
               if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
                 {
-                  org.apache.thrift.protocol.TMap _map85 = iprot.readMapBegin();
-                  struct.addedBlockIds = new HashMap<Long,List<Long>>(2*_map85.size);
-                  for (int _i86 = 0; _i86 < _map85.size; ++_i86)
+                  org.apache.thrift.protocol.TMap _map120 = iprot.readMapBegin();
+                  struct.addedBlockIds = new HashMap<Long,List<Long>>(2*_map120.size);
+                  for (int _i121 = 0; _i121 < _map120.size; ++_i121)
                   {
-                    long _key87;
-                    List<Long> _val88;
-                    _key87 = iprot.readI64();
+                    long _key122;
+                    List<Long> _val123;
+                    _key122 = iprot.readI64();
                     {
-                      org.apache.thrift.protocol.TList _list89 = iprot.readListBegin();
-                      _val88 = new ArrayList<Long>(_list89.size);
-                      for (int _i90 = 0; _i90 < _list89.size; ++_i90)
+                      org.apache.thrift.protocol.TList _list124 = iprot.readListBegin();
+                      _val123 = new ArrayList<Long>(_list124.size);
+                      for (int _i125 = 0; _i125 < _list124.size; ++_i125)
                       {
-                        long _elem91;
-                        _elem91 = iprot.readI64();
-                        _val88.add(_elem91);
+                        long _elem126;
+                        _elem126 = iprot.readI64();
+                        _val123.add(_elem126);
                       }
                       iprot.readListEnd();
                     }
-                    struct.addedBlockIds.put(_key87, _val88);
+                    struct.addedBlockIds.put(_key122, _val123);
                   }
                   iprot.readMapEnd();
                 }
@@ -9884,16 +10329,25 @@ public class MasterService {
         oprot.writeFieldBegin(WORKER_ID_FIELD_DESC);
         oprot.writeI64(struct.workerId);
         oprot.writeFieldEnd();
-        oprot.writeFieldBegin(USED_BYTES_FIELD_DESC);
-        oprot.writeI64(struct.usedBytes);
-        oprot.writeFieldEnd();
+        if (struct.usedBytes != null) {
+          oprot.writeFieldBegin(USED_BYTES_FIELD_DESC);
+          {
+            oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.usedBytes.size()));
+            for (long _iter127 : struct.usedBytes)
+            {
+              oprot.writeI64(_iter127);
+            }
+            oprot.writeListEnd();
+          }
+          oprot.writeFieldEnd();
+        }
         if (struct.removedBlockIds != null) {
           oprot.writeFieldBegin(REMOVED_BLOCK_IDS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.removedBlockIds.size()));
-            for (long _iter92 : struct.removedBlockIds)
+            for (long _iter128 : struct.removedBlockIds)
             {
-              oprot.writeI64(_iter92);
+              oprot.writeI64(_iter128);
             }
             oprot.writeListEnd();
           }
@@ -9903,14 +10357,14 @@ public class MasterService {
           oprot.writeFieldBegin(ADDED_BLOCK_IDS_FIELD_DESC);
           {
             oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.LIST, struct.addedBlockIds.size()));
-            for (Map.Entry<Long, List<Long>> _iter93 : struct.addedBlockIds.entrySet())
+            for (Map.Entry<Long, List<Long>> _iter129 : struct.addedBlockIds.entrySet())
             {
-              oprot.writeI64(_iter93.getKey());
+              oprot.writeI64(_iter129.getKey());
               {
-                oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, _iter93.getValue().size()));
-                for (long _iter94 : _iter93.getValue())
+                oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, _iter129.getValue().size()));
+                for (long _iter130 : _iter129.getValue())
                 {
-                  oprot.writeI64(_iter94);
+                  oprot.writeI64(_iter130);
                 }
                 oprot.writeListEnd();
               }
@@ -9954,28 +10408,34 @@ public class MasterService {
           oprot.writeI64(struct.workerId);
         }
         if (struct.isSetUsedBytes()) {
-          oprot.writeI64(struct.usedBytes);
+          {
+            oprot.writeI32(struct.usedBytes.size());
+            for (long _iter131 : struct.usedBytes)
+            {
+              oprot.writeI64(_iter131);
+            }
+          }
         }
         if (struct.isSetRemovedBlockIds()) {
           {
             oprot.writeI32(struct.removedBlockIds.size());
-            for (long _iter95 : struct.removedBlockIds)
+            for (long _iter132 : struct.removedBlockIds)
             {
-              oprot.writeI64(_iter95);
+              oprot.writeI64(_iter132);
             }
           }
         }
         if (struct.isSetAddedBlockIds()) {
           {
             oprot.writeI32(struct.addedBlockIds.size());
-            for (Map.Entry<Long, List<Long>> _iter96 : struct.addedBlockIds.entrySet())
+            for (Map.Entry<Long, List<Long>> _iter133 : struct.addedBlockIds.entrySet())
             {
-              oprot.writeI64(_iter96.getKey());
+              oprot.writeI64(_iter133.getKey());
               {
-                oprot.writeI32(_iter96.getValue().size());
-                for (long _iter97 : _iter96.getValue())
+                oprot.writeI32(_iter133.getValue().size());
+                for (long _iter134 : _iter133.getValue())
                 {
-                  oprot.writeI64(_iter97);
+                  oprot.writeI64(_iter134);
                 }
               }
             }
@@ -9992,42 +10452,51 @@ public class MasterService {
           struct.setWorkerIdIsSet(true);
         }
         if (incoming.get(1)) {
-          struct.usedBytes = iprot.readI64();
+          {
+            org.apache.thrift.protocol.TList _list135 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+            struct.usedBytes = new ArrayList<Long>(_list135.size);
+            for (int _i136 = 0; _i136 < _list135.size; ++_i136)
+            {
+              long _elem137;
+              _elem137 = iprot.readI64();
+              struct.usedBytes.add(_elem137);
+            }
+          }
           struct.setUsedBytesIsSet(true);
         }
         if (incoming.get(2)) {
           {
-            org.apache.thrift.protocol.TList _list98 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-            struct.removedBlockIds = new ArrayList<Long>(_list98.size);
-            for (int _i99 = 0; _i99 < _list98.size; ++_i99)
+            org.apache.thrift.protocol.TList _list138 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+            struct.removedBlockIds = new ArrayList<Long>(_list138.size);
+            for (int _i139 = 0; _i139 < _list138.size; ++_i139)
             {
-              long _elem100;
-              _elem100 = iprot.readI64();
-              struct.removedBlockIds.add(_elem100);
+              long _elem140;
+              _elem140 = iprot.readI64();
+              struct.removedBlockIds.add(_elem140);
             }
           }
           struct.setRemovedBlockIdsIsSet(true);
         }
         if (incoming.get(3)) {
           {
-            org.apache.thrift.protocol.TMap _map101 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.LIST, iprot.readI32());
-            struct.addedBlockIds = new HashMap<Long,List<Long>>(2*_map101.size);
-            for (int _i102 = 0; _i102 < _map101.size; ++_i102)
+            org.apache.thrift.protocol.TMap _map141 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.LIST, iprot.readI32());
+            struct.addedBlockIds = new HashMap<Long,List<Long>>(2*_map141.size);
+            for (int _i142 = 0; _i142 < _map141.size; ++_i142)
             {
-              long _key103;
-              List<Long> _val104;
-              _key103 = iprot.readI64();
+              long _key143;
+              List<Long> _val144;
+              _key143 = iprot.readI64();
               {
-                org.apache.thrift.protocol.TList _list105 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-                _val104 = new ArrayList<Long>(_list105.size);
-                for (int _i106 = 0; _i106 < _list105.size; ++_i106)
+                org.apache.thrift.protocol.TList _list145 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+                _val144 = new ArrayList<Long>(_list145.size);
+                for (int _i146 = 0; _i146 < _list145.size; ++_i146)
                 {
-                  long _elem107;
-                  _elem107 = iprot.readI64();
-                  _val104.add(_elem107);
+                  long _elem147;
+                  _elem147 = iprot.readI64();
+                  _val144.add(_elem147);
                 }
               }
-              struct.addedBlockIds.put(_key103, _val104);
+              struct.addedBlockIds.put(_key143, _val144);
             }
           }
           struct.setAddedBlockIdsIsSet(true);
@@ -10502,7 +10971,7 @@ public class MasterService {
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("worker_cacheBlock_args");
 
     private static final org.apache.thrift.protocol.TField WORKER_ID_FIELD_DESC = new org.apache.thrift.protocol.TField("workerId", org.apache.thrift.protocol.TType.I64, (short)1);
-    private static final org.apache.thrift.protocol.TField WORKER_USED_BYTES_FIELD_DESC = new org.apache.thrift.protocol.TField("workerUsedBytes", org.apache.thrift.protocol.TType.I64, (short)2);
+    private static final org.apache.thrift.protocol.TField STORAGE_TIER_USED_BYTES_FIELD_DESC = new org.apache.thrift.protocol.TField("storageTierUsedBytes", org.apache.thrift.protocol.TType.I64, (short)2);
     private static final org.apache.thrift.protocol.TField STORAGE_DIR_ID_FIELD_DESC = new org.apache.thrift.protocol.TField("storageDirId", org.apache.thrift.protocol.TType.I64, (short)3);
     private static final org.apache.thrift.protocol.TField BLOCK_ID_FIELD_DESC = new org.apache.thrift.protocol.TField("blockId", org.apache.thrift.protocol.TType.I64, (short)4);
     private static final org.apache.thrift.protocol.TField LENGTH_FIELD_DESC = new org.apache.thrift.protocol.TField("length", org.apache.thrift.protocol.TType.I64, (short)5);
@@ -10514,7 +10983,7 @@ public class MasterService {
     }
 
     public long workerId; // required
-    public long workerUsedBytes; // required
+    public long storageTierUsedBytes; // required
     public long storageDirId; // required
     public long blockId; // required
     public long length; // required
@@ -10522,7 +10991,7 @@ public class MasterService {
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift.TFieldIdEnum {
       WORKER_ID((short)1, "workerId"),
-      WORKER_USED_BYTES((short)2, "workerUsedBytes"),
+      STORAGE_TIER_USED_BYTES((short)2, "storageTierUsedBytes"),
       STORAGE_DIR_ID((short)3, "storageDirId"),
       BLOCK_ID((short)4, "blockId"),
       LENGTH((short)5, "length");
@@ -10542,8 +11011,8 @@ public class MasterService {
         switch(fieldId) {
           case 1: // WORKER_ID
             return WORKER_ID;
-          case 2: // WORKER_USED_BYTES
-            return WORKER_USED_BYTES;
+          case 2: // STORAGE_TIER_USED_BYTES
+            return STORAGE_TIER_USED_BYTES;
           case 3: // STORAGE_DIR_ID
             return STORAGE_DIR_ID;
           case 4: // BLOCK_ID
@@ -10591,7 +11060,7 @@ public class MasterService {
 
     // isset id assignments
     private static final int __WORKERID_ISSET_ID = 0;
-    private static final int __WORKERUSEDBYTES_ISSET_ID = 1;
+    private static final int __STORAGETIERUSEDBYTES_ISSET_ID = 1;
     private static final int __STORAGEDIRID_ISSET_ID = 2;
     private static final int __BLOCKID_ISSET_ID = 3;
     private static final int __LENGTH_ISSET_ID = 4;
@@ -10601,7 +11070,7 @@ public class MasterService {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
       tmpMap.put(_Fields.WORKER_ID, new org.apache.thrift.meta_data.FieldMetaData("workerId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
-      tmpMap.put(_Fields.WORKER_USED_BYTES, new org.apache.thrift.meta_data.FieldMetaData("workerUsedBytes", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.STORAGE_TIER_USED_BYTES, new org.apache.thrift.meta_data.FieldMetaData("storageTierUsedBytes", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       tmpMap.put(_Fields.STORAGE_DIR_ID, new org.apache.thrift.meta_data.FieldMetaData("storageDirId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
@@ -10618,7 +11087,7 @@ public class MasterService {
 
     public worker_cacheBlock_args(
       long workerId,
-      long workerUsedBytes,
+      long storageTierUsedBytes,
       long storageDirId,
       long blockId,
       long length)
@@ -10626,8 +11095,8 @@ public class MasterService {
       this();
       this.workerId = workerId;
       setWorkerIdIsSet(true);
-      this.workerUsedBytes = workerUsedBytes;
-      setWorkerUsedBytesIsSet(true);
+      this.storageTierUsedBytes = storageTierUsedBytes;
+      setStorageTierUsedBytesIsSet(true);
       this.storageDirId = storageDirId;
       setStorageDirIdIsSet(true);
       this.blockId = blockId;
@@ -10642,7 +11111,7 @@ public class MasterService {
     public worker_cacheBlock_args(worker_cacheBlock_args other) {
       __isset_bitfield = other.__isset_bitfield;
       this.workerId = other.workerId;
-      this.workerUsedBytes = other.workerUsedBytes;
+      this.storageTierUsedBytes = other.storageTierUsedBytes;
       this.storageDirId = other.storageDirId;
       this.blockId = other.blockId;
       this.length = other.length;
@@ -10656,8 +11125,8 @@ public class MasterService {
     public void clear() {
       setWorkerIdIsSet(false);
       this.workerId = 0;
-      setWorkerUsedBytesIsSet(false);
-      this.workerUsedBytes = 0;
+      setStorageTierUsedBytesIsSet(false);
+      this.storageTierUsedBytes = 0;
       setStorageDirIdIsSet(false);
       this.storageDirId = 0;
       setBlockIdIsSet(false);
@@ -10689,27 +11158,27 @@ public class MasterService {
       __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __WORKERID_ISSET_ID, value);
     }
 
-    public long getWorkerUsedBytes() {
-      return this.workerUsedBytes;
+    public long getStorageTierUsedBytes() {
+      return this.storageTierUsedBytes;
     }
 
-    public worker_cacheBlock_args setWorkerUsedBytes(long workerUsedBytes) {
-      this.workerUsedBytes = workerUsedBytes;
-      setWorkerUsedBytesIsSet(true);
+    public worker_cacheBlock_args setStorageTierUsedBytes(long storageTierUsedBytes) {
+      this.storageTierUsedBytes = storageTierUsedBytes;
+      setStorageTierUsedBytesIsSet(true);
       return this;
     }
 
-    public void unsetWorkerUsedBytes() {
-      __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __WORKERUSEDBYTES_ISSET_ID);
+    public void unsetStorageTierUsedBytes() {
+      __isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __STORAGETIERUSEDBYTES_ISSET_ID);
     }
 
-    /** Returns true if field workerUsedBytes is set (has been assigned a value) and false otherwise */
-    public boolean isSetWorkerUsedBytes() {
-      return EncodingUtils.testBit(__isset_bitfield, __WORKERUSEDBYTES_ISSET_ID);
+    /** Returns true if field storageTierUsedBytes is set (has been assigned a value) and false otherwise */
+    public boolean isSetStorageTierUsedBytes() {
+      return EncodingUtils.testBit(__isset_bitfield, __STORAGETIERUSEDBYTES_ISSET_ID);
     }
 
-    public void setWorkerUsedBytesIsSet(boolean value) {
-      __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __WORKERUSEDBYTES_ISSET_ID, value);
+    public void setStorageTierUsedBytesIsSet(boolean value) {
+      __isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __STORAGETIERUSEDBYTES_ISSET_ID, value);
     }
 
     public long getStorageDirId() {
@@ -10791,11 +11260,11 @@ public class MasterService {
         }
         break;
 
-      case WORKER_USED_BYTES:
+      case STORAGE_TIER_USED_BYTES:
         if (value == null) {
-          unsetWorkerUsedBytes();
+          unsetStorageTierUsedBytes();
         } else {
-          setWorkerUsedBytes((Long)value);
+          setStorageTierUsedBytes((Long)value);
         }
         break;
 
@@ -10831,8 +11300,8 @@ public class MasterService {
       case WORKER_ID:
         return Long.valueOf(getWorkerId());
 
-      case WORKER_USED_BYTES:
-        return Long.valueOf(getWorkerUsedBytes());
+      case STORAGE_TIER_USED_BYTES:
+        return Long.valueOf(getStorageTierUsedBytes());
 
       case STORAGE_DIR_ID:
         return Long.valueOf(getStorageDirId());
@@ -10856,8 +11325,8 @@ public class MasterService {
       switch (field) {
       case WORKER_ID:
         return isSetWorkerId();
-      case WORKER_USED_BYTES:
-        return isSetWorkerUsedBytes();
+      case STORAGE_TIER_USED_BYTES:
+        return isSetStorageTierUsedBytes();
       case STORAGE_DIR_ID:
         return isSetStorageDirId();
       case BLOCK_ID:
@@ -10890,12 +11359,12 @@ public class MasterService {
           return false;
       }
 
-      boolean this_present_workerUsedBytes = true;
-      boolean that_present_workerUsedBytes = true;
-      if (this_present_workerUsedBytes || that_present_workerUsedBytes) {
-        if (!(this_present_workerUsedBytes && that_present_workerUsedBytes))
+      boolean this_present_storageTierUsedBytes = true;
+      boolean that_present_storageTierUsedBytes = true;
+      if (this_present_storageTierUsedBytes || that_present_storageTierUsedBytes) {
+        if (!(this_present_storageTierUsedBytes && that_present_storageTierUsedBytes))
           return false;
-        if (this.workerUsedBytes != that.workerUsedBytes)
+        if (this.storageTierUsedBytes != that.storageTierUsedBytes)
           return false;
       }
 
@@ -10952,12 +11421,12 @@ public class MasterService {
           return lastComparison;
         }
       }
-      lastComparison = Boolean.valueOf(isSetWorkerUsedBytes()).compareTo(other.isSetWorkerUsedBytes());
+      lastComparison = Boolean.valueOf(isSetStorageTierUsedBytes()).compareTo(other.isSetStorageTierUsedBytes());
       if (lastComparison != 0) {
         return lastComparison;
       }
-      if (isSetWorkerUsedBytes()) {
-        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.workerUsedBytes, other.workerUsedBytes);
+      if (isSetStorageTierUsedBytes()) {
+        lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.storageTierUsedBytes, other.storageTierUsedBytes);
         if (lastComparison != 0) {
           return lastComparison;
         }
@@ -11016,8 +11485,8 @@ public class MasterService {
       sb.append(this.workerId);
       first = false;
       if (!first) sb.append(", ");
-      sb.append("workerUsedBytes:");
-      sb.append(this.workerUsedBytes);
+      sb.append("storageTierUsedBytes:");
+      sb.append(this.storageTierUsedBytes);
       first = false;
       if (!first) sb.append(", ");
       sb.append("storageDirId:");
@@ -11084,10 +11553,10 @@ public class MasterService {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
-            case 2: // WORKER_USED_BYTES
+            case 2: // STORAGE_TIER_USED_BYTES
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
-                struct.workerUsedBytes = iprot.readI64();
-                struct.setWorkerUsedBytesIsSet(true);
+                struct.storageTierUsedBytes = iprot.readI64();
+                struct.setStorageTierUsedBytesIsSet(true);
               } else { 
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
@@ -11134,8 +11603,8 @@ public class MasterService {
         oprot.writeFieldBegin(WORKER_ID_FIELD_DESC);
         oprot.writeI64(struct.workerId);
         oprot.writeFieldEnd();
-        oprot.writeFieldBegin(WORKER_USED_BYTES_FIELD_DESC);
-        oprot.writeI64(struct.workerUsedBytes);
+        oprot.writeFieldBegin(STORAGE_TIER_USED_BYTES_FIELD_DESC);
+        oprot.writeI64(struct.storageTierUsedBytes);
         oprot.writeFieldEnd();
         oprot.writeFieldBegin(STORAGE_DIR_ID_FIELD_DESC);
         oprot.writeI64(struct.storageDirId);
@@ -11167,7 +11636,7 @@ public class MasterService {
         if (struct.isSetWorkerId()) {
           optionals.set(0);
         }
-        if (struct.isSetWorkerUsedBytes()) {
+        if (struct.isSetStorageTierUsedBytes()) {
           optionals.set(1);
         }
         if (struct.isSetStorageDirId()) {
@@ -11183,8 +11652,8 @@ public class MasterService {
         if (struct.isSetWorkerId()) {
           oprot.writeI64(struct.workerId);
         }
-        if (struct.isSetWorkerUsedBytes()) {
-          oprot.writeI64(struct.workerUsedBytes);
+        if (struct.isSetStorageTierUsedBytes()) {
+          oprot.writeI64(struct.storageTierUsedBytes);
         }
         if (struct.isSetStorageDirId()) {
           oprot.writeI64(struct.storageDirId);
@@ -11206,8 +11675,8 @@ public class MasterService {
           struct.setWorkerIdIsSet(true);
         }
         if (incoming.get(1)) {
-          struct.workerUsedBytes = iprot.readI64();
-          struct.setWorkerUsedBytesIsSet(true);
+          struct.storageTierUsedBytes = iprot.readI64();
+          struct.setStorageTierUsedBytesIsSet(true);
         }
         if (incoming.get(2)) {
           struct.storageDirId = iprot.readI64();
@@ -12338,13 +12807,13 @@ public class MasterService {
             case 0: // SUCCESS
               if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
                 {
-                  org.apache.thrift.protocol.TSet _set108 = iprot.readSetBegin();
-                  struct.success = new HashSet<Integer>(2*_set108.size);
-                  for (int _i109 = 0; _i109 < _set108.size; ++_i109)
+                  org.apache.thrift.protocol.TSet _set148 = iprot.readSetBegin();
+                  struct.success = new HashSet<Integer>(2*_set148.size);
+                  for (int _i149 = 0; _i149 < _set148.size; ++_i149)
                   {
-                    int _elem110;
-                    _elem110 = iprot.readI32();
-                    struct.success.add(_elem110);
+                    int _elem150;
+                    _elem150 = iprot.readI32();
+                    struct.success.add(_elem150);
                   }
                   iprot.readSetEnd();
                 }
@@ -12372,9 +12841,9 @@ public class MasterService {
           oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
           {
             oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I32, struct.success.size()));
-            for (int _iter111 : struct.success)
+            for (int _iter151 : struct.success)
             {
-              oprot.writeI32(_iter111);
+              oprot.writeI32(_iter151);
             }
             oprot.writeSetEnd();
           }
@@ -12405,9 +12874,9 @@ public class MasterService {
         if (struct.isSetSuccess()) {
           {
             oprot.writeI32(struct.success.size());
-            for (int _iter112 : struct.success)
+            for (int _iter152 : struct.success)
             {
-              oprot.writeI32(_iter112);
+              oprot.writeI32(_iter152);
             }
           }
         }
@@ -12419,13 +12888,13 @@ public class MasterService {
         BitSet incoming = iprot.readBitSet(1);
         if (incoming.get(0)) {
           {
-            org.apache.thrift.protocol.TSet _set113 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I32, iprot.readI32());
-            struct.success = new HashSet<Integer>(2*_set113.size);
-            for (int _i114 = 0; _i114 < _set113.size; ++_i114)
+            org.apache.thrift.protocol.TSet _set153 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I32, iprot.readI32());
+            struct.success = new HashSet<Integer>(2*_set153.size);
+            for (int _i154 = 0; _i154 < _set153.size; ++_i154)
             {
-              int _elem115;
-              _elem115 = iprot.readI32();
-              struct.success.add(_elem115);
+              int _elem155;
+              _elem155 = iprot.readI32();
+              struct.success.add(_elem155);
             }
           }
           struct.setSuccessIsSet(true);
@@ -12987,13 +13456,13 @@ public class MasterService {
             case 0: // SUCCESS
               if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
                 {
-                  org.apache.thrift.protocol.TList _list116 = iprot.readListBegin();
-                  struct.success = new ArrayList<Integer>(_list116.size);
-                  for (int _i117 = 0; _i117 < _list116.size; ++_i117)
+                  org.apache.thrift.protocol.TList _list156 = iprot.readListBegin();
+                  struct.success = new ArrayList<Integer>(_list156.size);
+                  for (int _i157 = 0; _i157 < _list156.size; ++_i157)
                   {
-                    int _elem118;
-                    _elem118 = iprot.readI32();
-                    struct.success.add(_elem118);
+                    int _elem158;
+                    _elem158 = iprot.readI32();
+                    struct.success.add(_elem158);
                   }
                   iprot.readListEnd();
                 }
@@ -13021,9 +13490,9 @@ public class MasterService {
           oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, struct.success.size()));
-            for (int _iter119 : struct.success)
+            for (int _iter159 : struct.success)
             {
-              oprot.writeI32(_iter119);
+              oprot.writeI32(_iter159);
             }
             oprot.writeListEnd();
           }
@@ -13054,9 +13523,9 @@ public class MasterService {
         if (struct.isSetSuccess()) {
           {
             oprot.writeI32(struct.success.size());
-            for (int _iter120 : struct.success)
+            for (int _iter160 : struct.success)
             {
-              oprot.writeI32(_iter120);
+              oprot.writeI32(_iter160);
             }
           }
         }
@@ -13068,13 +13537,13 @@ public class MasterService {
         BitSet incoming = iprot.readBitSet(1);
         if (incoming.get(0)) {
           {
-            org.apache.thrift.protocol.TList _list121 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
-            struct.success = new ArrayList<Integer>(_list121.size);
-            for (int _i122 = 0; _i122 < _list121.size; ++_i122)
+            org.apache.thrift.protocol.TList _list161 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
+            struct.success = new ArrayList<Integer>(_list161.size);
+            for (int _i162 = 0; _i162 < _list161.size; ++_i162)
             {
-              int _elem123;
-              _elem123 = iprot.readI32();
-              struct.success.add(_elem123);
+              int _elem163;
+              _elem163 = iprot.readI32();
+              struct.success.add(_elem163);
             }
           }
           struct.setSuccessIsSet(true);
@@ -14036,13 +14505,13 @@ public class MasterService {
             case 1: // PARENTS
               if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
                 {
-                  org.apache.thrift.protocol.TList _list124 = iprot.readListBegin();
-                  struct.parents = new ArrayList<String>(_list124.size);
-                  for (int _i125 = 0; _i125 < _list124.size; ++_i125)
+                  org.apache.thrift.protocol.TList _list164 = iprot.readListBegin();
+                  struct.parents = new ArrayList<String>(_list164.size);
+                  for (int _i165 = 0; _i165 < _list164.size; ++_i165)
                   {
-                    String _elem126;
-                    _elem126 = iprot.readString();
-                    struct.parents.add(_elem126);
+                    String _elem166;
+                    _elem166 = iprot.readString();
+                    struct.parents.add(_elem166);
                   }
                   iprot.readListEnd();
                 }
@@ -14054,13 +14523,13 @@ public class MasterService {
             case 2: // CHILDREN
               if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
                 {
-                  org.apache.thrift.protocol.TList _list127 = iprot.readListBegin();
-                  struct.children = new ArrayList<String>(_list127.size);
-                  for (int _i128 = 0; _i128 < _list127.size; ++_i128)
+                  org.apache.thrift.protocol.TList _list167 = iprot.readListBegin();
+                  struct.children = new ArrayList<String>(_list167.size);
+                  for (int _i168 = 0; _i168 < _list167.size; ++_i168)
                   {
-                    String _elem129;
-                    _elem129 = iprot.readString();
-                    struct.children.add(_elem129);
+                    String _elem169;
+                    _elem169 = iprot.readString();
+                    struct.children.add(_elem169);
                   }
                   iprot.readListEnd();
                 }
@@ -14080,13 +14549,13 @@ public class MasterService {
             case 4: // DATA
               if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
                 {
-                  org.apache.thrift.protocol.TList _list130 = iprot.readListBegin();
-                  struct.data = new ArrayList<ByteBuffer>(_list130.size);
-                  for (int _i131 = 0; _i131 < _list130.size; ++_i131)
+                  org.apache.thrift.protocol.TList _list170 = iprot.readListBegin();
+                  struct.data = new ArrayList<ByteBuffer>(_list170.size);
+                  for (int _i171 = 0; _i171 < _list170.size; ++_i171)
                   {
-                    ByteBuffer _elem132;
-                    _elem132 = iprot.readBinary();
-                    struct.data.add(_elem132);
+                    ByteBuffer _elem172;
+                    _elem172 = iprot.readBinary();
+                    struct.data.add(_elem172);
                   }
                   iprot.readListEnd();
                 }
@@ -14154,9 +14623,9 @@ public class MasterService {
           oprot.writeFieldBegin(PARENTS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.parents.size()));
-            for (String _iter133 : struct.parents)
+            for (String _iter173 : struct.parents)
             {
-              oprot.writeString(_iter133);
+              oprot.writeString(_iter173);
             }
             oprot.writeListEnd();
           }
@@ -14166,9 +14635,9 @@ public class MasterService {
           oprot.writeFieldBegin(CHILDREN_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.children.size()));
-            for (String _iter134 : struct.children)
+            for (String _iter174 : struct.children)
             {
-              oprot.writeString(_iter134);
+              oprot.writeString(_iter174);
             }
             oprot.writeListEnd();
           }
@@ -14183,9 +14652,9 @@ public class MasterService {
           oprot.writeFieldBegin(DATA_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, struct.data.size()));
-            for (ByteBuffer _iter135 : struct.data)
+            for (ByteBuffer _iter175 : struct.data)
             {
-              oprot.writeBinary(_iter135);
+              oprot.writeBinary(_iter175);
             }
             oprot.writeListEnd();
           }
@@ -14261,18 +14730,18 @@ public class MasterService {
         if (struct.isSetParents()) {
           {
             oprot.writeI32(struct.parents.size());
-            for (String _iter136 : struct.parents)
+            for (String _iter176 : struct.parents)
             {
-              oprot.writeString(_iter136);
+              oprot.writeString(_iter176);
             }
           }
         }
         if (struct.isSetChildren()) {
           {
             oprot.writeI32(struct.children.size());
-            for (String _iter137 : struct.children)
+            for (String _iter177 : struct.children)
             {
-              oprot.writeString(_iter137);
+              oprot.writeString(_iter177);
             }
           }
         }
@@ -14282,9 +14751,9 @@ public class MasterService {
         if (struct.isSetData()) {
           {
             oprot.writeI32(struct.data.size());
-            for (ByteBuffer _iter138 : struct.data)
+            for (ByteBuffer _iter178 : struct.data)
             {
-              oprot.writeBinary(_iter138);
+              oprot.writeBinary(_iter178);
             }
           }
         }
@@ -14311,26 +14780,26 @@ public class MasterService {
         BitSet incoming = iprot.readBitSet(9);
         if (incoming.get(0)) {
           {
-            org.apache.thrift.protocol.TList _list139 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-            struct.parents = new ArrayList<String>(_list139.size);
-            for (int _i140 = 0; _i140 < _list139.size; ++_i140)
+            org.apache.thrift.protocol.TList _list179 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+            struct.parents = new ArrayList<String>(_list179.size);
+            for (int _i180 = 0; _i180 < _list179.size; ++_i180)
             {
-              String _elem141;
-              _elem141 = iprot.readString();
-              struct.parents.add(_elem141);
+              String _elem181;
+              _elem181 = iprot.readString();
+              struct.parents.add(_elem181);
             }
           }
           struct.setParentsIsSet(true);
         }
         if (incoming.get(1)) {
           {
-            org.apache.thrift.protocol.TList _list142 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-            struct.children = new ArrayList<String>(_list142.size);
-            for (int _i143 = 0; _i143 < _list142.size; ++_i143)
+            org.apache.thrift.protocol.TList _list182 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+            struct.children = new ArrayList<String>(_list182.size);
+            for (int _i183 = 0; _i183 < _list182.size; ++_i183)
             {
-              String _elem144;
-              _elem144 = iprot.readString();
-              struct.children.add(_elem144);
+              String _elem184;
+              _elem184 = iprot.readString();
+              struct.children.add(_elem184);
             }
           }
           struct.setChildrenIsSet(true);
@@ -14341,13 +14810,13 @@ public class MasterService {
         }
         if (incoming.get(3)) {
           {
-            org.apache.thrift.protocol.TList _list145 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-            struct.data = new ArrayList<ByteBuffer>(_list145.size);
-            for (int _i146 = 0; _i146 < _list145.size; ++_i146)
+            org.apache.thrift.protocol.TList _list185 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+            struct.data = new ArrayList<ByteBuffer>(_list185.size);
+            for (int _i186 = 0; _i186 < _list185.size; ++_i186)
             {
-              ByteBuffer _elem147;
-              _elem147 = iprot.readBinary();
-              struct.data.add(_elem147);
+              ByteBuffer _elem187;
+              _elem187 = iprot.readBinary();
+              struct.data.add(_elem187);
             }
           }
           struct.setDataIsSet(true);
@@ -25654,14 +26123,14 @@ public class MasterService {
             case 0: // SUCCESS
               if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
                 {
-                  org.apache.thrift.protocol.TList _list148 = iprot.readListBegin();
-                  struct.success = new ArrayList<ClientBlockInfo>(_list148.size);
-                  for (int _i149 = 0; _i149 < _list148.size; ++_i149)
+                  org.apache.thrift.protocol.TList _list188 = iprot.readListBegin();
+                  struct.success = new ArrayList<ClientBlockInfo>(_list188.size);
+                  for (int _i189 = 0; _i189 < _list188.size; ++_i189)
                   {
-                    ClientBlockInfo _elem150;
-                    _elem150 = new ClientBlockInfo();
-                    _elem150.read(iprot);
-                    struct.success.add(_elem150);
+                    ClientBlockInfo _elem190;
+                    _elem190 = new ClientBlockInfo();
+                    _elem190.read(iprot);
+                    struct.success.add(_elem190);
                   }
                   iprot.readListEnd();
                 }
@@ -25707,9 +26176,9 @@ public class MasterService {
           oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
           {
             oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.success.size()));
-            for (ClientBlockInfo _iter151 : struct.success)
+            for (ClientBlockInfo _iter191 : struct.success)
             {
-              _iter151.write(oprot);
+              _iter191.write(oprot);
             }
             oprot.writeListEnd();
           }
@@ -25756,9 +26225,9 @@ public class MasterService {
         if (struct.isSetSuccess()) {
           {
             oprot.writeI32(struct.success.size());
-            for (ClientBlockInfo _iter152 : struct.success)
+            for (ClientBlockInfo _iter192 : struct.success)
             {
-              _iter152.write(oprot);
+              _iter192.write(oprot);
             }
           }
         }
@@ -25776,14 +26245,14 @@ public class MasterService {
         BitSet incoming = iprot.readBitSet(3);
         if (incoming.get(0)) {
           {
-            org.apache.thrift.protocol.TList _list153 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-            struct.success = new ArrayList<ClientBlockInfo>(_list153.size);
-            for (int _i154 = 0; _i154 < _list153.size; ++_i154)
+            org.apache.thrift.protocol.TList _list193 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+            struct.success = new ArrayList<ClientBlockInfo>(_list193.size);
+            for (int _i194 = 0; _i194 < _list193.size; ++_i194)
             {
-              ClientBlockInfo _elem155;
-              _elem155 = new ClientBlockInfo();
-              _elem155.read(iprot);
-              struct.success.add(_elem155);
+              ClientBlockInfo _elem195;
+              _elem195 = new ClientBlockInfo();
+              _elem195.read(iprot);
+              struct.success.add(_elem195);
             }
           }
           struct.setSuccessIsSet(true);

--- a/core/src/main/webapp/general.jsp
+++ b/core/src/main/webapp/general.jsp
@@ -1,4 +1,5 @@
 <%@ page import="java.util.*" %>
+<%@ page import="tachyon.web.*" %>
 
 <html>
 <head>
@@ -67,12 +68,12 @@
             <table class="table">
               <tbody>
                 <tr>
-                  <th>Memory Capacity:</th>
+                  <th>Workers Capacity:</th>
                   <!-- <th>${capacity}</th> -->
                   <th><%= request.getAttribute("capacity") %></th>
                 </tr>
                 <tr>
-                  <th>Memory Free / Used:</th>
+                  <th>Workers Free / Used:</th>
                   <!-- <th>${usedCapacity}</th> -->
                   <th><%= request.getAttribute("freeCapacity") %> / <%= request.getAttribute("usedCapacity") %></th>
                 </tr>
@@ -86,6 +87,54 @@
                   <!-- <th>${freeCapacity}</th> -->
                   <th><%= request.getAttribute("diskFreeCapacity") %> / <%= request.getAttribute("diskUsedCapacity") %></th>
                 </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row-fluid">
+    <div class="accordion span14" id="accordion3">
+      <div class="accordion-group">
+        <div class="accordion-heading">
+          <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion3" href="#data3">
+            <h4>Hierarchy Usage Summary</h4>
+          </a>
+        </div>
+        <div id="data3" class="accordion-body collapse in">
+          <div class="accordion-inner">
+            <table class="table table-hover table-condensed">
+              <thead>
+                <th>Hierarchy Store Level</th>
+                <th>Hierarchy Store Alias</th>
+                <th>Space Capacity</th>
+                <th>Space Used</th>
+                <th>Space Usage</th>
+              </thead>
+              <tbody>
+                <% for (WebInterfaceGeneralServlet.StorageLevelInfo levelInfo : ((WebInterfaceGeneralServlet.StorageLevelInfo[]) request.getAttribute("storageLevelInfos"))) { %>
+                  <tr>
+                    <th><%= levelInfo.getStorageLevel() %></th>
+                    <th><%= levelInfo.getStorageLevelAlias() %></th>
+                    <th><%= levelInfo.getCapacity() %></th>
+                    <th><%= levelInfo.getUsedCapacity() %></th>
+                    <th>
+                      <div class="progress custom-progress">
+                          <div class="bar bar-success" style="width: <%= levelInfo.getFreeSpacePercent() %>%;">
+                            <% if (levelInfo.getFreeSpacePercent() >= levelInfo.getUsedSpacePercent()) { %>
+                              <%= levelInfo.getFreeSpacePercent() %>%Free
+                            <% } %>
+                          </div>
+                          <div class="bar bar-danger" style="width: <%= levelInfo.getUsedSpacePercent() %>%;">
+                            <% if (levelInfo.getFreeSpacePercent() < levelInfo.getUsedSpacePercent()) { %>
+                              <%= levelInfo.getUsedSpacePercent() %>%Used
+                            <% } %>
+                          </div>
+                      </div>
+                    </th>
+                  </tr>
+                <% } %>
               </tbody>
             </table>
           </div>

--- a/core/src/main/webapp/workers.jsp
+++ b/core/src/main/webapp/workers.jsp
@@ -30,9 +30,9 @@
                 <% } %>
                 <th>Last Heartbeat</th>
                 <th>State</th>
-                <th>Memory Capacity</th>
-                <th>Used Memory</th>
-                <th>Memory Usage</th>
+                <th>Workers Capacity</th>
+                <th>Space Used</th>
+                <th>Space Usage</th>
               </thead>  
               <tbody>
                 <% for (WebInterfaceWorkersServlet.NodeInfo nodeInfo : ((WebInterfaceWorkersServlet.NodeInfo[]) request.getAttribute("normalNodeInfos"))) { %>
@@ -85,7 +85,7 @@
                   <th>[D]Uptime</th>
                 <% } %>
                 <th>Last Heartbeat</th>
-                <th>Memory Capacity</th>
+                <th>Workers Capacity</th>
               </thead>  
               <tbody>
                 <% if (request.getAttribute("failedNodeInfos") != null) {

--- a/core/src/thrift/tachyon.thrift
+++ b/core/src/thrift/tachyon.thrift
@@ -138,8 +138,9 @@ service MasterService {
    * is master started time. currentBlocks maps from id of storage directory to the blocks it
    * contains.
    */
-  i64 worker_register(1: NetAddress workerNetAddress, 2: i64 totalBytes, 3: i64 usedBytes,
-      4: map<i64, list<i64>> currentBlocks)
+  i64 worker_register(1: NetAddress workerNetAddress, 2: list<i32> storageLevels,
+      3: list<i32> storageLevelAliasValues, 4: list<i64> totalBytes, 5: list<i64> usedBytes,
+      6: map<i64, list<i64>> currentBlocks)
     throws (1: BlockInfoException e)
 
   /**
@@ -148,7 +149,7 @@ service MasterService {
    * return the command from master to worker. addedBlockIds maps from id of storage directory
    * to the blocks added in it.
    */
-  Command worker_heartbeat(1: i64 workerId, 2: i64 usedBytes, 3: list<i64> removedBlockIds,
+  Command worker_heartbeat(1: i64 workerId, 2: list<i64> usedBytes, 3: list<i64> removedBlockIds,
       4: map<i64, list<i64>> addedBlockIds)
     throws (1: BlockInfoException e)
 
@@ -157,7 +158,7 @@ service MasterService {
    * bytes, the id of the storage directory in which the block is, the id of the block and the size
    * of the block in bytes.
    */
-  void worker_cacheBlock(1: i64 workerId, 2: i64 workerUsedBytes, 3: i64 storageDirId,
+  void worker_cacheBlock(1: i64 workerId, 2: i64 storageTierUsedBytes, 3: i64 storageDirId,
       4: i64 blockId, 5: i64 length)
     throws (1: FileDoesNotExistException eP, 2: SuspectedFileSizeException eS, 3: BlockInfoException eB)
 


### PR DESCRIPTION

![qq 20150209132408](https://cloud.githubusercontent.com/assets/8843442/6101474/e03b5520-b05f-11e4-9bed-4d222955e6b3.png)
We improve the overview page of webUI about Hierarchy to add information about "Hierarchy Store Level" "Hierarchy Store Alias" "Space Capacity" "Space Used" and "Space Usage" information. In order to realize the function, we amend tachyon.thrift file to recreate tachyon.thrift package. Maily,  we amend worker_register and worker_heartbeat function to replace total bytes and used bytes of workers with hierarchy store levels, hierarchy store alias values, total bytes of each hierarchy store level, used bytes of  each hierarchy store level. In MasterInfo class, we add getHierarchyStoreLevels(), getHierarchyStoreLevelAliasValues(), getHierarchyCapacityBytes(), getHierarchyUsedBytes() to collect hierarchy information about workers. 