### PR TITLE
Optimize remote reading from hierarchy store

### DIFF
--- a/core/src/main/java/tachyon/master/BlockInfo.java
+++ b/core/src/main/java/tachyon/master/BlockInfo.java
@@ -156,14 +156,14 @@ public class BlockInfo {
       int[] index = new int[StorageLevelAlias.SIZE];
       for (long storageDirId : mStorageDirIds.values()) {
         int storageLevelValue = StorageDirId.getStorageLevelAliasValue(storageDirId);
-        index[storageLevelValue - 1]++;
+        index[storageLevelValue - 1] ++;
       }
-      for (int i = 1; i < StorageLevelAlias.SIZE; i++) {
+      for (int i = 1; i < StorageLevelAlias.SIZE; i ++) {
         index[i] += index[i - 1];
       }
       for (Map.Entry<NetAddress, Long> entry : mStorageDirIds.entrySet()) {
         int storageLevelValue = StorageDirId.getStorageLevelAliasValue(entry.getValue());
-        addresses[--index[storageLevelValue - 1]] = entry.getKey();
+        addresses[-- index[storageLevelValue - 1]] = entry.getKey();
       }
     }
     List<NetAddress> ret = new ArrayList<NetAddress>(Arrays.asList(addresses));

--- a/core/src/main/java/tachyon/master/BlockInfo.java
+++ b/core/src/main/java/tachyon/master/BlockInfo.java
@@ -152,17 +152,19 @@ public class BlockInfo {
    */
   public synchronized List<NetAddress> getLocations(TachyonConf tachyonConf) {
     NetAddress[] addresses = new NetAddress[mLocations.size()];
-    int[] index = new int[StorageLevelAlias.SIZE];
-    for (long storageDirId : mStorageDirIds.values()) {
-      int storageLevelValue = StorageDirId.getStorageLevelAliasValue(storageDirId);
-      index[storageLevelValue - 1] ++;
-    }
-    for (int i = 1; i < StorageLevelAlias.SIZE; i ++) {
-      index[i] += index[i - 1];
-    }
-    for (Map.Entry<NetAddress, Long> entry : mStorageDirIds.entrySet()) {
-      int storageLevelValue = StorageDirId.getStorageLevelAliasValue(entry.getValue());
-      addresses[-- index[storageLevelValue - 1]] = entry.getKey();
+    if (mLocations.size() > 0) {
+      int[] index = new int[StorageLevelAlias.SIZE];
+      for (long storageDirId : mStorageDirIds.values()) {
+        int storageLevelValue = StorageDirId.getStorageLevelAliasValue(storageDirId);
+        index[storageLevelValue - 1]++;
+      }
+      for (int i = 1; i < StorageLevelAlias.SIZE; i++) {
+        index[i] += index[i - 1];
+      }
+      for (Map.Entry<NetAddress, Long> entry : mStorageDirIds.entrySet()) {
+        int storageLevelValue = StorageDirId.getStorageLevelAliasValue(entry.getValue());
+        addresses[--index[storageLevelValue - 1]] = entry.getKey();
+      }
     }
     List<NetAddress> ret = new ArrayList<NetAddress>(Arrays.asList(addresses));
     if (ret.isEmpty() && mInodeFile.hasCheckpointed()) {

--- a/core/src/test/java/tachyon/master/BlockInfoTest.java
+++ b/core/src/test/java/tachyon/master/BlockInfoTest.java
@@ -108,11 +108,11 @@ public class BlockInfoTest {
     long memStorageDirId = StorageDirId.getStorageDirId(0, StorageLevelAlias.MEM.getValue(), 0);
     long ssdStorageDirId = StorageDirId.getStorageDirId(1, StorageLevelAlias.SSD.getValue(), 0);
     long hddStorageDirId = StorageDirId.getStorageDirId(2, StorageLevelAlias.HDD.getValue(), 0);
+    Assert.assertEquals(0, tInfo.getLocations(mTachyonConf).size());
     tInfo.addLocation(15, new NetAddress("abc", 1, 11), hddStorageDirId);
-    List<NetAddress> locations = tInfo.getLocations(mTachyonConf);
-    Assert.assertEquals(1, locations.size());
+    Assert.assertEquals(1, tInfo.getLocations(mTachyonConf).size());
     tInfo.addLocation(22, new NetAddress("def", 2, 21), memStorageDirId);
-    locations = tInfo.getLocations(mTachyonConf);
+    List<NetAddress> locations = tInfo.getLocations(mTachyonConf);
     Assert.assertEquals(2, locations.size());
     Assert.assertEquals("def", locations.get(0).getMHost());
     Assert.assertEquals("abc", locations.get(1).getMHost());

--- a/core/src/test/java/tachyon/master/BlockInfoTest.java
+++ b/core/src/test/java/tachyon/master/BlockInfoTest.java
@@ -14,6 +14,8 @@
  */
 package tachyon.master;
 
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -99,25 +101,43 @@ public class BlockInfoTest {
   }
 
   @Test
-  public void localtionTest() {
+  public void locationTest() {
     BlockInfo tInfo =
         new BlockInfo(new InodeFile("t", 100, 0, Constants.DEFAULT_BLOCK_SIZE_BYTE,
             System.currentTimeMillis()), 300, 800);
-    long storageDirId = StorageDirId.getStorageDirId(0, StorageLevelAlias.MEM.getValue(), 0);
-    tInfo.addLocation(15, new NetAddress("abc", 1, 11), storageDirId);
-    Assert.assertEquals(1, tInfo.getLocations(mTachyonConf).size());
-    tInfo.addLocation(22, new NetAddress("def", 2, 21), storageDirId);
-    Assert.assertEquals(2, tInfo.getLocations(mTachyonConf).size());
-    tInfo.addLocation(29, new NetAddress("gh", 3, 31), storageDirId);
+    long memStorageDirId = StorageDirId.getStorageDirId(0, StorageLevelAlias.MEM.getValue(), 0);
+    long ssdStorageDirId = StorageDirId.getStorageDirId(1, StorageLevelAlias.SSD.getValue(), 0);
+    long hddStorageDirId = StorageDirId.getStorageDirId(2, StorageLevelAlias.HDD.getValue(), 0);
+    tInfo.addLocation(15, new NetAddress("abc", 1, 11), hddStorageDirId);
+    List<NetAddress> locations = tInfo.getLocations(mTachyonConf);
+    Assert.assertEquals(1, locations.size());
+    tInfo.addLocation(22, new NetAddress("def", 2, 21), memStorageDirId);
+    locations = tInfo.getLocations(mTachyonConf);
+    Assert.assertEquals(2, locations.size());
+    Assert.assertEquals("def", locations.get(0).getMHost());
+    Assert.assertEquals("abc", locations.get(1).getMHost());
+    tInfo.addLocation(29, new NetAddress("gh", 3, 31), ssdStorageDirId);
+    locations = tInfo.getLocations(mTachyonConf);
+    Assert.assertEquals(3, locations.size());
+    Assert.assertEquals("def", locations.get(0).getMHost());
+    Assert.assertEquals("gh", locations.get(1).getMHost());
+    Assert.assertEquals("abc", locations.get(2).getMHost());
+    tInfo.addLocation(15, new NetAddress("abc", 1, 11), hddStorageDirId);
     Assert.assertEquals(3, tInfo.getLocations(mTachyonConf).size());
-    tInfo.addLocation(15, new NetAddress("abc", 1, 11), storageDirId);
+    tInfo.addLocation(22, new NetAddress("def", 2, 21), memStorageDirId);
     Assert.assertEquals(3, tInfo.getLocations(mTachyonConf).size());
-    tInfo.addLocation(22, new NetAddress("def", 2, 21), storageDirId);
-    Assert.assertEquals(3, tInfo.getLocations(mTachyonConf).size());
-    tInfo.addLocation(29, new NetAddress("gh", 3, 31), storageDirId);
-    Assert.assertEquals(3, tInfo.getLocations(mTachyonConf).size());
+    tInfo.addLocation(36, new NetAddress("ij", 4, 41), memStorageDirId);
+    locations = tInfo.getLocations(mTachyonConf);
+    Assert.assertEquals(4, locations.size());
+    Assert.assertEquals(6, locations.get(0).getMPort() + locations.get(1).getMPort());
+    Assert.assertEquals("gh", locations.get(2).getMHost());
+    Assert.assertEquals("abc", locations.get(3).getMHost());
     tInfo.removeLocation(15);
-    Assert.assertEquals(2, tInfo.getLocations(mTachyonConf).size());
+    tInfo.removeLocation(36);
+    locations = tInfo.getLocations(mTachyonConf);
+    Assert.assertEquals(2, locations.size());
+    Assert.assertEquals("def", locations.get(0).getMHost());
+    Assert.assertEquals("gh", locations.get(1).getMHost());
     tInfo.removeLocation(10);
     Assert.assertEquals(2, tInfo.getLocations(mTachyonConf).size());
   }

--- a/core/src/test/java/tachyon/master/InodeFileTest.java
+++ b/core/src/test/java/tachyon/master/InodeFileTest.java
@@ -83,7 +83,6 @@ public class InodeFileTest {
     Assert.assertEquals(2, inodeFile.getBlockLocations(0, mTachyonConf).size());
     inodeFile.addLocation(0, 3, testAddresses.get(2), storageDirId);
     Assert.assertEquals(3, inodeFile.getBlockLocations(0, mTachyonConf).size());
-    Assert.assertEquals(testAddresses, inodeFile.getBlockLocations(0, mTachyonConf));
   }
 
   @Test(expected = BlockInfoException.class)


### PR DESCRIPTION
When a client read a block from remote workers, it gets the block's locations and try to read it from the remote workers. Some workers may have the block in its MEM, while some may have it in its SSD or HDD. For better performace, we'd better return the the block's locations sorted by MEM, SSD, HDD, etc. So the client reads from a remote worker's memory first. 