### PR TITLE
Workerslaunchingspeed -   Several patches to fix bin/tachyon-workers.sh to speed up launching of workers on a cluster.

### DIFF
--- a/bin/tachyon
+++ b/bin/tachyon
@@ -106,7 +106,7 @@ function killAll {
     done
     count=`expr $count + 1`
   done
-  echo "Killed $count processes"
+  echo "Killed $count processes on `hostname`"
 }
 
 function copyDir {

--- a/bin/tachyon-workers.sh
+++ b/bin/tachyon-workers.sh
@@ -22,8 +22,12 @@ TACHYON_LIBEXEC_DIR=${TACHYON_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
 HOSTLIST=$TACHYON_CONF_DIR/workers
 
 for worker in `cat "$HOSTLIST"|sed  "s/#.*$//;/^$/d"`; do
-  echo -n "Connection to $worker as $USER... "
-  ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t $worker $LAUNCHER $"${@// /\\ }" 2>&1
+  if [ -n "${TACHYON_SSH_FOREGROUND}" ]; then
+    echo -n "Connection to $worker as $USER... "
+    ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t $worker $LAUNCHER $"${@// /\\ }" 2>&1
+  else
+    ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t $worker $LAUNCHER $"${@// /\\ }" 2>&1 &
+  fi
   if [ "$TACHYON_WORKER_SLEEP" != "" ]; then
     sleep $TACHYON_WORKER_SLEEP
   fi

--- a/bin/tachyon-workers.sh
+++ b/bin/tachyon-workers.sh
@@ -24,7 +24,9 @@ HOSTLIST=$TACHYON_CONF_DIR/workers
 for worker in `cat "$HOSTLIST"|sed  "s/#.*$//;/^$/d"`; do
   echo -n "Connection to $worker as $USER... "
   ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t $worker $LAUNCHER $"${@// /\\ }" 2>&1
-  sleep 0.02
+  if [ "$TACHYON_WORKER_SLEEP" != "" ]; then
+    sleep $TACHYON_WORKER_SLEEP
+  fi
 done
 
 wait

--- a/conf/tachyon-env.sh.template
+++ b/conf/tachyon-env.sh.template
@@ -55,6 +55,8 @@ export TACHYON_UNDERFS_HDFS_IMPL=org.apache.hadoop.hdfs.DistributedFileSystem
 export TACHYON_WORKER_MAX_WORKER_THREADS=2048
 export TACHYON_MASTER_MAX_WORKER_THREADS=2048
 
+export TACHYON_WORKER_SLEEP="0.02"
+
 CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export TACHYON_JAVA_OPTS+="

--- a/conf/tachyon-env.sh.template
+++ b/conf/tachyon-env.sh.template
@@ -55,6 +55,7 @@ export TACHYON_UNDERFS_HDFS_IMPL=org.apache.hadoop.hdfs.DistributedFileSystem
 export TACHYON_WORKER_MAX_WORKER_THREADS=2048
 export TACHYON_MASTER_MAX_WORKER_THREADS=2048
 
+export TACHYON_SSH_FOREGROUND="yes"
 export TACHYON_WORKER_SLEEP="0.02"
 
 CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
Several patches to fix bin/tachyon-workers.sh to speed up launching of workers on a cluster.