### PR TITLE
Fix broken SNAPSHOT builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,9 @@
             <exclude>**/src/main/findbugs/*</exclude>
             <exclude>**/src/main/resources/tachyon_checks*</exclude>
             <exclude>**/src/main/assembly/*</exclude>
+            
+            <!-- Snapshot Builds insist on creating a local Maven repo in the working copy -->
+            <exclude>**/local-m2-repo/**/*</exclude>
 
             <!-- Documentation Exclusions -->
             <exclude>**/docs/**/*</exclude>


### PR DESCRIPTION
This is an alternative to PR #681 which fixes the license plugin for the SNAPSHOT builds rather than ripping it out as that PR suggests.

The SNAPSHOT builds insist on using a local maven repository inside of
the working copy which means the license plugin sees the artifacts in
those directories and rejects them as not having a license (see my commentary on #681)

This commit simply adds the relevant path to the excludes list.  I set up
my local environment to create a local maven repository within the
working copy as the SNAPSHOT builds do and verified that mvn validate now passes