### PR TITLE
[TACHYON-292] Block caching fix

### DIFF
--- a/core/src/main/java/tachyon/client/BlockOutStream.java
+++ b/core/src/main/java/tachyon/client/BlockOutStream.java
@@ -97,7 +97,6 @@ public class BlockOutStream extends OutStream {
       String msg = "The machine does not have any local worker.";
       throw new IOException(msg);
     }
-    mAvailableBytes += initialBytes;
 
     mBuffer = ByteBuffer.allocate(mUserConf.FILE_BUFFER_BYTES + 4);
   }
@@ -195,6 +194,7 @@ public class BlockOutStream extends OutStream {
       // use the sticky bit, only the client and the worker can write to the block
       CommonUtils.setLocalFileStickyBit(mLocalFilePath);
       LOG.info(mLocalFilePath + " was created!");
+      mAvailableBytes += mInitialBytes;
     }
   }
 

--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -199,8 +199,12 @@ public class RemoteBlockInStream extends BlockInStream {
     while (bytesLeft > 0 && updateCurrentBuffer()) {
       int bytesToRead = (int) Math.min(bytesLeft, mCurrentBuffer.remaining());
       mCurrentBuffer.get(b, off, bytesToRead);
-      if (mRecache) {
-        mBlockOutStream.write(b, off, bytesToRead);
+      try {
+        if (mRecache) {
+          mBlockOutStream.write(b, off, bytesToRead);
+        }
+      } catch (IOException e) {
+        cancelRecache();
       }
       off += bytesToRead;
       bytesLeft -= bytesToRead;
@@ -221,8 +225,12 @@ public class RemoteBlockInStream extends BlockInStream {
           LOG.error("Checkpoint stream read 0 bytes, which shouldn't ever happen");
           return len - bytesLeft;
         }
-        if (mRecache) {
-          mBlockOutStream.write(b, off, readBytes);
+        try {
+          if (mRecache) {
+            mBlockOutStream.write(b, off, readBytes);
+          }
+        } catch (IOException e) {
+          cancelRecache();
         }
         off += readBytes;
         bytesLeft -= readBytes;


### PR DESCRIPTION
Currently, a temp path to write a block into cache will be requested on initialization of the RemoteBlockOutStream. In cases where the block is being read in multiple parts (for example as part of mapreduce), this will cause all but the first request to fail because we only allow one temporary file per block/user pair.

This change requests the temp path lazily, allowing Tachyon's cancelCache logic to resolve most collisions. In cases where that does not suffice, we catch the exception and no-op.