### PR TITLE
SleepMs can optionally propagate interrupts.

### DIFF
--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -232,7 +232,7 @@ public class MasterInfo extends ImageWriter {
           if (hasLostFiles) {
             LOG.info("HasLostFiles, but no job can be launched.");
           }
-          CommonUtils.sleepMs(LOG, Constants.SECOND_MS);
+          CommonUtils.sleepMs(LOG, Constants.SECOND_MS, true);
         }
       }
     }

--- a/core/src/main/java/tachyon/util/CommonUtils.java
+++ b/core/src/main/java/tachyon/util/CommonUtils.java
@@ -474,10 +474,17 @@ public final class CommonUtils {
   }
 
   public static void sleepMs(Logger logger, long timeMs) {
+    sleepMs(logger, timeMs, false);
+  }
+
+  public static void sleepMs(Logger logger, long timeMs, boolean shouldInterrupt) {
     try {
       Thread.sleep(timeMs);
     } catch (InterruptedException e) {
       logger.warn(e.getMessage(), e);
+      if (shouldInterrupt) {
+        Thread.currentThread().interrupt();
+      }
     }
   }
 

--- a/core/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/core/src/main/java/tachyon/worker/WorkerStorage.java
@@ -181,7 +181,7 @@ public class WorkerStorage {
 
           if (fileId == -1) {
             LOG.debug("Thread {} has nothing to checkpoint. Sleep for 1 sec.", mId);
-            CommonUtils.sleepMs(LOG, Constants.SECOND_MS);
+            CommonUtils.sleepMs(LOG, Constants.SECOND_MS, true);
             continue;
           }
 
@@ -255,7 +255,7 @@ public class WorkerStorage {
             LOG.info("Checkpointed last file " + fileId + " took "
                 + (currentTimeMs - startCopyTimeMs) + " ms. Need to sleep " + shouldSleepMs
                 + " ms.");
-            CommonUtils.sleepMs(LOG, shouldSleepMs);
+            CommonUtils.sleepMs(LOG, shouldSleepMs, true);
           }
         } catch (IOException e) {
           LOG.error(e.getMessage(), e);


### PR DESCRIPTION
The sleepMs utility catches interrupts, but there are places where we rely on the thread being interrupted to break out of a while loop.

One case is during worker shutdown, currently if the workerStorage checkpoint threads are interrupted, they will not stop and the executor will wait 5 seconds before terminating them. As a side effect, our unit tests which spin up and down tachyon clusters take 5 additional seconds each (partially avoided by using BeforeClass/AfterClass). Unit tests after this change take around 5 minutes to run on my machine (previously 20+).