### PR TITLE
Fix bug with UIWebServer getting the wrong conf (TACHYON-286)

### DIFF
--- a/core/src/main/java/tachyon/master/TachyonMaster.java
+++ b/core/src/main/java/tachyon/master/TachyonMaster.java
@@ -228,7 +228,7 @@ public class TachyonMaster {
 
     mWebServer =
         new UIWebServer("Tachyon Master Server", new InetSocketAddress(
-            NetworkUtils.getFqdnHost(mMasterAddress), mWebPort), mMasterInfo);
+            NetworkUtils.getFqdnHost(mMasterAddress), mWebPort), mMasterInfo, mTachyonConf);
 
     mMasterServiceHandler = new MasterServiceHandler(mMasterInfo);
     MasterService.Processor<MasterServiceHandler> masterServiceProcessor =

--- a/core/src/main/java/tachyon/web/UIWebServer.java
+++ b/core/src/main/java/tachyon/web/UIWebServer.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 
 import tachyon.Constants;
@@ -55,11 +56,14 @@ public class UIWebServer {
    * @param serverName Name of the server
    * @param address Address of the server
    * @param masterInfo MasterInfo for the tachyon filesystem this UIWebServer supports
+   * @param conf Tachyon configuration
    */
-  public UIWebServer(String serverName, InetSocketAddress address, MasterInfo masterInfo) {
+  public UIWebServer(String serverName, InetSocketAddress address, MasterInfo masterInfo, 
+      TachyonConf conf) {
+    Preconditions.checkNotNull(conf, "Configuration cannot be null");
     mAddress = address;
     mServerName = serverName;
-    mTachyonConf = new TachyonConf();
+    mTachyonConf = conf;
 
     QueuedThreadPool threadPool = new QueuedThreadPool();
     int webThreadCount = mTachyonConf.getInt(Constants.MASTER_WEB_THREAD_COUNT, 1);
@@ -111,6 +115,10 @@ public class UIWebServer {
   public void startWebServer() {
     try {
       mServer.start();
+      if (mAddress.getPort() == 0) {
+        mAddress = new InetSocketAddress(mAddress.getHostName(), 
+            mServer.getConnectors()[0].getLocalPort());
+      }
       LOG.info(mServerName + " started @ " + mAddress);
     } catch (Exception e) {
       throw Throwables.propagate(e);

--- a/core/src/test/java/tachyon/master/LocalTachyonMaster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonMaster.java
@@ -92,6 +92,9 @@ public final class LocalTachyonMaster {
 
     tachyonConf.set(Constants.MASTER_MIN_WORKER_THREADS, "1");
     tachyonConf.set(Constants.MASTER_MAX_WORKER_THREADS, "100");
+    
+    // If tests fail to connect they should fail early rather than using the default ridiculously high retries
+    tachyonConf.set(Constants.MASTER_RETRY_COUNT, "3");
 
     tachyonConf.set(Constants.MASTER_WEB_THREAD_COUNT, "1");
     tachyonConf.set(Constants.WEB_RESOURCES, System.getProperty("user.dir") + "/src/main/webapp");


### PR DESCRIPTION
After the configuration changes I found that tests were hanging in my
environment and looking at the logs the web server was failing to start
properly because it wasn't respecting the test configuration that
LocalTachyonMaster created.

The problem was that UIWebServer simply creates a new TachyonConf
instance and thus gets the default values rather than it being passed
the TachyonConf object by the TachyonMaster to which it belongs.  This
commit simply changes the behaviour to do that.

It also improves the logging when the web server starts under a test
environment (port = 0) so it actually prints the port chosen for the web
server.