### PR TITLE
Set the default block size in AbstractTFS to be the default block size in Tachyon

### DIFF
--- a/core/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/core/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -240,6 +240,11 @@ abstract class AbstractTFS extends FileSystem {
   }
 
   @Override
+  public long getDefaultBlockSize() {
+    return getConf().getLong("fs.local.block.size", Constants.DEFAULT_BLOCK_SIZE_BYTE);
+  }
+
+  @Override
   public BlockLocation[] getFileBlockLocations(FileStatus file, long start, long len)
       throws IOException {
     if (file == null) {


### PR DESCRIPTION
The default block size in AbstractTFS is provided by FileSystem, which is 32MB.
Use default block size in Tachyon to replace the default value in FileSystem.