### PR TITLE
Fix TachyonURI authority parsing (TACHYON-289)

### DIFF
--- a/core/src/main/java/tachyon/TachyonURI.java
+++ b/core/src/main/java/tachyon/TachyonURI.java
@@ -63,8 +63,7 @@ public final class TachyonURI implements Comparable<TachyonURI> {
     }
 
     // parse uri authority, if any
-    if (pathStr.startsWith("//", start) && (pathStr.length() - start > 2)
-        && pathStr.substring(start).indexOf(":") != -1) { // has authority
+    if (pathStr.startsWith("//", start) && (pathStr.length() - start > 2)) { // has authority
       int nextSlash = pathStr.indexOf('/', start + 2);
       int authEnd = nextSlash > 0 ? nextSlash : pathStr.length();
       authority = pathStr.substring(start + 2, authEnd);

--- a/core/src/main/java/tachyon/TachyonURI.java
+++ b/core/src/main/java/tachyon/TachyonURI.java
@@ -386,10 +386,12 @@ public final class TachyonURI implements Comparable<TachyonURI> {
     StringBuffer sb = new StringBuffer();
     if (mUri.getScheme() != null) {
       sb.append(mUri.getScheme());
-      sb.append(":");
+      sb.append("://");
     }
     if (mUri.getAuthority() != null) {
-      sb.append("//");
+      if (mUri.getScheme() == null) {
+        sb.append("//");
+      }
       sb.append(mUri.getAuthority());
     }
     if (mUri.getPath() != null) {

--- a/core/src/main/java/tachyon/util/NetworkUtils.java
+++ b/core/src/main/java/tachyon/util/NetworkUtils.java
@@ -104,7 +104,10 @@ public final class NetworkUtils {
     }
 
     if (path.hasAuthority()) {
-      String authority = resolveHostName(path.getHost()) + ":" + path.getPort();
+      String authority = resolveHostName(path.getHost());
+      if (path.getPort() != -1) {
+        authority += ":" + path.getPort();
+      }
       return new TachyonURI(path.getScheme(), authority, path.getPath());
     } else {
       return path;

--- a/core/src/test/java/tachyon/TachyonURITest.java
+++ b/core/src/test/java/tachyon/TachyonURITest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
  */
 public class TachyonURITest {
   @Test
-  public void basicTest() {
+  public void basicTest1() {
     TachyonURI uri = new TachyonURI("tachyon://localhost:19998/xy z/a b c");
     Assert.assertEquals("localhost:19998", uri.getAuthority());
     Assert.assertEquals(2, uri.getDepth());
@@ -41,6 +41,28 @@ public class TachyonURITest {
     Assert.assertEquals("tachyon://localhost:19998/xy z/a b c/d", uri.join(new TachyonURI("/d"))
         .toString());
     Assert.assertEquals("tachyon://localhost:19998/xy z/a b c", uri.toString());
+  }
+  
+  @Test
+  public void basicTest2() {
+    TachyonURI uri = new TachyonURI("hdfs://localhost/xy z/a b c");
+    Assert.assertEquals("localhost", uri.getAuthority());
+    Assert.assertEquals(2, uri.getDepth());
+    Assert.assertEquals("localhost", uri.getHost());
+    Assert.assertEquals("a b c", uri.getName());
+    Assert.assertEquals("hdfs://localhost/xy z", uri.getParent().toString());
+    Assert.assertEquals("hdfs://localhost/", uri.getParent().getParent().toString());
+    Assert.assertEquals("/xy z/a b c", uri.getPath());
+    Assert.assertEquals(-1, uri.getPort());
+    Assert.assertEquals("hdfs", uri.getScheme());
+    Assert.assertEquals(true, uri.hasAuthority());
+    Assert.assertEquals(true, uri.hasScheme());
+    Assert.assertEquals(true, uri.isAbsolute());
+    Assert.assertEquals(true, uri.isPathAbsolute());
+    Assert.assertEquals("hdfs://localhost/xy z/a b c/d", uri.join("/d").toString());
+    Assert.assertEquals("hdfs://localhost/xy z/a b c/d", uri.join(new TachyonURI("/d"))
+        .toString());
+    Assert.assertEquals("hdfs://localhost/xy z/a b c", uri.toString());
   }
 
   @Test
@@ -177,7 +199,7 @@ public class TachyonURITest {
   @Test
   public void getAuthorityTests() {
     String[] authorities =
-        new String[] {"localhost", "localhost:8080", "127.0.0.1", "127.0.0.1:8080"};
+        new String[] {"localhost", "localhost:8080", "127.0.0.1", "127.0.0.1:8080", "localhost", null};
     for (String authority : authorities) {
       TachyonURI uri = new TachyonURI("file", authority, "/a/b");
       Assert.assertEquals(authority, uri.getAuthority());
@@ -216,7 +238,7 @@ public class TachyonURITest {
   @Test
   public void getNameTests() {
     Assert.assertEquals("", new TachyonURI("/").getName());
-    Assert.assertEquals("localhost", new TachyonURI("tachyon://localhost/").getName());
+    Assert.assertEquals("", new TachyonURI("tachyon://localhost/").getName());
     Assert.assertEquals("", new TachyonURI("tachyon:/").getName());
     Assert.assertEquals("a", new TachyonURI("tachyon:/a/").getName());
     Assert.assertEquals("a.txt", new TachyonURI("tachyon:/a.txt/").getName());
@@ -227,8 +249,10 @@ public class TachyonURITest {
   @Test
   public void getParentTests() {
     Assert.assertEquals(null, new TachyonURI("/").getParent());
-    Assert.assertEquals(new TachyonURI("tachyon://"),
+    Assert.assertEquals(null,
         new TachyonURI("tachyon://localhost/").getParent());
+    Assert.assertEquals(new TachyonURI("tachyon://localhost/"),
+        new TachyonURI("tachyon://localhost/a").getParent());
     Assert.assertEquals(new TachyonURI("/a"), new TachyonURI("/a/b/../c").getParent());
     Assert.assertEquals(new TachyonURI("tachyon:/a"),
         new TachyonURI("tachyon:/a/b/../c").getParent());
@@ -273,9 +297,11 @@ public class TachyonURITest {
   public void hasAuthorityTests() {
     Assert.assertFalse(new TachyonURI("/").hasAuthority());
     Assert.assertFalse(new TachyonURI("file:/").hasAuthority());
-    Assert.assertFalse(new TachyonURI("file://localhost/").hasAuthority());
+    Assert.assertFalse(new TachyonURI("file:///test").hasAuthority());
+    Assert.assertTrue(new TachyonURI("file://localhost/").hasAuthority());
     Assert.assertTrue(new TachyonURI("file://localhost:8080/").hasAuthority());
     Assert.assertTrue(new TachyonURI(null, "localhost:8080", "/").hasAuthority());
+    Assert.assertTrue(new TachyonURI(null, "localhost", "/").hasAuthority());
   }
 
   @Test
@@ -316,7 +342,7 @@ public class TachyonURITest {
     Assert.assertTrue(new TachyonURI("tachyon://localhost:19998/").isRoot());
     Assert.assertTrue(new TachyonURI("hdfs://localhost:19998").isRoot());
     Assert.assertTrue(new TachyonURI("hdfs://localhost:19998/").isRoot());
-    Assert.assertFalse(new TachyonURI("file://localhost/").isRoot());
+    Assert.assertTrue(new TachyonURI("file://localhost/").isRoot());
     Assert.assertFalse(new TachyonURI("file://localhost/a/b").isRoot());
     Assert.assertFalse(new TachyonURI("a/b").isRoot());
   }


### PR DESCRIPTION
TachyonURI parses URIs from strings incorrectly in cases where the
authority does not contain a port.  Since the port is an optional
component of the authority (see RFC 3986 Section 3.2) this is incorrect.
This wrong assumption means that Tachyon can treat some URIs as not
having authorities causing them to get mangled and produce odd error
messages as reported in [TACHYON-289](https://tachyon.atlassian.net/browse/TACHYON-289)

This commit corrects the parsing of the authority component and updates
the corresponding tests to cover authorities without ports and correct
existing tests that were using this wrong assumption.

NetworkUtils.replaceHostName() is also appropriately updated to not
include a port if there wasn't one to start with