### PR TITLE
Address intermittent test failures

### DIFF
--- a/core/src/test/java/tachyon/client/TachyonFileTest.java
+++ b/core/src/test/java/tachyon/client/TachyonFileTest.java
@@ -37,8 +37,8 @@ public class TachyonFileTest {
   private static final int WORKER_CAPACITY_BYTES = 1000;
   private static final int USER_QUOTA_UNIT_BYTES = 100;
   private static final int FILE_BUFFER_BYTES = WORKER_CAPACITY_BYTES / 4;
-  private static final int WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS =
-      WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS;
+  private static final int SLEEP_MS =
+      WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS * 2 + 10;
   private static final int MAX_FILES = WORKER_CAPACITY_BYTES / USER_QUOTA_UNIT_BYTES;
 
   private static final int MIN_LEN = 0;
@@ -114,7 +114,7 @@ public class TachyonFileTest {
       Assert.assertTrue(file.isInMemory());
     }
 
-    CommonUtils.sleepMs(null, WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    CommonUtils.sleepMs(null, SLEEP_MS);
     for (int k = 0; k < MAX_FILES; k ++) {
       TachyonFile file = mTfs.getFile(new TachyonURI("/file" + k));
       Assert.assertTrue(file.isInMemory());
@@ -127,7 +127,7 @@ public class TachyonFileTest {
       Assert.assertTrue(file.isInMemory());
     }
 
-    CommonUtils.sleepMs(null, WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    CommonUtils.sleepMs(null, SLEEP_MS);
     TachyonFile file = mTfs.getFile(new TachyonURI("/file" + 0));
     Assert.assertFalse(file.isInMemory());
 
@@ -160,7 +160,7 @@ public class TachyonFileTest {
       Assert.assertTrue(file.isInMemory());
     }
 
-    CommonUtils.sleepMs(null, WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    CommonUtils.sleepMs(null, SLEEP_MS);
 
     file = mTfs.getFile(new TachyonURI("/pin/file"));
     Assert.assertTrue(file.isInMemory());

--- a/core/src/test/java/tachyon/command/TFsShellTest.java
+++ b/core/src/test/java/tachyon/command/TFsShellTest.java
@@ -52,6 +52,7 @@ import tachyon.util.NetworkUtils;
  */
 public class TFsShellTest {
   private static final int SIZE_BYTES = Constants.MB * 10;
+  private static final int SLEEP_MS = WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS * 2 + 10;
   private LocalTachyonCluster mLocalTachyonCluster = null;
   private TachyonFS mTfs = null;
   private TFsShell mFsShell = null;
@@ -584,7 +585,7 @@ public class TFsShellTest {
   public void freeTest() throws IOException {
     TestUtils.createByteFile(mTfs, "/testFile", WriteType.MUST_CACHE, 10);
     mFsShell.free(new String[]{"free", "/testFile"});
-    CommonUtils.sleepMs(null, WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS *2);;
+    CommonUtils.sleepMs(null, SLEEP_MS);;
     Assert.assertFalse(mTfs.getFile(new TachyonURI("/testFile")).isInMemory()); ;
   }
 }

--- a/core/src/test/java/tachyon/worker/DataServerTest.java
+++ b/core/src/test/java/tachyon/worker/DataServerTest.java
@@ -49,6 +49,7 @@ import tachyon.worker.nio.DataServerMessage;
 public class DataServerTest {
   private static final int WORKER_CAPACITY_BYTES = 1000;
   private static final int USER_QUOTA_UNIT_BYTES = 100;
+  private static final int SLEEP_MS = WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS * 2 + 10;
 
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
@@ -153,7 +154,7 @@ public class DataServerTest {
     DataServerMessage recvMsg2 = request(block2);
     assertValid(recvMsg2, length, block2.getBlockId(), 0, length);
 
-    CommonUtils.sleepMs(null, WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    CommonUtils.sleepMs(null, SLEEP_MS);
     ClientFileInfo fileInfo = mTFS.getFileStatus(-1, new TachyonURI("/readFile1"));
     Assert.assertEquals(0, fileInfo.inMemoryPercentage);
   }

--- a/core/src/test/java/tachyon/worker/WorkerServiceHandlerTest.java
+++ b/core/src/test/java/tachyon/worker/WorkerServiceHandlerTest.java
@@ -44,8 +44,8 @@ import tachyon.util.CommonUtils;
 public class WorkerServiceHandlerTest {
   private static final long WORKER_CAPACITY_BYTES = 10000;
   private static final int USER_QUOTA_UNIT_BYTES = 100;
-  private static final int WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS =
-      WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS;
+  private static final int SLEEP_MS = 
+      WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS * 2 + 10;
 
   private LocalTachyonCluster mLocalTachyonCluster = null;
   private MasterInfo mMasterInfo = null;
@@ -78,7 +78,7 @@ public class WorkerServiceHandlerTest {
     createBlockFile(filename, (int)(WORKER_CAPACITY_BYTES / 10L - 10L));
     mWorkerServiceHandler.cancelBlock(userId, blockId);
     Assert.assertFalse(new File(filename).exists());
-    CommonUtils.sleepMs(null, WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    CommonUtils.sleepMs(null, SLEEP_MS);
     Assert.assertEquals(0, mMasterInfo.getUsedBytes());
   }
 
@@ -133,7 +133,7 @@ public class WorkerServiceHandlerTest {
     int fileId3 =
         TestUtils.createByteFile(mTfs, "/file3", WriteType.MUST_CACHE,
             (int) WORKER_CAPACITY_BYTES / 2);
-    CommonUtils.sleepMs(null, WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    CommonUtils.sleepMs(null, SLEEP_MS);
     fileInfo1 = mMasterInfo.getClientFileInfo(new TachyonURI("/file1"));
     fileInfo2 = mMasterInfo.getClientFileInfo(new TachyonURI("/file2"));
     ClientFileInfo fileInfo3 = mMasterInfo.getClientFileInfo(new TachyonURI("/file3"));

--- a/core/src/test/java/tachyon/worker/hierarchy/HierarchyStoreTest.java
+++ b/core/src/test/java/tachyon/worker/hierarchy/HierarchyStoreTest.java
@@ -39,8 +39,8 @@ public class HierarchyStoreTest {
   private static final int MEM_CAPACITY_BYTES = 1000;
   private static final int DISK_CAPACITY_BYTES = 10000;
   private static final int USER_QUOTA_UNIT_BYTES = 100;
-  private static final int WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS
-      = WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS;
+  private static final int SLEEP_MS
+      = WorkerConf.get().TO_MASTER_HEARTBEAT_INTERVAL_MS * 2 + 10;
 
   private LocalTachyonCluster mLocalTachyonCluster = null;
   private TachyonFS mTFS = null;
@@ -86,7 +86,7 @@ public class HierarchyStoreTest {
     int fileId5 =
         TestUtils.createByteFile(mTFS, "/root/test5", WriteType.TRY_CACHE, MEM_CAPACITY_BYTES / 2);
 
-    CommonUtils.sleepMs(null, WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    CommonUtils.sleepMs(null, SLEEP_MS);
     TachyonFile file4 = mTFS.getFile(fileId4);
     TachyonFile file5 = mTFS.getFile(fileId5);
 
@@ -106,7 +106,7 @@ public class HierarchyStoreTest {
     int fileId3 =
         TestUtils.createByteFile(mTFS, "/root/test3", WriteType.TRY_CACHE, MEM_CAPACITY_BYTES / 2);
 
-    CommonUtils.sleepMs(null, WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    CommonUtils.sleepMs(null, SLEEP_MS);
     TachyonFile file1 = mTFS.getFile(fileId1);
     TachyonFile file2 = mTFS.getFile(fileId2);
     TachyonFile file3 = mTFS.getFile(fileId3);
@@ -122,7 +122,7 @@ public class HierarchyStoreTest {
     int len = is.read(buf);
     is.close();
 
-    CommonUtils.sleepMs(null, WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    CommonUtils.sleepMs(null, SLEEP_MS);
     Assert.assertEquals(MEM_CAPACITY_BYTES / 6, len);
     Assert.assertEquals(true, file1.isInMemory());
     Assert.assertEquals(false, file2.isInMemory());


### PR DESCRIPTION
There are many tests that rely on an embedded Tachyon cluster running.
Lots of these take some action and then need to wait for the workers to
update the masters state (or vice versa) before checking their assertions.

They do this by sleeping before carrying on with their assertions.  Due to 
the vagaries of JVM thread scheduling tests need to wait longer than the 
heartbeat interval because otherwise the heartbeat may not have yet 
occurred.  Most tests already do this by sleeping for double the heartbeat
interval plus a little bit extra.

However there were a few tests that only waited for a single heartbeat
interval so could intermittently fail with no real cause.  This commit
fixes up the tests that weren't waiting long enough to use the same
longer wait as other tests.