### PR TITLE
Remove local Maven repo excludes from license plugin. (Reverts #682).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,9 +299,6 @@
             <exclude>**/src/main/findbugs/*</exclude>
             <exclude>**/src/main/resources/tachyon_checks*</exclude>
             <exclude>**/src/main/assembly/*</exclude>
-            
-            <!-- Snapshot Builds insist on creating a local Maven repo in the working copy -->
-            <exclude>**/local-m2-repo/**/*</exclude>
 
             <!-- Documentation Exclusions -->
             <exclude>**/docs/**/*</exclude>


### PR DESCRIPTION
Could probably just do a git revert if that seems cleaner.

I don't think the excludes should be there since the maven repo isn't something in the provided/auto-generated by the default Tachyon codebase.

@rvesse what do you think?