### PR TITLE
Fix corner case with killAll

### DIFF
--- a/bin/tachyon
+++ b/bin/tachyon
@@ -90,7 +90,7 @@ function killAll {
 
   keyword=$1
   count=0
-  for pid in `ps -A -o pid,command | grep -i "[j]ava" | grep $keyword | awk '{print $1}'`; do
+  for pid in `ps -Aww -o pid,command | grep -i "[j]ava" | grep $keyword | awk '{print $1}'`; do
     kill -15 "$pid" > /dev/null 2>&1
     local cnt=30
     while kill -0 "$pid" > /dev/null 2>&1; do


### PR DESCRIPTION
In the event the command line is very long and the keyword being searched
for runs out of the column width, killAll fails to kill the appropriate
daemon.  This is fixed by simply adding "ww" to the 'ps' command to
force unlimited width.