### PR TITLE
[TACHYON-302] loadufs fix

### DIFF
--- a/core/src/main/java/tachyon/util/UfsUtils.java
+++ b/core/src/main/java/tachyon/util/UfsUtils.java
@@ -90,15 +90,11 @@ public class UfsUtils {
       PrefixList excludePathPrefix) throws IOException {
     LOG.info("Loading to " + tachyonPath + " " + ufsAddrRootPath + " " + excludePathPrefix);
     try {
-      // resolve and replace hostname embedded in the given ufsAddress
-      TachyonURI oldPath = ufsAddrRootPath;
+      // resolve and replace hostname embedded in the given ufsAddress/tachyonAddress
       ufsAddrRootPath = NetworkUtils.replaceHostName(ufsAddrRootPath);
-      String host = ufsAddrRootPath.getHost();
-      if (host != null && !host.equalsIgnoreCase(oldPath.getHost())) {
-        LOG.info("UnderFS hostname resolved: " + ufsAddrRootPath);
-      }
+      tachyonPath = NetworkUtils.replaceHostName(tachyonPath);
     } catch (UnknownHostException e) {
-      LOG.info("hostname cannot be resolved in given UFS path: " + ufsAddrRootPath);
+      LOG.error("Failed to resolve hostname", e);
       throw new IOException(e);
     }
 
@@ -200,9 +196,9 @@ public class UfsUtils {
 
     System.out.println("Usage: " + cmd + "<TachyonPath> <UfsPath> "
         + "[<Optional ExcludePathPrefix, separated by ;>]");
-    System.out.println("Example: " + cmd + "tachyon://localhost:19998/a hdfs://localhost:9000/b c");
-    System.out.println("Example: " + cmd + "tachyon://localhost:19998/a file:///b c");
-    System.out.println("Example: " + cmd + "tachyon://localhost:19998/a /b c");
+    System.out.println("Example: " + cmd + "tachyon://127.0.0.1:19998/a hdfs://localhost:9000/b c");
+    System.out.println("Example: " + cmd + "tachyon://127.0.0.1:19998/a file:///b c");
+    System.out.println("Example: " + cmd + "tachyon://127.0.0.1:19998/a /b c");
     System.out.print("In the TFS, all files under local FS /b will be registered under /a, ");
     System.out.println("except for those with prefix c");
   }

--- a/core/src/main/java/tachyon/util/UfsUtils.java
+++ b/core/src/main/java/tachyon/util/UfsUtils.java
@@ -89,13 +89,13 @@ public class UfsUtils {
   public static void loadUnderFs(TachyonFS tfs, TachyonURI tachyonPath, TachyonURI ufsAddrRootPath,
       PrefixList excludePathPrefix) throws IOException {
     LOG.info("Loading to " + tachyonPath + " " + ufsAddrRootPath + " " + excludePathPrefix);
-
     try {
       // resolve and replace hostname embedded in the given ufsAddress
       TachyonURI oldPath = ufsAddrRootPath;
       ufsAddrRootPath = NetworkUtils.replaceHostName(ufsAddrRootPath);
-      if (!ufsAddrRootPath.getHost().equalsIgnoreCase(oldPath.getHost())) {
-        System.out.println("UnderFS hostname resolved: " + ufsAddrRootPath);
+      String host = ufsAddrRootPath.getHost();
+      if (host != null && !host.equalsIgnoreCase(oldPath.getHost())) {
+        LOG.info("UnderFS hostname resolved: " + ufsAddrRootPath);
       }
     } catch (UnknownHostException e) {
       LOG.info("hostname cannot be resolved in given UFS path: " + ufsAddrRootPath);
@@ -200,9 +200,9 @@ public class UfsUtils {
 
     System.out.println("Usage: " + cmd + "<TachyonPath> <UfsPath> "
         + "[<Optional ExcludePathPrefix, separated by ;>]");
-    System.out.println("Example: " + cmd + "tachyon://127.0.0.1:19998/a hdfs://localhost:9000/b c");
-    System.out.println("Example: " + cmd + "tachyon://127.0.0.1:19998/a file:///b c");
-    System.out.println("Example: " + cmd + "tachyon://127.0.0.1:19998/a /b c");
+    System.out.println("Example: " + cmd + "tachyon://localhost:19998/a hdfs://localhost:9000/b c");
+    System.out.println("Example: " + cmd + "tachyon://localhost:19998/a file:///b c");
+    System.out.println("Example: " + cmd + "tachyon://localhost:19998/a /b c");
     System.out.print("In the TFS, all files under local FS /b will be registered under /a, ");
     System.out.println("except for those with prefix c");
   }

--- a/docs/Syncing-the-Underlying-Filesystem.md
+++ b/docs/Syncing-the-Underlying-Filesystem.md
@@ -12,16 +12,15 @@ Use the tachyon shell command loadufs to sync the filesystems.
 
 For example:
 
-    $ ./bin/tachyon loadufs tachyon://127.0.0.1:19998 hdfs://localhost:9000 tachyon
+    $ ./bin/tachyon loadufs tachyon://localhost:19998/ hdfs://localhost:9000/ tachyon
 
 Would load the meta-data for all the files in the local hdfs, except for the tachyon folder.
 
-    $ ./bin/tachyon loadufs tachyon://127.0.0.1:19998/tomlogs file:///Users/tom/logs "tachyon;spark"
+    $ ./bin/tachyon loadufs tachyon://localhost:19998/tomlogs /Users/tom/logs "tachyon;spark"
 
 Would load the metadata for all local files under the /Users/tom/logs directory (except for tachyon
 and spark) to the address tachyon://127.0.0.1:19998/tomlogs. If /Users/tom/logs itself is a file,
-only that file is loaded as /tomlogs/logs in the TFS. The prefix "file://" can be safely omitted for
-a local file system.
+only that file is loaded as /tomlogs/logs in the TFS. The prefix "file://" can be safely omitted for a local file system.
 
 Note that the optional EXCLUDE_PATHS are prefixes relative to the given local file path. Moreover,
 only files matching the given prefixes relative to the path will be excluded. Hence, in the above

--- a/docs/Syncing-the-Underlying-Filesystem.md
+++ b/docs/Syncing-the-Underlying-Filesystem.md
@@ -12,11 +12,11 @@ Use the tachyon shell command loadufs to sync the filesystems.
 
 For example:
 
-    $ ./bin/tachyon loadufs tachyon://localhost:19998/ hdfs://localhost:9000/ tachyon
+    $ ./bin/tachyon loadufs tachyon://127.0.0.1:19998/ hdfs://localhost:9000/ tachyon
 
 Would load the meta-data for all the files in the local hdfs, except for the tachyon folder.
 
-    $ ./bin/tachyon loadufs tachyon://localhost:19998/tomlogs /Users/tom/logs "tachyon;spark"
+    $ ./bin/tachyon loadufs tachyon://127.0.0.1:19998/tomlogs /Users/tom/logs "tachyon;spark"
 
 Would load the metadata for all local files under the /Users/tom/logs directory (except for tachyon
 and spark) to the address tachyon://127.0.0.1:19998/tomlogs. If /Users/tom/logs itself is a file,

--- a/docs/Syncing-the-Underlying-Filesystem.md
+++ b/docs/Syncing-the-Underlying-Filesystem.md
@@ -20,7 +20,8 @@ Would load the meta-data for all the files in the local hdfs, except for the tac
 
 Would load the metadata for all local files under the /Users/tom/logs directory (except for tachyon
 and spark) to the address tachyon://127.0.0.1:19998/tomlogs. If /Users/tom/logs itself is a file,
-only that file is loaded as /tomlogs/logs in the TFS. The prefix "file://" can be safely omitted for a local file system.
+only that file is loaded as /tomlogs/logs in the TFS. The prefix "file://" can be safely omitted for
+a local file system.
 
 Note that the optional EXCLUDE_PATHS are prefixes relative to the given local file path. Moreover,
 only files matching the given prefixes relative to the path will be excluded. Hence, in the above


### PR DESCRIPTION
Update the documentation since users are running into the fail to parse uri issue. Also make local ufs work properly (to an extent, won't work with file:// prefix, but that can go into 0.7).