### PR TITLE
Add bundled code to LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -203,10 +203,89 @@
 
 
 =======================================================================
+
 Tachyon Subcomponents:
 
 The Tachyon project contains subcomponents with separate copyright
 notices and license terms. Your use of the source code for the these
 subcomponents is subject to the terms and conditions of the following
 licenses.
+
+-----------------------------------------------------------------------
+The Apache License
+-----------------------------------------------------------------------
+
+Tachyon bundles portions of the following under the Apache License 2.0 as detailed
+above:
+
+ - Bootstrap 2 (http://getbootstrap.com) - Copyright 2011-2015 Twitter Inc
+
+-----------------------------------------------------------------------
+The MIT License
+-----------------------------------------------------------------------
+
+Tachyon bundles portions of the following under the MIT License:
+
+ - jQuery (http://jquery.com) - Copyright 2014 jQuery Foundation and other contributors
+ - Modernizr (http://modernizr.com) - Copyright 2009-2015 Modernizr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-----------------------------------------------------------------------
+The BSD 2-Clause License
+-----------------------------------------------------------------------
+
+Tachyon bundles portions of the following under the BSD 2-Clause License:
+
+ -  Pygments (http://pygments.org) - Copyright 2006-2015 various contributors
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----------------------------------------------------------------------
+Public Domain
+-----------------------------------------------------------------------
+
+Tachyon bundles portions of the following which are in the public domain:
+
+ - Cookies.js (https://github.com/ScottHamper/Cookies/)
+
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,9 @@
 Tachyon
-Copyright 2012-2014 University of California, Berkeley
+Copyright 2012-2015 University of California, Berkeley
+
+==========
+
+Tachyon project contains subcomponents with separate copyright notices and license terms. 
+Your use of the source code for the these subcomponents is subject to the terms and conditions of their respective licenses.
+
+See the LICENSE file for a list of subcomponents and dependencies and their respective licenses.


### PR DESCRIPTION
Respinning this again, per @hsaputra and @haoyuan previous comments I have changed the format to better match Apache style `LICENSE` and `NOTICE` files

Tachyon bundles several third party libraries as-is in its
web-application.  These include all/part of the following:

- Bootstrap 2 (Apache License)
- jQuery (MIT License)
- Cookies.js (Public domain)
- Modernizr (MIT License)
- Pygments (BSD 2-Clause License)

Entries for each of these are added to the `LICENSE` file along with the
relevant licenses

The `NOTICE` is also updated to update the copyright year to 2015 and to
inform users that some portions of Tachyon are under alternative
licenses and they should consult `LICENSE` to see the details of this.