### PR TITLE
Fix potential capacity leak in StorageDir and add unit tests

### DIFF
--- a/core/src/main/java/tachyon/worker/hierarchy/StorageDir.java
+++ b/core/src/main/java/tachyon/worker/hierarchy/StorageDir.java
@@ -164,9 +164,9 @@ public final class StorageDir {
   public boolean cacheBlock(long userId, long blockId) throws IOException {
     String srcPath = getUserTempFilePath(userId, blockId);
     String dstPath = getBlockFilePath(blockId);
-    Long allocatedBytes = mTempBlockAllocatedBytes.remove(new Pair<Long, Long>(userId, blockId));
+    Pair<Long, Long> blockInfo = new Pair<Long, Long>(userId, blockId);
 
-    if (!mFs.exists(srcPath) || allocatedBytes == null) {
+    if (!(mFs.exists(srcPath) && mTempBlockAllocatedBytes.containsKey(blockInfo))) {
       cancelBlock(userId, blockId);
       throw new IOException("Block file doesn't exist! blockId:" + blockId + " " + srcPath);
     }
@@ -175,6 +175,7 @@ public final class StorageDir {
       cancelBlock(userId, blockId);
       throw new IOException("Negative block size! blockId:" + blockId);
     }
+    Long allocatedBytes = mTempBlockAllocatedBytes.remove(blockInfo);
     returnSpace(userId, allocatedBytes - blockSize);
     if (mFs.rename(srcPath, dstPath)) {
       addBlockId(blockId, blockSize, false);

--- a/core/src/test/java/tachyon/worker/hierarchy/StorageDirTest.java
+++ b/core/src/test/java/tachyon/worker/hierarchy/StorageDirTest.java
@@ -50,6 +50,7 @@ public class StorageDirTest {
   public void cacheBlockCancelTest() throws  IOException {
     long blockId = 100;
     int blockSize = 500;
+    Exception exception = null;
 
     mSrcDir.requestSpace(USER_ID, blockSize);
     mSrcDir.updateTempBlockAllocatedBytes(USER_ID, blockId, blockSize);
@@ -57,7 +58,11 @@ public class StorageDirTest {
       // cacheBlock calls cancelBlock and throws IOException
       mSrcDir.cacheBlock(USER_ID, blockId);
     } catch (IOException e) {
+      exception = e;
     }
+    Assert.assertEquals(
+        "Block file doesn't exist! blockId:100 " + mSrcDir.getUserTempFilePath(USER_ID, blockId),
+        exception.getMessage());
     Assert.assertEquals(CAPACITY, mSrcDir.getAvailableBytes());
     Assert.assertEquals(0, mSrcDir.getUserOwnBytes(USER_ID));
   }


### PR DESCRIPTION
The method cancelBlock gets the allocatedBytes from mTempBlockAllocatedBytes and returns the space. The info should not be removed from mTempBlockAllocatedBytes before calling cancelBlock, otherwise the space is not returend.