### PR TITLE
Add bundled code to NOTICE file (TACHYON-281)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,32 @@
 Tachyon
 Copyright 2012-2014 University of California, Berkeley
+
+------------
+
+This product bundles Bootstrap 2 which is under the Apache License 2.0
+
+http://getbootstrap.com
+
+------------
+
+This product bundles Cookies.js which is in the public domain
+
+https://github.com/ScottHamper/Cookies/
+
+------------
+
+This product bundles jQuery which is under the MIT License
+
+http://jquery.com
+
+------------
+
+This product bundles Modernizr which is licensed under the MIT License
+
+http://modernizr.com
+
+------------
+
+This products bundles portions of Pygments which is licensed under the BSD 2-clause License
+
+http://pygments.org


### PR DESCRIPTION
Tachyon bundles several third party libraries as-is in its
web-application.  These include all/part of the following:

- Bootstrap 2 (Apache License)
- jQuery (MIT License)
- Cookies.js (Public domain)
- Modernizr (MIT License)
- Pygments

Entries for each of these are added to the `NOTICE` file since otherwise a user of Tachyon has no obvious notice that these dependencies are being bundled.

@hsaputra I would appreciate your input on whether these additions to the `NOTICE` file are sufficient for these bundled dependencies