### PR TITLE
Tachyon command should abort tests early if they receive a signal

### DIFF
--- a/bin/tachyon
+++ b/bin/tachyon
@@ -79,6 +79,15 @@ function runTest {
   esac
   $LAUNCHER $bin/tachyon tfs rmr "$file"
   $JAVA -cp $CLASSPATH $TACHYON_JAVA_OPTS "$class" tachyon://$MASTER_ADDRESS:19998 "$file" "$args"
+
+  # If test process received a signal abort early
+  # Exit Codes for signals terminating a JVM are 128 + signal
+  RET=$?
+  if [ $RET -gt 128 ]; then
+    echo "Test process was terminated due to signal"
+    exit $RET
+  fi
+  return $RET
 }
 
 function killAll {
@@ -212,6 +221,14 @@ elif [ "$COMMAND" == "runTests" ]; then
       echo $LAUNCHER $bin/tachyon runTest $example $op
       $LAUNCHER $bin/tachyon runTest $example $op
       st=$?
+
+      # If test process received a signal abort early
+      # Exit Codes for signals terminating a JVM are 128 + signal
+      if [ $st -gt 128 ]; then
+        # Received some kind of signal
+        echo "Test process was terminated due to signal"
+        exit $st
+      fi
       failed=$(( $failed + $st ))
     done
   done


### PR DESCRIPTION
Currently if you use `bin/tachyon runTests` and for whatever reason it
starts failing e.g. misconfiguration using Ctrl+C or `kill` to terminate
it only terminates the current test but still proceeds to run the
subsequent tests.

This commit changes the logic of both runTests and runTest so that if
the JVM receives a signal (whether via Ctrl+C, kill or some other means)
that causes further testing to be aborted.