### PR TITLE
Lock block before copying it

### DIFF
--- a/core/src/main/java/tachyon/worker/hierarchy/StorageDir.java
+++ b/core/src/main/java/tachyon/worker/hierarchy/StorageDir.java
@@ -635,8 +635,16 @@ public final class StorageDir {
    * @throws IOException
    */
   public boolean moveBlock(long blockId, StorageDir dstDir) throws IOException {
-    if (copyBlock(blockId, dstDir)) {
-      return deleteBlock(blockId);
+    if (lockBlock(blockId, Users.MIGRATE_DATA_USER_ID)) {
+      boolean result = false;
+      try {
+        result = copyBlock(blockId, dstDir);
+      } finally {
+        unlockBlock(blockId, Users.MIGRATE_DATA_USER_ID);
+      }
+      if (result) {
+        return deleteBlock(blockId);
+      }
     }
     return false;
   }

--- a/core/src/main/java/tachyon/worker/hierarchy/StorageDir.java
+++ b/core/src/main/java/tachyon/worker/hierarchy/StorageDir.java
@@ -557,7 +557,7 @@ public final class StorageDir {
    * 
    * @throws IOException
    */
-  public void initailize() throws IOException {
+  public void initialize() throws IOException {
     String dataPath = mDataPath.toString();
     if (!mFs.exists(dataPath)) {
       LOG.info("Data folder {} does not exist. Creating a new one.", mDataPath);

--- a/core/src/main/java/tachyon/worker/hierarchy/StorageTier.java
+++ b/core/src/main/java/tachyon/worker/hierarchy/StorageTier.java
@@ -202,7 +202,7 @@ public class StorageTier {
    */
   public void initialize() throws IOException {
     for (StorageDir dir : mDirs) {
-      dir.initailize();
+      dir.initialize();
     }
   }
 

--- a/core/src/test/java/tachyon/worker/hierarchy/AllocateStrategyTest.java
+++ b/core/src/test/java/tachyon/worker/hierarchy/AllocateStrategyTest.java
@@ -131,7 +131,7 @@ public class AllocateStrategyTest {
   }
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
-    dir.initailize();
+    dir.initialize();
     UnderFileSystem ufs = dir.getUfs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));

--- a/core/src/test/java/tachyon/worker/hierarchy/EvictStrategyTest.java
+++ b/core/src/test/java/tachyon/worker/hierarchy/EvictStrategyTest.java
@@ -142,7 +142,7 @@ public class EvictStrategyTest {
   }
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
-    dir.initailize();
+    dir.initialize();
     UnderFileSystem ufs = dir.getUfs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));

--- a/core/src/test/java/tachyon/worker/hierarchy/StorageDirTest.java
+++ b/core/src/test/java/tachyon/worker/hierarchy/StorageDirTest.java
@@ -135,7 +135,7 @@ public class StorageDirTest {
   }
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
-    dir.initailize();
+    dir.initialize();
     UnderFileSystem ufs = dir.getUfs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));


### PR DESCRIPTION
In method StorageDir.moveBlock, we make sure the block is locked during copying.