### PR TITLE
fix default block size conflict

### DIFF
--- a/core/src/main/java/tachyon/conf/UserConf.java
+++ b/core/src/main/java/tachyon/conf/UserConf.java
@@ -53,7 +53,8 @@ public class UserConf extends Utils {
     FILE_BUFFER_BYTES = getIntProperty("tachyon.user.file.buffer.bytes", Constants.MB);
     HEARTBEAT_INTERVAL_MS =
         getLongProperty("tachyon.user.heartbeat.interval.ms", Constants.SECOND_MS);
-    DEFAULT_BLOCK_SIZE_BYTE = getLongProperty("tachyon.user.default.block.size.byte", Constants.GB);
+    DEFAULT_BLOCK_SIZE_BYTE = getLongProperty("tachyon.user.default.block.size.byte",
+        Constants.DEFAULT_BLOCK_SIZE_BYTE);
     REMOTE_READ_BUFFER_SIZE_BYTE =
         getIntProperty("tachyon.user.remote.read.buffer.size.byte", Constants.MB);
     DEFAULT_WRITE_TYPE =


### PR DESCRIPTION
there are two different configurations for default block size in UserConf and Constants. make them consistent.
