### PR TITLE
Add bundled code to LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -210,3 +210,32 @@ notices and license terms. Your use of the source code for the these
 subcomponents is subject to the terms and conditions of the following
 licenses.
 
+------------
+
+This product bundles Bootstrap 2 which is under the Apache License 2.0
+
+http://getbootstrap.com
+
+------------
+
+This product bundles Cookies.js which is in the public domain
+
+https://github.com/ScottHamper/Cookies/
+
+------------
+
+This product bundles jQuery which is under the MIT License
+
+http://jquery.com
+
+------------
+
+This product bundles Modernizr which is licensed under the MIT License
+
+http://modernizr.com
+
+------------
+
+This products bundles portions of Pygments which is licensed under the BSD 2-clause License
+
+http://pygments.org

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Tachyon
-Copyright 2012-2014 University of California, Berkeley
+Copyright 2012-2015 University of California, Berkeley


### PR DESCRIPTION
Respin of #669 since I realised I put the notices in the wrong file thanks to @hsaputra's review.  I also updated the copyright year as requested

--

Tachyon bundles several third party libraries as-is in its
web-application.  These include all/part of the following:

- Bootstrap 2 (Apache License)
- jQuery (MIT License)
- Cookies.js (Public domain)
- Modernizr (MIT License)
- Pygments (BSD 2-Clause License)

Entries for each of these are added to the LICENSE file

The NOTICE is also updated to update the copyright year to 2015