### PR TITLE
Use getBytes instead of getInt or getLong for bytes config

### DIFF
--- a/core/src/main/java/tachyon/client/BlockOutStream.java
+++ b/core/src/main/java/tachyon/client/BlockOutStream.java
@@ -67,7 +67,7 @@ public class BlockOutStream extends OutStream {
   BlockOutStream(TachyonFile file, WriteType opType, int blockIndex, TachyonConf tachyonConf)
       throws IOException {
     this(file, opType, blockIndex,
-        tachyonConf.getLong(Constants.USER_QUOTA_UNIT_BYTES, 8 * Constants.MB), tachyonConf);
+        tachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES, 8 * Constants.MB), tachyonConf);
   }
 
   /**

--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -367,7 +367,7 @@ public class RemoteBlockInStream extends BlockInStream {
    */
   private boolean updateCurrentBuffer() throws IOException {
     long bufferSize =
-        mTachyonConf.getInt(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE, Constants.MB);
+        mTachyonConf.getBytes(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE, Constants.MB);
     if (mCurrentBuffer != null && mBufferStartPos <= mBlockPos
         && mBlockPos < Math.min(mBufferStartPos + bufferSize, mBlockInfo.length)) {
       // We move the buffer to read at mBlockPos

--- a/core/src/main/java/tachyon/client/TachyonFile.java
+++ b/core/src/main/java/tachyon/client/TachyonFile.java
@@ -495,7 +495,8 @@ public class TachyonFile implements Comparable<TachyonFile> {
       long offset = blockIndex * length;
       inputStream.skip(offset);
 
-      int bufferBytes = mTachyonConf.getInt(Constants.USER_FILE_BUFFER_BYTES, Constants.MB) * 4;
+      int bufferBytes =
+          (int) mTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES, Constants.MB) * 4;
       byte[] buffer = new byte[bufferBytes];
       bos = new BlockOutStream(this, WriteType.TRY_CACHE, blockIndex, mTachyonConf);
       int limit;


### PR DESCRIPTION
We should use TachyonConf.getBytes instead of getInt or getLong for any configuration value like xMB, xGB. Otherwise it fails to parse the value and always use the default value.