### PR TITLE
Upgrade JUnit and PowerMock to the latest versions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,9 +132,10 @@
     <cxf.version>2.7.0</cxf.version>
     <jetty.version>7.6.15.v20140411</jetty.version>
     <slf4j.version>1.7.2</slf4j.version>
-    <powermock.version>1.5.4</powermock.version>
+    <powermock.version>1.6.1</powermock.version>
     <log4j.version>1.2.17</log4j.version>
     <apache.curator.version>2.1.0-incubating</apache.curator.version>
+    <junit.version>4.12</junit.version>
     <license.header.path>build/license/</license.header.path>
     <checkstyle.path>build/checkstyle/</checkstyle.path>
     <findbugs.path>build/findbugs/</findbugs.path>


### PR DESCRIPTION
Currently JUnit 4.10 is used which is from Sept 2011 whereas the latest
version is 4.12 from Dec 2014.  The old version is licensed under the
Common Public License 1.0 which is a deprecated license that was
superseded by the Eclipse Public License which makes it problematic from
a licensing perspective.  Newer versions of JUnit are licensed under the
Eclipse Public License.

This commit upgrades JUnit to 4.12 and changes the hard coding of the
JUnit version in the dependency declaration to use a Maven property
to make this easy to change in the future.  Powermock was also upgraded
to the latest version in order to align with the JUnit upgrade