### PR TITLE
Tier bytes cleanup

### DIFF
--- a/core/src/main/java/tachyon/StorageLevelAlias.java
+++ b/core/src/main/java/tachyon/StorageLevelAlias.java
@@ -46,4 +46,6 @@ public enum StorageLevelAlias {
   public int getValue() {
     return mValue;
   }
+
+  public static final int SIZE = StorageLevelAlias.values().length;
 }

--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -1397,8 +1397,7 @@ public class MasterInfo extends ImageWriter {
    * @return the total bytes on each storage tier.
    */
   public List<Long> getTotalBytesOnTiers() {
-    List<Long> ret = new ArrayList<Long>(StorageLevelAlias.SIZE);
-    Collections.fill(ret, 0L);
+    List<Long> ret = new ArrayList<Long>(Collections.nCopies(StorageLevelAlias.SIZE, 0L));
     synchronized (mWorkers) {
       for (MasterWorkerInfo worker : mWorkers.values()) {
         for (int i = 0; i < worker.getTotalBytesOnTiers().size(); i ++) {
@@ -1413,12 +1412,11 @@ public class MasterInfo extends ImageWriter {
    * @return the used bytes on each storage tier.
    */
   public List<Long> getUsedBytesOnTiers() {
-    List<Long> ret = new ArrayList<Long>(StorageLevelAlias.SIZE);
-    Collections.fill(ret, 0L);
+    List<Long> ret = new ArrayList<Long>(Collections.nCopies(StorageLevelAlias.SIZE, 0L));
     synchronized (mWorkers) {
       for (MasterWorkerInfo worker : mWorkers.values()) {
-        for (int i = 0; i < worker.getTotalBytesOnTiers().size(); i ++) {
-          ret.set(i, ret.get(i) + worker.getTotalBytesOnTiers().get(i));
+        for (int i = 0; i < worker.getUsedBytesOnTiers().size(); i ++) {
+          ret.set(i, ret.get(i) + worker.getUsedBytesOnTiers().get(i));
         }
       }
     }

--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -319,7 +319,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Add a checkpoint to a file, inner method.
-   * 
+   *
    * @param workerId The worker which submitted the request. -1 if the request is not from a worker.
    * @param fileId The file to add the checkpoint.
    * @param length The length of the checkpoint.
@@ -391,7 +391,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Completes the checkpointing of a file, inner method.
-   * 
+   *
    * @param fileId The id of the file
    * @param opTimeMs The time of the complete file operation, in milliseconds
    * @throws FileDoesNotExistException
@@ -474,7 +474,7 @@ public class MasterInfo extends ImageWriter {
   // TODO Make this API better.
   /**
    * Internal API.
-   * 
+   *
    * @param recursive If recursive is true and the filesystem tree is not filled in all the way to
    *        path yet, it fills in the missing components.
    * @param path The path to create
@@ -593,7 +593,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Inner delete function. Return true if the file does not exist in the first place.
-   * 
+   *
    * @param fileId The inode to delete
    * @param recursive True if the file and it's subdirectories should be deleted
    * @param opTimeMs The time of the delete operation, in milliseconds
@@ -676,7 +676,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the raw table info associated with the given id.
-   * 
+   *
    * @param path The path of the table
    * @param inode The inode at the path
    * @return the table info
@@ -699,7 +699,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the names of the sub-directories at the given path.
-   * 
+   *
    * @param inode The inode to list
    * @param path The path of the given inode
    * @param recursive If true, recursively add the paths of the sub-directories
@@ -728,7 +728,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Inner method of recomputePinnedFiles. Also directly called by EditLog.
-   * 
+   *
    * @param inode The inode to start traversal from
    * @param setPinState An optional parameter indicating whether we should also set the "pinned"
    *        flag on each inode we traverse. If absent, the "isPinned" flag is unchanged.
@@ -755,7 +755,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Rename a file to the given path, inner method.
-   * 
+   *
    * @param fileId The id of the file to rename
    * @param dstPath The new path of the file
    * @param opTimeMs The time of the rename operation, in milliseconds
@@ -851,7 +851,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Add a checkpoint to a file.
-   * 
+   *
    * @param workerId The worker which submitted the request. -1 if the request is not from a worker.
    * @param fileId The file to add the checkpoint.
    * @param length The length of the checkpoint.
@@ -877,7 +877,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Removes a checkpointed file from the set of lost or being-recomputed files if it's there
-   * 
+   *
    * @param fileId The file to examine
    */
   private void addFile(int fileId, int dependencyId) {
@@ -893,7 +893,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * While loading an image, addToInodeMap will map the various ids to their inodes.
-   * 
+   *
    * @param inode The inode to add
    * @param map The map to add the inodes to
    */
@@ -909,7 +909,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * A worker cache a block in its memory.
-   * 
+   *
    * @param workerId
    * @param usedBytesOnTier
    * @param blockId
@@ -960,7 +960,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Completes the checkpointing of a file.
-   * 
+   *
    * @param fileId The id of the file
    * @throws FileDoesNotExistException
    */
@@ -994,7 +994,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Create a file. // TODO Make this API better.
-   * 
+   *
    * @throws FileAlreadyExistException
    * @throws InvalidPathException
    * @throws BlockInfoException
@@ -1023,7 +1023,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Creates a new block for the given file.
-   * 
+   *
    * @param fileId The id of the file
    * @return the block id.
    * @throws FileDoesNotExistException
@@ -1045,7 +1045,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Creates a raw table.
-   * 
+   *
    * @param path The path to place the table at
    * @param columns The number of columns in the table
    * @param metadata Additional metadata about the table
@@ -1083,7 +1083,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Delete a file based on the file's ID.
-   * 
+   *
    * @param fileId the file to be deleted.
    * @param recursive whether delete the file recursively or not.
    * @return succeed or not
@@ -1101,7 +1101,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Delete files based on the path.
-   * 
+   *
    * @param path The file to be deleted.
    * @param recursive whether delete the file recursively or not.
    * @return succeed or not
@@ -1139,7 +1139,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the list of blocks of an InodeFile determined by path.
-   * 
+   *
    * @param path The file.
    * @return The list of the blocks of the file.
    * @throws InvalidPathException
@@ -1160,7 +1160,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the capacity of the whole system.
-   * 
+   *
    * @return the system's capacity in bytes.
    */
   public long getCapacityBytes() {
@@ -1175,7 +1175,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the block info associated with the given id.
-   * 
+   *
    * @param blockId The id of the block return
    * @return the block info
    * @throws FileDoesNotExistException
@@ -1199,7 +1199,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the dependency info associated with the given id.
-   * 
+   *
    * @param dependencyId The id of the dependency
    * @return the dependency info
    * @throws DependencyDoesNotExistException
@@ -1218,7 +1218,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the file info associated with the given id.
-   * 
+   *
    * @param fid The id of the file
    * @return the file info
    */
@@ -1236,7 +1236,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the file info for the file at the given path
-   * 
+   *
    * @param path The path of the file
    * @return the file info
    * @throws InvalidPathException
@@ -1255,7 +1255,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the raw table info associated with the given id.
-   * 
+   *
    * @param id The id of the table
    * @return the table info
    * @throws TableDoesNotExistException
@@ -1272,7 +1272,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the raw table info for the table at the given path
-   * 
+   *
    * @param path The path of the table
    * @return the table info
    * @throws TableDoesNotExistException
@@ -1291,7 +1291,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the file id of the file.
-   * 
+   *
    * @param path The path of the file
    * @return The file id of the file. -1 if the file does not exist.
    * @throws InvalidPathException
@@ -1309,7 +1309,7 @@ public class MasterInfo extends ImageWriter {
   /**
    * Get the block infos of a file with the given id. Throws an exception if the id names a
    * directory.
-   * 
+   *
    * @param fileId The id of the file to look up
    * @return the block infos of the file
    * @throws FileDoesNotExistException
@@ -1329,7 +1329,7 @@ public class MasterInfo extends ImageWriter {
   /**
    * Get the block infos of a file with the given path. Throws an exception if the path names a
    * directory.
-   * 
+   *
    * @param path The path of the file to look up
    * @return the block infos of the file
    * @throws FileDoesNotExistException
@@ -1350,7 +1350,7 @@ public class MasterInfo extends ImageWriter {
   /**
    * Get the file id's of the given paths. It recursively scans directories for the file id's inside
    * of them.
-   * 
+   *
    * @param pathList The list of paths to look at
    * @return the file id's of the files.
    * @throws InvalidPathException
@@ -1368,7 +1368,7 @@ public class MasterInfo extends ImageWriter {
   /**
    * If the <code>path</code> is a directory, return all the direct entries in it. If the
    * <code>path</code> is a file, return its ClientFileInfo.
-   * 
+   *
    * @param path the target directory/file path
    * @return A list of ClientFileInfo
    * @throws FileDoesNotExistException
@@ -1392,16 +1392,14 @@ public class MasterInfo extends ImageWriter {
     }
     return ret;
   }
-  
+
   /**
    * @return the total bytes on each storage tier.
    */
   public List<Long> getTotalBytesOnTiers() {
-    List<Long> ret = new ArrayList<Long>(StorageLevelAlias.values().length);
+    List<Long> ret = new ArrayList<Long>(StorageLevelAlias.SIZE);
+    Collections.fill(ret, 0L);
     synchronized (mWorkers) {
-      for (int i = 0; i < StorageLevelAlias.values().length; i ++) {
-        ret.add((long) 0);
-      }
       for (MasterWorkerInfo worker : mWorkers.values()) {
         for (int i = 0; i < worker.getTotalBytesOnTiers().size(); i ++) {
           ret.set(i, ret.get(i) + worker.getTotalBytesOnTiers().get(i));
@@ -1410,19 +1408,17 @@ public class MasterInfo extends ImageWriter {
     }
     return ret;
   }
-  
+
   /**
    * @return the used bytes on each storage tier.
    */
   public List<Long> getUsedBytesOnTiers() {
-    List<Long> ret = new ArrayList<Long>(StorageLevelAlias.values().length);
+    List<Long> ret = new ArrayList<Long>(StorageLevelAlias.SIZE);
+    Collections.fill(ret, 0L);
     synchronized (mWorkers) {
-      for (int i = 0; i < StorageLevelAlias.values().length; i ++) {
-        ret.add((long) 0);
-      }
       for (MasterWorkerInfo worker : mWorkers.values()) {
-        for (int i = 0; i < worker.getUsedBytesOnTiers().size(); i ++) {
-          ret.set(i, ret.get(i) + worker.getUsedBytesOnTiers().get(i));  
+        for (int i = 0; i < worker.getTotalBytesOnTiers().size(); i ++) {
+          ret.set(i, ret.get(i) + worker.getTotalBytesOnTiers().get(i));
         }
       }
     }
@@ -1431,7 +1427,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get absolute paths of all in memory files.
-   * 
+   *
    * @return absolute paths of all in memory files.
    */
   public List<TachyonURI> getInMemoryFiles() {
@@ -1471,7 +1467,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the inode of the file at the given path.
-   * 
+   *
    * @param pathNames The path components of the path to search for
    * @return the inode of the file at the given path, or null if the file does not exist
    * @throws InvalidPathException
@@ -1487,7 +1483,7 @@ public class MasterInfo extends ImageWriter {
   /**
    * Returns a list of the given folder's children, recursively scanning subdirectories. It adds the
    * parent of a node before adding its children.
-   * 
+   *
    * @param inodeFolder The folder to start looking at
    * @return a list of the children inodes.
    */
@@ -1506,7 +1502,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get Journal instance for MasterInfo for Unit test only
-   * 
+   *
    * @return Journal instance
    */
   public Journal getJournal() {
@@ -1515,7 +1511,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the master address.
-   * 
+   *
    * @return the master address
    */
   public InetSocketAddress getMasterAddress() {
@@ -1524,7 +1520,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get a new user id
-   * 
+   *
    * @return a new user id
    */
   public long getNewUserId() {
@@ -1533,7 +1529,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the number of files at a given path.
-   * 
+   *
    * @param path The path to look at
    * @return The number of files at the path. Returns 1 if the path specifies a file. If it's a
    *         directory, returns the number of items in the directory.
@@ -1554,7 +1550,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the path specified by a given inode.
-   * 
+   *
    * @param inode The inode
    * @return the path of the inode
    */
@@ -1572,7 +1568,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the path of a file with the given id
-   * 
+   *
    * @param fileId The id of the file to look up
    * @return the path of the file
    * @throws FileDoesNotExistException raise if the file does not exist.
@@ -1589,7 +1585,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get a list of the pin id's.
-   * 
+   *
    * @return a list of pin id's
    */
   public List<Integer> getPinIdList() {
@@ -1600,7 +1596,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Creates a list of high priority dependencies, which don't yet have checkpoints.
-   * 
+   *
    * @return the list of dependency ids
    */
   public List<Integer> getPriorityDependencyList() {
@@ -1638,7 +1634,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the id of the table at the given path.
-   * 
+   *
    * @param path The path of the table
    * @return the id of the table
    * @throws InvalidPathException
@@ -1661,7 +1657,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the master start time in milliseconds.
-   * 
+   *
    * @return the master start time in milliseconds
    */
   public long getStarttimeMs() {
@@ -1670,7 +1666,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the capacity of the under file system.
-   * 
+   *
    * @return the capacity in bytes
    * @throws IOException
    */
@@ -1681,7 +1677,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the amount of free space in the under file system.
-   * 
+   *
    * @return the free space in bytes
    * @throws IOException
    */
@@ -1692,7 +1688,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the amount of space used in the under file system.
-   * 
+   *
    * @return the space used in bytes
    * @throws IOException
    */
@@ -1703,7 +1699,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the amount of space used by the workers.
-   * 
+   *
    * @return the amount of space used in bytes
    */
   public long getUsedBytes() {
@@ -1718,7 +1714,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the white list.
-   * 
+   *
    * @return the white list
    */
   public List<String> getWhiteList() {
@@ -1727,7 +1723,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the address of a worker.
-   * 
+   *
    * @param random If true, select a random worker
    * @param host If <code>random</code> is false, select a worker on this host
    * @return the address of the selected worker, or null if no address could be found
@@ -1767,7 +1763,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the number of workers.
-   * 
+   *
    * @return the number of workers
    */
   public int getWorkerCount() {
@@ -1778,7 +1774,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get info about a worker.
-   * 
+   *
    * @param workerId The id of the worker to look at
    * @return the info about the worker
    */
@@ -1796,7 +1792,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get info about all the workers.
-   * 
+   *
    * @return a list of worker infos
    */
   public List<ClientWorkerInfo> getWorkersInfo() {
@@ -1813,7 +1809,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get info about the lost workers
-   * 
+   *
    * @return a list of worker info
    */
   public List<ClientWorkerInfo> getLostWorkersInfo() {
@@ -1841,7 +1837,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the id of the file at the given path. If recursive, it scans the subdirectories as well.
-   * 
+   *
    * @param path The path to start looking at
    * @param recursive If true, recursively scan the subdirectories at the given path as well
    * @return the list of the inode id's at the path
@@ -1884,7 +1880,7 @@ public class MasterInfo extends ImageWriter {
   /**
    * Load the image from <code>parser</code>, which is created based on the <code>path</code>.
    * Assume this blocks the whole MasterInfo.
-   * 
+   *
    * @param parser the JsonParser to load the image
    * @param path the file to load the image
    * @throws IOException
@@ -1958,7 +1954,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Get the names of the sub-directories at the given path.
-   * 
+   *
    * @param path The path to look at
    * @param recursive If true, recursively add the paths of the sub-directories
    * @return the list of paths
@@ -1978,7 +1974,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Create a directory at the given path.
-   * 
+   *
    * @param path The path to create a directory at
    * @return true if and only if the directory was created; false otherwise
    * @throws FileAlreadyExistException
@@ -1996,7 +1992,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Called by edit log only.
-   * 
+   *
    * @param fileId
    * @param blockIndex
    * @param blockLength
@@ -2024,7 +2020,7 @@ public class MasterInfo extends ImageWriter {
   /**
    * Recomputes mFileIdPinList at the given Inode, recursively recomputing for children. Optionally
    * will set the "pinned" flag as we go.
-   * 
+   *
    * @param inode The inode to start traversal from
    * @param setPinState An optional parameter indicating whether we should also set the "pinned"
    *        flag on each inode we traverse. If absent, the "isPinned" flag is unchanged.
@@ -2037,7 +2033,7 @@ public class MasterInfo extends ImageWriter {
   /**
    * Register a worker at the given address, setting it up and associating it with a given list of
    * blocks.
-   * 
+   *
    * @param workerNetAddress The address of the worker to register
    * @param totalBytesOnTiers Total bytes on each storage tier
    * @param usedBytesOnTiers Used Bytes on each storage tier
@@ -2071,7 +2067,7 @@ public class MasterInfo extends ImageWriter {
       }
       MasterWorkerInfo tWorkerInfo =
           new MasterWorkerInfo(id, workerAddress, totalBytesOnTiers, capacityBytes);
-      tWorkerInfo.updateUsedBytes(usedBytesOnTiers); 
+      tWorkerInfo.updateUsedBytes(usedBytesOnTiers);
       for (List<Long> blockIds : currentBlockIds.values()) {
         tWorkerInfo.updateBlocks(true, blockIds);
       }
@@ -2102,7 +2098,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Rename a file to the given path.
-   * 
+   *
    * @param fileId The id of the file to rename
    * @param dstPath The new path of the file
    * @return true if the rename succeeded, false otherwise
@@ -2122,7 +2118,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Rename a file to the given path.
-   * 
+   *
    * @param srcPath The path of the file to rename
    * @param dstPath The new path of the file
    * @return true if the rename succeeded, false otherwise
@@ -2142,7 +2138,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Logs a lost file and sets it to be recovered.
-   * 
+   *
    * @param fileId The id of the file to be recovered
    */
   public void reportLostFile(int fileId) {
@@ -2173,7 +2169,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Request that the files for the given dependency be recomputed.
-   * 
+   *
    * @param depId The dependency whose files are to be recomputed
    */
   public void requestFilesInDependency(int depId) {

--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -96,7 +96,8 @@ public class MasterInfo extends ImageWriter {
         for (Entry<Long, MasterWorkerInfo> worker : mWorkers.entrySet()) {
           int masterWorkerTimeoutMs =
               mTachyonConf.getInt(Constants.MASTER_WORKER_TIMEOUT_MS, 10 * Constants.SECOND_MS);
-          if (CommonUtils.getCurrentMs() - worker.getValue().getLastUpdatedTimeMs() > masterWorkerTimeoutMs) {
+          if (CommonUtils.getCurrentMs()
+              - worker.getValue().getLastUpdatedTimeMs() > masterWorkerTimeoutMs) {
             LOG.error("The worker " + worker.getValue() + " got timed out!");
             mLostWorkers.add(worker.getValue());
             lostWorkers.add(worker.getKey());
@@ -810,7 +811,8 @@ public class MasterInfo extends ImageWriter {
       if (srcInode == null) {
         return false;
       }
-      if (((InodeFolder) dstParentInode).getChild(dstComponents[dstComponents.length - 1]) != null) {
+      if (((InodeFolder) dstParentInode)
+          .getChild(dstComponents[dstComponents.length - 1]) != null) {
         return false;
       }
 
@@ -1634,7 +1636,8 @@ public class MasterInfo extends ImageWriter {
    * @throws InvalidPathException
    * @throws TableDoesNotExistException
    */
-  public int getRawTableId(TachyonURI path) throws InvalidPathException, TableDoesNotExistException {
+  public int getRawTableId(TachyonURI path) throws InvalidPathException,
+      TableDoesNotExistException {
     Inode inode = getInode(path);
     if (inode == null) {
       throw new TableDoesNotExistException(path.toString());
@@ -2035,7 +2038,8 @@ public class MasterInfo extends ImageWriter {
    * @throws BlockInfoException
    */
   public long registerWorker(NetAddress workerNetAddress, List<Long> totalBytesOnTiers,
-      List<Long> usedBytesOnTiers, Map<Long, List<Long>> currentBlockIds) throws BlockInfoException {
+      List<Long> usedBytesOnTiers, Map<Long, List<Long>> currentBlockIds)
+      throws BlockInfoException {
     long id = 0;
     long capacityBytes = 0;
     NetAddress workerAddress = new NetAddress(workerNetAddress);
@@ -2281,7 +2285,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Returns whether the traversal was successful or not.
-   * 
+   *
    * @return true if the traversal was successful, or false otherwise.
    */
   private boolean traversalSucceeded(Pair<Inode, Integer> inodeTraversal) {
@@ -2290,7 +2294,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Traverse to the inode at the given path.
-   * 
+   *
    * @param pathNames The path to search for, broken into components
    * @return the inode of the file at the given path. If it was not able to traverse down the entire
    *         path, it will set the second field to the first path component it didn't find. It never
@@ -2343,7 +2347,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Update the metadata of a table.
-   * 
+   *
    * @param tableId The id of the table to update
    * @param metadata The new metadata to update the table with
    * @throws TableDoesNotExistException
@@ -2368,7 +2372,7 @@ public class MasterInfo extends ImageWriter {
   /**
    * The heartbeat of the worker. It updates the information of the worker and removes the given
    * block id's.
-   * 
+   *
    * @param workerId The id of the worker to deal with
    * @param usedBytesOnTiers Used bytes on each storage tier
    * @param removedBlockIds The list of removed block ids
@@ -2440,7 +2444,7 @@ public class MasterInfo extends ImageWriter {
 
   /**
    * Create an image of the dependencies and filesystem tree.
-   * 
+   *
    * @param objWriter The used object writer
    * @param dos The target data output stream
    * @throws IOException

--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -94,10 +94,9 @@ public class MasterInfo extends ImageWriter {
 
       synchronized (mWorkers) {
         for (Entry<Long, MasterWorkerInfo> worker : mWorkers.entrySet()) {
-          int masterWorkerTimeoutMs = mTachyonConf.getInt(Constants.MASTER_WORKER_TIMEOUT_MS,
-              10 * Constants.SECOND_MS);
-          if (CommonUtils.getCurrentMs()
-              - worker.getValue().getLastUpdatedTimeMs() > masterWorkerTimeoutMs) {
+          int masterWorkerTimeoutMs =
+              mTachyonConf.getInt(Constants.MASTER_WORKER_TIMEOUT_MS, 10 * Constants.SECOND_MS);
+          if (CommonUtils.getCurrentMs() - worker.getValue().getLastUpdatedTimeMs() > masterWorkerTimeoutMs) {
             LOG.error("The worker " + worker.getValue() + " got timed out!");
             mLostWorkers.add(worker.getValue());
             lostWorkers.add(worker.getKey());
@@ -160,8 +159,8 @@ public class MasterInfo extends ImageWriter {
         LOG.warn("Restarting failed workers.");
         try {
           String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
-          java.lang.Runtime.getRuntime().exec(
-              tachyonHome + "/bin/tachyon-start.sh restart_workers");
+          java.lang.Runtime.getRuntime()
+              .exec(tachyonHome + "/bin/tachyon-start.sh restart_workers");
         } catch (IOException e) {
           LOG.error(e.getMessage());
         }
@@ -222,7 +221,7 @@ public class MasterInfo extends ImageWriter {
         for (String cmd : cmds) {
           String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
           String filePath = tachyonHome + "/logs/rerun-" + mRerunCounter.incrementAndGet();
-          //TODO use bounded threads (ExecutorService)
+          // TODO use bounded threads (ExecutorService)
           Thread thread = new Thread(new RecomputeCommand(cmd, filePath));
           thread.setName("recompute-command-" + cmd);
           thread.start();
@@ -296,8 +295,7 @@ public class MasterInfo extends ImageWriter {
       TachyonConf tachyonConf) throws IOException {
     mExecutorService = executorService;
     mTachyonConf = tachyonConf;
-    mUFSDataFolder = mTachyonConf.get(Constants.UNDERFS_DATA_FOLDER,
-        Constants.DEFAULT_DATA_FOLDER);
+    mUFSDataFolder = mTachyonConf.get(Constants.UNDERFS_DATA_FOLDER, Constants.DEFAULT_DATA_FOLDER);
 
     mRawTables = new RawTables(mTachyonConf);
 
@@ -310,8 +308,9 @@ public class MasterInfo extends ImageWriter {
     mStartTimeNSPrefix = mStartTimeMs - (mStartTimeMs % 1000000);
     mJournal = journal;
 
-    mWhitelist = new PrefixList(mTachyonConf.getList(Constants.MASTER_WHITELIST, ",",
-        new LinkedList<String>()));
+    mWhitelist =
+        new PrefixList(mTachyonConf.getList(Constants.MASTER_WHITELIST, ",",
+            new LinkedList<String>()));
     mPinnedInodeFileIds = Collections.synchronizedSet(new HashSet<Integer>());
 
     mJournal.loadImage(this);
@@ -811,8 +810,7 @@ public class MasterInfo extends ImageWriter {
       if (srcInode == null) {
         return false;
       }
-      if (((InodeFolder) dstParentInode)
-          .getChild(dstComponents[dstComponents.length - 1]) != null) {
+      if (((InodeFolder) dstParentInode).getChild(dstComponents[dstComponents.length - 1]) != null) {
         return false;
       }
 
@@ -920,8 +918,7 @@ public class MasterInfo extends ImageWriter {
    * @throws BlockInfoException
    */
   public int cacheBlock(long workerId, long usedBytesOnTier, long storageDirId, long blockId,
-      long length)
-      throws FileDoesNotExistException, BlockInfoException {
+      long length) throws FileDoesNotExistException, BlockInfoException {
     LOG.debug("Cache block: {}",
         CommonUtils.parametersToString(workerId, usedBytesOnTier, blockId, length));
 
@@ -975,8 +972,8 @@ public class MasterInfo extends ImageWriter {
 
   public int createDependency(List<TachyonURI> parents, List<TachyonURI> children,
       String commandPrefix, List<ByteBuffer> data, String comment, String framework,
-      String frameworkVersion, DependencyType dependencyType)
-      throws InvalidPathException, FileDoesNotExistException {
+      String frameworkVersion, DependencyType dependencyType) throws InvalidPathException,
+      FileDoesNotExistException {
     synchronized (mRootLock) {
       LOG.info("ParentList: " + CommonUtils.listToString(parents));
       List<Integer> parentsIdList = getFilesIds(parents);
@@ -1062,8 +1059,7 @@ public class MasterInfo extends ImageWriter {
 
     int maxColumns = mTachyonConf.getInt(Constants.MAX_COLUMNS, 1000);
     if (columns <= 0 || columns >= maxColumns) {
-      throw new TableColumnException("Column " + columns + " should between 0 to "
-          + maxColumns);
+      throw new TableColumnException("Column " + columns + " should between 0 to " + maxColumns);
     }
 
     int id;
@@ -1190,8 +1186,8 @@ public class MasterInfo extends ImageWriter {
         throw new FileDoesNotExistException("FileId " + fileId + " does not exist.");
       }
       ClientBlockInfo ret =
-          ((InodeFile) inode).getClientBlockInfo(BlockInfo.computeBlockIndex(blockId),
-              mTachyonConf);
+          ((InodeFile) inode)
+              .getClientBlockInfo(BlockInfo.computeBlockIndex(blockId), mTachyonConf);
       LOG.debug("getClientBlockInfo: {} : {}", blockId, ret);
       return ret;
     }
@@ -1435,8 +1431,8 @@ public class MasterInfo extends ImageWriter {
         new LinkedList<Pair<InodeFolder, TachyonURI>>();
     synchronized (mRootLock) {
       // TODO: Verify we want to use absolute path.
-      nodesQueue.add(
-          new Pair<InodeFolder, TachyonURI>(mRoot, new TachyonURI(TachyonURI.SEPARATOR)));
+      nodesQueue
+          .add(new Pair<InodeFolder, TachyonURI>(mRoot, new TachyonURI(TachyonURI.SEPARATOR)));
       while (!nodesQueue.isEmpty()) {
         Pair<InodeFolder, TachyonURI> tPair = nodesQueue.poll();
         InodeFolder tFolder = tPair.getFirst();
@@ -1534,8 +1530,8 @@ public class MasterInfo extends ImageWriter {
    * @throws InvalidPathException
    * @throws FileDoesNotExistException
    */
-  public int getNumberOfFiles(TachyonURI path)
-      throws InvalidPathException, FileDoesNotExistException {
+  public int getNumberOfFiles(TachyonURI path) throws InvalidPathException,
+      FileDoesNotExistException {
     Inode inode = getInode(path);
     if (inode == null) {
       throw new FileDoesNotExistException(path.toString());
@@ -1638,8 +1634,7 @@ public class MasterInfo extends ImageWriter {
    * @throws InvalidPathException
    * @throws TableDoesNotExistException
    */
-  public int getRawTableId(TachyonURI path)
-      throws InvalidPathException, TableDoesNotExistException {
+  public int getRawTableId(TachyonURI path) throws InvalidPathException, TableDoesNotExistException {
     Inode inode = getInode(path);
     if (inode == null) {
       throw new TableDoesNotExistException(path.toString());
@@ -1827,8 +1822,8 @@ public class MasterInfo extends ImageWriter {
     mJournal.createEditLog(mCheckpointInfo.getEditTransactionCounter());
     mHeartbeat =
         mExecutorService.submit(new HeartbeatThread("Master Heartbeat",
-            new MasterInfoHeartbeatExecutor(),
-            mTachyonConf.getInt(Constants.MASTER_HEARTBEAT_INTERVAL_MS, Constants.SECOND_MS)));
+            new MasterInfoHeartbeatExecutor(), mTachyonConf.getInt(
+                Constants.MASTER_HEARTBEAT_INTERVAL_MS, Constants.SECOND_MS)));
 
     mRecompute = mExecutorService.submit(new RecomputationScheduler());
   }
@@ -2040,8 +2035,7 @@ public class MasterInfo extends ImageWriter {
    * @throws BlockInfoException
    */
   public long registerWorker(NetAddress workerNetAddress, List<Long> totalBytesOnTiers,
-      List<Long> usedBytesOnTiers, Map<Long, List<Long>> currentBlockIds)
-          throws BlockInfoException {
+      List<Long> usedBytesOnTiers, Map<Long, List<Long>> currentBlockIds) throws BlockInfoException {
     long id = 0;
     long capacityBytes = 0;
     NetAddress workerAddress = new NetAddress(workerNetAddress);
@@ -2233,8 +2227,8 @@ public class MasterInfo extends ImageWriter {
         Inode freeInode = freeInodes.get(i);
 
         if (freeInode.isFile()) {
-          List<Pair<Long, Long>> blockIdWorkerIdList
-              = ((InodeFile) freeInode).getBlockIdWorkerIdPairs();
+          List<Pair<Long, Long>> blockIdWorkerIdList =
+              ((InodeFile) freeInode).getBlockIdWorkerIdPairs();
           synchronized (mWorkers) {
             for (Pair<Long, Long> blockIdWorkerId : blockIdWorkerIdList) {
               MasterWorkerInfo workerInfo = mWorkers.get(blockIdWorkerId.getSecond());

--- a/core/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/core/src/main/java/tachyon/worker/WorkerStorage.java
@@ -628,8 +628,7 @@ public class WorkerStorage {
    * @return used bytes on each storage tier
    */
   private List<Long> getUsedBytesOnTiers() {
-    List<Long> usedBytes = new ArrayList<Long>(StorageLevelAlias.SIZE);
-    Collections.fill(usedBytes, 0L);
+    List<Long> usedBytes = new ArrayList<Long>(Collections.nCopies(StorageLevelAlias.SIZE, 0L));
     for (StorageTier curTier : mStorageTiers) {
       int tier = curTier.getAlias().getValue() - 1;
       usedBytes.set(tier, usedBytes.get(tier) + curTier.getUsedBytes());
@@ -806,8 +805,8 @@ public class WorkerStorage {
   public void register() {
     long id = 0;
     Map<Long, List<Long>> blockIdLists = new HashMap<Long, List<Long>>();
-    List<Long> capacityBytesOnTiers = new ArrayList<Long>(StorageLevelAlias.SIZE);
-    Collections.fill(capacityBytesOnTiers, 0L);
+    List<Long> capacityBytesOnTiers =
+        new ArrayList<Long>(Collections.nCopies(StorageLevelAlias.SIZE, 0L));
     for (StorageTier curStorageTier : mStorageTiers) {
       int tier = curStorageTier.getAlias().getValue() - 1;
       capacityBytesOnTiers.set(tier,

--- a/core/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/core/src/main/java/tachyon/worker/WorkerStorage.java
@@ -245,8 +245,9 @@ public class WorkerStorage {
             LOG.error("Failed to rename from " + midPath + " to " + dstPath);
           }
           mMasterClient.addCheckpoint(mWorkerId, fileId, fileSizeByte, dstPath);
-          int capMbSec = mTachyonConf.getInt(Constants.WORKER_PER_THREAD_CHECKPOINT_CAP_MB_SEC,
-              Constants.SECOND_MS);
+          int capMbSec =
+              mTachyonConf.getInt(Constants.WORKER_PER_THREAD_CHECKPOINT_CAP_MB_SEC,
+                  Constants.SECOND_MS);
           long shouldTakeMs = (long) (1000.0 * fileSizeByte / Constants.MB / capMbSec);
           long currentTimeMs = System.currentTimeMillis();
           if (startCopyTimeMs + shouldTakeMs > currentTimeMs) {
@@ -327,8 +328,8 @@ public class WorkerStorage {
     mUserFolder = CommonUtils.concat(mDataFolder, userTmpFolder);
 
     int checkpointThreads = mTachyonConf.getInt(Constants.WORKER_CHECKPOINT_THREADS, 1);
-    mCheckpointExecutor = Executors.newFixedThreadPool(checkpointThreads,
-        ThreadFactoryUtils.build("checkpoint-%d"));
+    mCheckpointExecutor =
+        Executors.newFixedThreadPool(checkpointThreads, ThreadFactoryUtils.build("checkpoint-%d"));
   }
 
   public void initialize(final NetAddress address) {
@@ -344,8 +345,8 @@ public class WorkerStorage {
 
     String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
     String ufsAddress = mTachyonConf.get(Constants.UNDERFS_ADDRESS, tachyonHome + "/underfs");
-    String ufsWorkerFolder = mTachyonConf.get(Constants.UNDERFS_WORKERS_FOLDER,
-        ufsAddress + "/tachyon/workers");
+    String ufsWorkerFolder =
+        mTachyonConf.get(Constants.UNDERFS_WORKERS_FOLDER, ufsAddress + "/tachyon/workers");
     mUfsWorkerFolder = CommonUtils.concat(ufsWorkerFolder, mWorkerId);
     mUfsWorkerDataFolder = mUfsWorkerFolder + "/data";
     mUfs = UnderFileSystem.get(ufsAddress, mTachyonConf);
@@ -433,9 +434,9 @@ public class WorkerStorage {
       for (StorageDir curStorageDir : curStorageTier.getStorageDirs()) {
         for (Entry<Long, Long> blockSize : curStorageDir.getBlockSizes()) {
           try {
-            mMasterClient.worker_cacheBlock(mWorkerId, getUsedBytesOnTiers().get(curStorageTier
-                .getAlias().getValue() - 1), curStorageDir.getStorageDirId(), blockSize.getKey(),
-                blockSize.getValue());
+            mMasterClient.worker_cacheBlock(mWorkerId,
+                getUsedBytesOnTiers().get(curStorageTier.getAlias().getValue() - 1),
+                curStorageDir.getStorageDirId(), blockSize.getKey(), blockSize.getValue());
           } catch (FileDoesNotExistException e) {
             LOG.error("Block not exist in metadata! blockId:{}", blockSize.getKey());
             swapoutOrphanBlocks(curStorageDir, blockSize.getKey());
@@ -489,8 +490,8 @@ public class WorkerStorage {
    * @throws BlockInfoException
    * @throws IOException
    */
-  public void cacheBlock(long userId, long blockId)
-      throws FileDoesNotExistException, BlockInfoException, IOException {
+  public void cacheBlock(long userId, long blockId) throws FileDoesNotExistException,
+      BlockInfoException, IOException {
     StorageDir storageDir = mTempBlockLocation.remove(new Pair<Long, Long>(userId, blockId));
     if (storageDir == null) {
       throw new FileDoesNotExistException("Block doesn't exist! blockId:" + blockId);
@@ -504,8 +505,10 @@ public class WorkerStorage {
     }
     if (result) {
       long blockSize = storageDir.getBlockSize(blockId);
-      mMasterClient.worker_cacheBlock(mWorkerId, getUsedBytesOnTiers()
-          .get(StorageDirId.getStorageLevelAliasValue(storageDir.getStorageDirId()) - 1),
+      mMasterClient.worker_cacheBlock(
+          mWorkerId,
+          getUsedBytesOnTiers().get(
+              StorageDirId.getStorageLevelAliasValue(storageDir.getStorageDirId()) - 1),
           storageDir.getStorageDirId(), blockId, blockSize);
     }
   }
@@ -674,8 +677,8 @@ public class WorkerStorage {
         addedBlockIds.put(storageDir.getStorageDirId(), storageDir.getAddedBlockIdList());
       }
     }
-    return mMasterClient
-        .worker_heartbeat(mWorkerId, getUsedBytesOnTiers(), removedBlockIds, addedBlockIds);
+    return mMasterClient.worker_heartbeat(mWorkerId, getUsedBytesOnTiers(), removedBlockIds,
+        addedBlockIds);
   }
 
   /**
@@ -701,16 +704,16 @@ public class WorkerStorage {
         index = level - 1;
       }
 
-      StorageLevelAlias storageLevelAlias = mTachyonConf.getEnum(tierLevelAliasProp,
-          StorageLevelAlias.MEM);
+      StorageLevelAlias storageLevelAlias =
+          mTachyonConf.getEnum(tierLevelAliasProp, StorageLevelAlias.MEM);
 
       String[] dirPaths = mTachyonConf.get(tierLevelDirPath, "/mnt/ramdisk").split(",");
       for (int i = 0; i < dirPaths.length; i ++) {
         dirPaths[i] = dirPaths[i].trim();
       }
 
-      String tierDirsQuota = mTachyonConf.get(tierDirsQuotaProp,
-          Constants.DEFAULT_STORAGE_TIER_DIR_QUOTA[index]);
+      String tierDirsQuota =
+          mTachyonConf.get(tierDirsQuotaProp, Constants.DEFAULT_STORAGE_TIER_DIR_QUOTA[index]);
 
       for (int i = 0; i < dirPaths.length; i ++) {
         dirPaths[i] = dirPaths[i].trim();
@@ -724,8 +727,9 @@ public class WorkerStorage {
           j ++;
         }
       }
-      StorageTier curTier = new StorageTier(level, storageLevelAlias, dirPaths, dirCapacities,
-          mDataFolder, mUserFolder, nextStorageTier, null, mTachyonConf); // TODO add conf for UFS
+      StorageTier curTier =
+          new StorageTier(level, storageLevelAlias, dirPaths, dirCapacities, mDataFolder,
+              mUserFolder, nextStorageTier, null, mTachyonConf); // TODO add conf for UFS
       curTier.initialize();
       mCapacityBytes += curTier.getCapacityBytes();
       mStorageTiers.set(level, curTier);
@@ -769,8 +773,8 @@ public class WorkerStorage {
     StorageDir storageDir = lockBlock(blockId, userId);
     if (storageDir == null) {
       return false;
-    } else if (StorageDirId.getStorageLevelAliasValue(storageDir.getStorageDirId())
-        != mStorageTiers.get(0).getAlias().getValue()) {
+    } else if (StorageDirId.getStorageLevelAliasValue(storageDir.getStorageDirId()) != mStorageTiers
+        .get(0).getAlias().getValue()) {
       long blockSize = storageDir.getBlockSize(blockId);
       StorageDir dstStorageDir = requestSpace(null, userId, blockSize);
       if (dstStorageDir == null) {
@@ -819,8 +823,8 @@ public class WorkerStorage {
     while (id == 0) {
       try {
         id =
-            mMasterClient.worker_register(mWorkerAddress,
-                capacityBytesOnTiers, getUsedBytesOnTiers(), blockIdLists);
+            mMasterClient.worker_register(mWorkerAddress, capacityBytesOnTiers,
+                getUsedBytesOnTiers(), blockIdLists);
       } catch (BlockInfoException e) {
         LOG.error(e.getMessage(), e);
         id = 0;
@@ -865,8 +869,8 @@ public class WorkerStorage {
   }
 
   /**
-   * Request space from the worker, and expecting worker return the appropriate StorageDir which
-   * has enough space for the requested space size
+   * Request space from the worker, and expecting worker return the appropriate StorageDir which has
+   * enough space for the requested space size
    *
    * @param dirCandidate The StorageDir in which the space will be allocated.
    * @param userId The id of the user who send the request

--- a/core/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/core/src/main/java/tachyon/worker/WorkerStorage.java
@@ -306,10 +306,10 @@ public class WorkerStorage {
 
   /**
    * Main logic behind the worker process.
-   * 
+   *
    * This object is lazily initialized. Before an object of this call should be used,
    * {@link #initialize} must be called.
-   * 
+   *
    * @param masterAddress The TachyonMaster's address
    * @param executorService
    * @param tachyonConf The instance of TachyonConf to be used. If null the instantiate new one.
@@ -370,7 +370,7 @@ public class WorkerStorage {
 
   /**
    * Update the latest block access time on the worker.
-   * 
+   *
    * @param blockId The id of the block
    */
   void accessBlock(long blockId) {
@@ -382,13 +382,13 @@ public class WorkerStorage {
 
   /**
    * Add the checkpoint information of a file. The information is from the user <code>userId</code>.
-   * 
+   *
    * This method is normally triggered from {@link tachyon.client.FileOutStream#close()} if and only
    * if {@link tachyon.client.WriteType#isThrough()} is true. The current implementation of
    * checkpointing is that through {@link tachyon.client.WriteType} operations write to
    * {@link tachyon.UnderFileSystem} on the client's write path, but under a user temp directory
    * (temp directory is defined in the worker as {@link #getUserUfsTempFolder(long)}).
-   * 
+   *
    * @param userId The user id of the client who send the notification
    * @param fileId The id of the checkpointed file
    * @throws FileDoesNotExistException
@@ -420,7 +420,7 @@ public class WorkerStorage {
 
   /**
    * Report blocks on the worker when initializing worker storage
-   * 
+   *
    * @throws IOException
    * @throws BlockInfoException
    */
@@ -448,7 +448,7 @@ public class WorkerStorage {
 
   /**
    * Notify the worker to checkpoint the file asynchronously.
-   * 
+   *
    * @param fileId The id of the file
    * @return true if succeed, false otherwise
    * @throws IOException
@@ -472,17 +472,17 @@ public class WorkerStorage {
 
   /**
    * Notify the worker the block is cached.
-   * 
+   *
    * This call is called remotely from {@link tachyon.client.TachyonFS#cacheBlock(long)} which is
    * only ever called from {@link tachyon.client.BlockOutStream#close()} (though its a public api so
    * anyone could call it). There are a few interesting preconditions for this to work.
-   * 
+   *
    * 1) Client process writes to files locally under a tachyon defined temp directory. 2) Worker
    * process is on the same node as the client 3) Client is talking to the local worker directly
-   * 
+   *
    * If all conditions are true, then and only then can this method ever be called; all operations
    * work on local files.
-   * 
+   *
    * @param userId The user id of the client who send the notification
    * @param blockId The id of the block
    * @throws FileDoesNotExistException
@@ -512,13 +512,13 @@ public class WorkerStorage {
 
   /**
    * Cancel the block which is being written by some user
-   * 
+   *
    * @param userId The id of the user who wants to cancel the block
    * @param blockId The id of the block that is cancelled
    */
   public void cancelBlock(long userId, long blockId) {
     StorageDir storageDir = mTempBlockLocation.remove(new Pair<Long, Long>(userId, blockId));
-    
+
     if (storageDir != null) {
       mUserIdToTempBlockIds.remove(userId, blockId);
       try {
@@ -553,7 +553,7 @@ public class WorkerStorage {
 
   /**
    * Remove a block from Tachyon cache space.
-   * 
+   *
    * @param blockId The block to be removed.
    */
   private void freeBlock(long blockId) {
@@ -573,10 +573,10 @@ public class WorkerStorage {
 
   /**
    * Remove blocks from Tachyon cache space.
-   * 
+   *
    * This is triggered when the worker heartbeats to the master, which sends a
    * {@link tachyon.thrift.Command} with type {@link tachyon.thrift.CommandType#Free}
-   * 
+   *
    * @param blockIds The id list of blocks to be removed.
    */
   public void freeBlocks(List<Long> blockIds) {
@@ -587,7 +587,7 @@ public class WorkerStorage {
 
   /**
    * Get StorageDir which contains specified block
-   * 
+   *
    * @param blockId the id of the block
    * @return StorageDir which contains the block
    */
@@ -611,7 +611,7 @@ public class WorkerStorage {
 
   /**
    * Get used bytes of current WorkerStorage
-   * 
+   *
    * @return used bytes of current WorkerStorage
    */
   private long getUsedBytes() {
@@ -621,35 +621,33 @@ public class WorkerStorage {
     }
     return usedBytes;
   }
-  
+
   /**
    * Get used bytes on each storage tier
-   * 
+   *
    * @return used bytes on each storage tier
    */
   private List<Long> getUsedBytesOnTiers() {
-    List<Long> usedBytes = new ArrayList<Long>(StorageLevelAlias.values().length);
-    for (int i = 0; i < StorageLevelAlias.values().length; i ++) {
-      usedBytes.add((long) 0);
-    }
+    List<Long> usedBytes = new ArrayList<Long>(StorageLevelAlias.SIZE);
+    Collections.fill(usedBytes, 0L);
     for (StorageTier curTier : mStorageTiers) {
-      usedBytes.set(curTier.getAlias().getValue() - 1, usedBytes.get(curTier.getAlias()
-          .getValue() - 1) + curTier.getUsedBytes());
+      int tier = curTier.getAlias().getValue() - 1;
+      usedBytes.set(tier, usedBytes.get(tier) + curTier.getUsedBytes());
     }
     return usedBytes;
   }
 
   /**
    * Get the user temporary folder in the under file system of the specified user.
-   * 
+   *
    * This method is a wrapper around {@link tachyon.Users#getUserUfsTempFolder(long)}, and as such
    * should be referentially transparent with {@link Users#getUserUfsTempFolder(long)}. In the
    * context of {@code this}, this call will output the result of path concat of
    * {@link #mUfsWorkerFolder} with the provided {@literal userId}.
-   * 
+   *
    * This temp folder generated lives inside the {@link tachyon.UnderFileSystem}, and as such, will
    * be stored remotely, most likely on disk.
-   * 
+   *
    * @param userId The id of the user
    * @return The user temporary folder in the under file system
    */
@@ -662,7 +660,7 @@ public class WorkerStorage {
   /**
    * Heartbeat with the TachyonMaster. Send the removed block list and added block list to the
    * Master.
-   * 
+   *
    * @return The Command received from the Master
    * @throws IOException
    */
@@ -683,7 +681,7 @@ public class WorkerStorage {
 
   /**
    * Initialize StorageTiers on current WorkerStorage
-   * 
+   *
    * @throws IOException
    */
   public void initializeStorageTier() throws IOException {
@@ -738,13 +736,13 @@ public class WorkerStorage {
 
   /**
    * Lock the block by some user
-   * 
+   *
    * Used internally to make sure blocks are unmodified, but also used in
    * {@link tachyon.client.TachyonFS} for caching blocks locally for users. When a user tries to
    * read a block ({@link tachyon.client.TachyonFile#readByteBuffer(int)} ()}), the client will
    * attempt to cache the block on the local users's node, while the user is reading from the local
    * block, the given block is locked and unlocked once read.
-   * 
+   *
    * @param blockId The id of the block
    * @param userId The id of the user who locks the block
    * @return the StorageDir in which the block is locked
@@ -763,7 +761,7 @@ public class WorkerStorage {
 
   /**
    * If the block is not on top StorageTier, promote block to top StorageTier
-   * 
+   *
    * @param blockId the id of the block
    * @return true if success, false otherwise
    */
@@ -808,14 +806,12 @@ public class WorkerStorage {
   public void register() {
     long id = 0;
     Map<Long, List<Long>> blockIdLists = new HashMap<Long, List<Long>>();
-    List<Long> capacityBytesOnTiers = new ArrayList<Long>(StorageLevelAlias.values().length);
-    
-    for (int i = 0; i < StorageLevelAlias.values().length; i ++) {
-      capacityBytesOnTiers.add((long) 0);
-    }
+    List<Long> capacityBytesOnTiers = new ArrayList<Long>(StorageLevelAlias.SIZE);
+    Collections.fill(capacityBytesOnTiers, 0L);
     for (StorageTier curStorageTier : mStorageTiers) {
-      capacityBytesOnTiers.set(curStorageTier.getAlias().getValue() - 1, capacityBytesOnTiers
-          .get(curStorageTier.getAlias().getValue() - 1) + curStorageTier.getCapacityBytes());
+      int tier = curStorageTier.getAlias().getValue() - 1;
+      capacityBytesOnTiers.set(tier,
+          capacityBytesOnTiers.get(tier) + curStorageTier.getCapacityBytes());
       for (StorageDir curStorageDir : curStorageTier.getStorageDirs()) {
         Set<Long> blockSet = curStorageDir.getBlockIds();
         blockIdLists.put(curStorageDir.getStorageDirId(), new ArrayList<Long>(blockSet));
@@ -824,7 +820,7 @@ public class WorkerStorage {
     while (id == 0) {
       try {
         id =
-            mMasterClient.worker_register(mWorkerAddress, 
+            mMasterClient.worker_register(mWorkerAddress,
                 capacityBytesOnTiers, getUsedBytesOnTiers(), blockIdLists);
       } catch (BlockInfoException e) {
         LOG.error(e.getMessage(), e);
@@ -841,14 +837,14 @@ public class WorkerStorage {
 
   /**
    * Get temporary file path for some block, it is used to choose appropriate StorageDir for some
-   * block file with specified initial size. 
-   * 
+   * block file with specified initial size.
+   *
    * @param userId the id of the user who wants to write the file
    * @param blockId the id of the block
-   * @param initialBytes the initial size allocated for the block 
+   * @param initialBytes the initial size allocated for the block
    * @return the temporary path of the block file
    * @throws OutOfSpaceException
-   * @throws FileAlreadyExistException 
+   * @throws FileAlreadyExistException
    */
   public String requestBlockLocation(long userId, long blockId, long initialBytes)
       throws OutOfSpaceException, FileAlreadyExistException {
@@ -872,7 +868,7 @@ public class WorkerStorage {
   /**
    * Request space from the worker, and expecting worker return the appropriate StorageDir which
    * has enough space for the requested space size
-   * 
+   *
    * @param dirCandidate The StorageDir in which the space will be allocated.
    * @param userId The id of the user who send the request
    * @param requestBytes The requested space size, in bytes
@@ -914,12 +910,12 @@ public class WorkerStorage {
   /**
    * Request space from the specified StorageDir, it is used for requesting space for the block
    * which is partially written in some StorageDir
-   * 
+   *
    * @param userId The id of the user who send the request
    * @param blockId The id of the block that the space is allocated for
    * @param requestBytes The requested space size, in bytes
    * @return true if succeed, false otherwise
-   * @throws FileDoesNotExistException 
+   * @throws FileDoesNotExistException
    */
   public boolean requestSpace(long userId, long blockId, long requestBytes)
       throws FileDoesNotExistException {


### PR DESCRIPTION
A follow up to #655. Adds a size field to the StorageLevelAlias enum since it is used a few times. Also fills empty lists by using nCopies.