### PR TITLE
make default block size consistant with TachyonConf and code clean

### DIFF
--- a/core/src/main/java/tachyon/client/AbstractTachyonFS.java
+++ b/core/src/main/java/tachyon/client/AbstractTachyonFS.java
@@ -41,7 +41,7 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
    */
   public synchronized int createFile(TachyonURI path) throws IOException {
     long defaultBlockSize = mTachyonConf.getBytes(Constants.USER_DEFAULT_BLOCK_SIZE_BYTE,
-        Constants.GB);
+        Constants.DEFAULT_BLOCK_SIZE_BYTE);
     return createFile(path, defaultBlockSize);
   }
 

--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -165,9 +165,6 @@ public class TachyonFS extends AbstractTachyonFS {
 
   private TachyonURI mRootUri = null;
 
-  // Available memory space for this client.
-  private Long mAvailableSpaceBytes;
-
   private TachyonFS(TachyonConf tachyonConf) throws IOException {
     super(tachyonConf);
 
@@ -176,7 +173,6 @@ public class TachyonFS extends AbstractTachyonFS {
 
     mMasterAddress = new InetSocketAddress(masterHost, masterPort);
     mZookeeperMode = mTachyonConf.getBoolean(Constants.USE_ZOOKEEPER, false);
-    mAvailableSpaceBytes = 0L;
 
     mExecutorService =
         Executors.newFixedThreadPool(2, ThreadFactoryUtils.daemon("client-heartbeat-%d"));

--- a/core/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/core/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -250,7 +250,8 @@ abstract class AbstractTFS extends FileSystem {
 
   @Override
   public long getDefaultBlockSize() {
-    return getConf().getLong("fs.local.block.size", Constants.DEFAULT_BLOCK_SIZE_BYTE);
+    return mTachyonConf.getBytes(Constants.USER_DEFAULT_BLOCK_SIZE_BYTE,
+        Constants.DEFAULT_BLOCK_SIZE_BYTE);
   }
 
   @Override

--- a/core/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/core/src/main/java/tachyon/worker/WorkerStorage.java
@@ -299,7 +299,7 @@ public class WorkerStorage {
   /** Mapping from temporary block Information to StorageDir in which the block is */
   private final Map<Pair<Long, Long>, StorageDir> mTempBlockLocation = Collections
       .synchronizedMap(new HashMap<Pair<Long, Long>, StorageDir>());
-  /** Mapping from user id to ids of temporary blocks which are being written by the user */
+  /** Mapping from user id to id list of temporary blocks which are being written by the user */
   private final Multimap<Long, Long> mUserIdToTempBlockIds = Multimaps
       .synchronizedMultimap(HashMultimap.<Long, Long>create());
 
@@ -613,19 +613,6 @@ public class WorkerStorage {
   }
 
   /**
-   * Get used bytes of current WorkerStorage
-   *
-   * @return used bytes of current WorkerStorage
-   */
-  private long getUsedBytes() {
-    long usedBytes = 0;
-    for (StorageTier curTier : mStorageTiers) {
-      usedBytes += curTier.getUsedBytes();
-    }
-    return usedBytes;
-  }
-
-  /**
    * Get used bytes on each storage tier
    *
    * @return used bytes on each storage tier
@@ -695,7 +682,6 @@ public class WorkerStorage {
     }
     StorageTier nextStorageTier = null;
     for (int level = maxStorageLevels - 1; level >= 0; level --) {
-
       String tierLevelAliasProp = "tachyon.worker.hierarchystore.level" + level + ".alias";
       String tierLevelDirPath = "tachyon.worker.hierarchystore.level" + level + ".dirs.path";
       String tierDirsQuotaProp = "tachyon.worker.hierarchystore.level" + level + ".dirs.quota";
@@ -985,7 +971,7 @@ public class WorkerStorage {
    * Unlock the block
    * 
    * Used internally to make sure blocks are unmodified, but also used in
-   * {@link tachyon.client.TachyonFS} for cacheing blocks locally for users. When a user tries to
+   * {@link tachyon.client.TachyonFS} for caching blocks locally for users. When a user tries to
    * read a block ({@link tachyon.client.TachyonFile#readByteBuffer(int)}), the client will attempt
    * to cache the block on the local users's node, while the user is reading from the local block,
    * the given block is locked and unlocked once read.

--- a/core/src/main/java/tachyon/worker/netty/NettyDataServer.java
+++ b/core/src/main/java/tachyon/worker/netty/NettyDataServer.java
@@ -17,7 +17,6 @@ package tachyon.worker.netty;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.concurrent.ThreadFactory;
 
 import io.netty.bootstrap.ServerBootstrap;

--- a/core/src/test/java/tachyon/hadoop/fs/TestDFSIO.java
+++ b/core/src/test/java/tachyon/hadoop/fs/TestDFSIO.java
@@ -108,7 +108,7 @@ public class TestDFSIO implements Tool {
       + " [-rootDir]";
 
   // Constants for Tachyon
-  private static final int BLOCK_SIZE = 30;
+  private static final int BLOCK_SIZE = 8192;
   private Configuration config;
   private static LocalTachyonCluster mLocalTachyonCluster = null;
   private static URI mLocalTachyonClusterUri = null;


### PR DESCRIPTION
make default block size consistant with TachyonConf
remove mAvailableBytes in TachyonFS which is not used
remove unused getUsedBytess method in WorkerStorage
remove unused import