### PR TITLE
Fix Tachyon host name resolution (TACHYON-303)

### DIFF
--- a/core/src/main/java/tachyon/Constants.java
+++ b/core/src/main/java/tachyon/Constants.java
@@ -58,7 +58,7 @@ public class Constants {
 
   public static final int WORKER_BLOCKS_QUEUE_SIZE = 10000;
   
-  public static final int DEFAULT_HOST_RESOLUTION_TIMEOUT = 5000;
+  public static final int DEFAULT_HOST_RESOLUTION_TIMEOUT_MS = 5000;
 
   public static final String LOGGER_TYPE = System.getProperty("tachyon.logger.type", "");
   public static final boolean DEBUG = Boolean.valueOf(System.getProperty("tachyon.debug", "false"));
@@ -92,7 +92,7 @@ public class Constants {
   public static final String ASYNC_ENABLED = "tachyon.async.enabled";
   public static final String MAX_COLUMNS = "tachyon.max.columns";
   public static final String IN_TEST_MODE = "tachyon.test.mode";
-  public static final String HOST_RESOLUTION_TIMEOUT = "tachyon.host.resolution.timeout.ms";
+  public static final String HOST_RESOLUTION_TIMEOUT_MS = "tachyon.host.resolution.timeout.ms";
   public static final String UNDERFS_GLUSTERFS_IMPL = "tachyon.underfs.glusterfs.impl";
   public static final String UNDERFS_GLUSTERFS_VOLUMES = "tachyon.underfs.glusterfs.volumes";
   public static final String UNDERFS_GLUSTERFS_MOUNTS = "tachyon.underfs.glusterfs.mounts";

--- a/core/src/main/java/tachyon/Constants.java
+++ b/core/src/main/java/tachyon/Constants.java
@@ -57,6 +57,8 @@ public class Constants {
   public static final int DEFAULT_BLOCK_SIZE_BYTE = 512 * MB;
 
   public static final int WORKER_BLOCKS_QUEUE_SIZE = 10000;
+  
+  public static final int DEFAULT_HOST_RESOLUTION_TIMEOUT = 5000;
 
   public static final String LOGGER_TYPE = System.getProperty("tachyon.logger.type", "");
   public static final boolean DEBUG = Boolean.valueOf(System.getProperty("tachyon.debug", "false"));
@@ -90,6 +92,7 @@ public class Constants {
   public static final String ASYNC_ENABLED = "tachyon.async.enabled";
   public static final String MAX_COLUMNS = "tachyon.max.columns";
   public static final String IN_TEST_MODE = "tachyon.test.mode";
+  public static final String HOST_RESOLUTION_TIMEOUT = "tachyon.host.resolution.timeout.ms";
   public static final String UNDERFS_GLUSTERFS_IMPL = "tachyon.underfs.glusterfs.impl";
   public static final String UNDERFS_GLUSTERFS_VOLUMES = "tachyon.underfs.glusterfs.volumes";
   public static final String UNDERFS_GLUSTERFS_MOUNTS = "tachyon.underfs.glusterfs.mounts";

--- a/core/src/main/java/tachyon/UnderFileSystemSingleLocal.java
+++ b/core/src/main/java/tachyon/UnderFileSystemSingleLocal.java
@@ -36,8 +36,15 @@ import tachyon.util.NetworkUtils;
  */
 public class UnderFileSystemSingleLocal extends UnderFileSystem {
 
+  private final String mLocalhost;
+
   protected UnderFileSystemSingleLocal(TachyonConf tachyonConf) {
     super(tachyonConf);
+    
+    // Cache local host address to avoid having to determine it every time we want file locations
+    mLocalhost =
+        NetworkUtils.getLocalHostName(tachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT,
+            Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT));
   }
 
   public static UnderFileSystem getClient(TachyonConf tachyonConf) {
@@ -45,7 +52,8 @@ public class UnderFileSystemSingleLocal extends UnderFileSystem {
   }
 
   @Override
-  public void close() throws IOException {}
+  public void close() throws IOException {
+  }
 
   @Override
   public OutputStream create(String path) throws IOException {
@@ -111,7 +119,7 @@ public class UnderFileSystemSingleLocal extends UnderFileSystem {
   @Override
   public List<String> getFileLocations(String path) throws IOException {
     List<String> ret = new ArrayList<String>();
-    ret.add(NetworkUtils.getLocalHostName());
+    ret.add(mLocalhost);
     return ret;
   }
 
@@ -190,7 +198,8 @@ public class UnderFileSystemSingleLocal extends UnderFileSystem {
   }
 
   @Override
-  public void setConf(Object conf) {}
+  public void setConf(Object conf) {
+  }
 
   @Override
   public void setPermission(String path, String posixPerm) throws IOException {

--- a/core/src/main/java/tachyon/UnderFileSystemSingleLocal.java
+++ b/core/src/main/java/tachyon/UnderFileSystemSingleLocal.java
@@ -36,15 +36,8 @@ import tachyon.util.NetworkUtils;
  */
 public class UnderFileSystemSingleLocal extends UnderFileSystem {
 
-  private final String mLocalhost;
-
   protected UnderFileSystemSingleLocal(TachyonConf tachyonConf) {
     super(tachyonConf);
-    
-    // Cache local host address to avoid having to determine it every time we want file locations
-    mLocalhost =
-        NetworkUtils.getLocalHostName(tachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT,
-            Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT));
   }
 
   public static UnderFileSystem getClient(TachyonConf tachyonConf) {
@@ -119,7 +112,7 @@ public class UnderFileSystemSingleLocal extends UnderFileSystem {
   @Override
   public List<String> getFileLocations(String path) throws IOException {
     List<String> ret = new ArrayList<String>();
-    ret.add(mLocalhost);
+    ret.add(NetworkUtils.getLocalHostName(mTachyonConf));
     return ret;
   }
 

--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -247,9 +247,7 @@ public class RemoteBlockInStream extends BlockInStream {
     try {
       List<NetAddress> blockLocations = blockInfo.getLocations();
       LOG.info("Block locations:" + blockLocations);
-      int hostResolutionTimeout = conf.getInt(Constants.HOST_RESOLUTION_TIMEOUT, 
-          Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
-      String localhost = NetworkUtils.getLocalHostName(hostResolutionTimeout);
+      String localhost = NetworkUtils.getLocalHostName(conf);
 
       for (NetAddress blockLocation : blockLocations) {
         String host = blockLocation.mHost;
@@ -267,7 +265,7 @@ public class RemoteBlockInStream extends BlockInStream {
               blockInfo.blockId);
         }
         LOG.info(host + ":" + port + " current host is " + localhost + " "
-            + NetworkUtils.getLocalIpAddress(hostResolutionTimeout));
+            + NetworkUtils.getLocalIpAddress(conf));
 
         try {
           buf =

--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -247,6 +247,9 @@ public class RemoteBlockInStream extends BlockInStream {
     try {
       List<NetAddress> blockLocations = blockInfo.getLocations();
       LOG.info("Block locations:" + blockLocations);
+      int hostResolutionTimeout = conf.getInt(Constants.HOST_RESOLUTION_TIMEOUT, 
+          Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
+      String localhost = NetworkUtils.getLocalHostName(hostResolutionTimeout);
 
       for (NetAddress blockLocation : blockLocations) {
         String host = blockLocation.mHost;
@@ -256,14 +259,15 @@ public class RemoteBlockInStream extends BlockInStream {
         if (port == -1) {
           continue;
         }
+        
         if (host.equals(InetAddress.getLocalHost().getHostName())
             || host.equals(InetAddress.getLocalHost().getHostAddress())
-            || host.equals(NetworkUtils.getLocalHostName())) {
+            || host.equals(localhost)) {
           LOG.warn("Master thinks the local machine has data, But not! blockId:{}",
               blockInfo.blockId);
         }
-        LOG.info(host + ":" + port + " current host is " + NetworkUtils.getLocalHostName() + " "
-            + NetworkUtils.getLocalIpAddress());
+        LOG.info(host + ":" + port + " current host is " + localhost + " "
+            + NetworkUtils.getLocalIpAddress(hostResolutionTimeout));
 
         try {
           buf =

--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -168,10 +168,7 @@ public class TachyonFS extends AbstractTachyonFS {
   private TachyonFS(TachyonConf tachyonConf) throws IOException {
     super(tachyonConf);
 
-    int hostResolutionTimeout = tachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT,
-        Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
-    String masterHost = tachyonConf.get(Constants.MASTER_HOSTNAME, 
-        NetworkUtils.getLocalHostName(hostResolutionTimeout));
+    String masterHost = NetworkUtils.getLocalHostName(tachyonConf);
     int masterPort = tachyonConf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
 
     mMasterAddress = new InetSocketAddress(masterHost, masterPort);

--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -168,7 +168,10 @@ public class TachyonFS extends AbstractTachyonFS {
   private TachyonFS(TachyonConf tachyonConf) throws IOException {
     super(tachyonConf);
 
-    String masterHost = tachyonConf.get(Constants.MASTER_HOSTNAME, NetworkUtils.getLocalHostName());
+    int hostResolutionTimeout = tachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT,
+        Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
+    String masterHost = tachyonConf.get(Constants.MASTER_HOSTNAME, 
+        NetworkUtils.getLocalHostName(hostResolutionTimeout));
     int masterPort = tachyonConf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
 
     mMasterAddress = new InetSocketAddress(masterHost, masterPort);

--- a/core/src/main/java/tachyon/conf/TachyonConf.java
+++ b/core/src/main/java/tachyon/conf/TachyonConf.java
@@ -143,7 +143,7 @@ public class TachyonConf {
 
     // Override runtime default
     defaultProps.setProperty(Constants.MASTER_HOSTNAME, 
-        NetworkUtils.getLocalHostName(100));
+        NetworkUtils.getLocalHostName(250));
     defaultProps.setProperty(Constants.WORKER_NETWORK_NETTY_CHANNEL,
         ChannelType.defaultType().toString());
     defaultProps.setProperty(Constants.WORKER_MIN_WORKER_THREADS,

--- a/core/src/main/java/tachyon/conf/TachyonConf.java
+++ b/core/src/main/java/tachyon/conf/TachyonConf.java
@@ -142,7 +142,8 @@ public class TachyonConf {
     Properties defaultProps = new Properties();
 
     // Override runtime default
-    defaultProps.setProperty(Constants.MASTER_HOSTNAME, NetworkUtils.getLocalHostName());
+    defaultProps.setProperty(Constants.MASTER_HOSTNAME, 
+        NetworkUtils.getLocalHostName(100));
     defaultProps.setProperty(Constants.WORKER_NETWORK_NETTY_CHANNEL,
         ChannelType.defaultType().toString());
     defaultProps.setProperty(Constants.WORKER_MIN_WORKER_THREADS,

--- a/core/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/core/src/main/java/tachyon/worker/TachyonWorker.java
@@ -97,10 +97,13 @@ public class TachyonWorker implements Runnable {
    * @return The new TachyonWorker
    */
   public static synchronized TachyonWorker createWorker(TachyonConf tachyonConf) {
+    int hostResolutionTimeout = tachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT, 
+        Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
     String masterHostname =
-        tachyonConf.get(Constants.MASTER_HOSTNAME, NetworkUtils.getLocalHostName());
+        tachyonConf.get(Constants.MASTER_HOSTNAME, 
+            NetworkUtils.getLocalHostName(hostResolutionTimeout));
     int masterPort = tachyonConf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
-    String workerHostName = NetworkUtils.getLocalHostName();
+    String workerHostName = NetworkUtils.getLocalHostName(hostResolutionTimeout);
     int workerPort = tachyonConf.getInt(Constants.WORKER_PORT, Constants.DEFAULT_WORKER_PORT);
     int dataPort =
         tachyonConf.getInt(Constants.WORKER_DATA_PORT, Constants.DEFAULT_WORKER_DATA_SERVER_PORT);
@@ -117,7 +120,10 @@ public class TachyonWorker implements Runnable {
   }
 
   private static String getMasterLocation(String[] args, TachyonConf conf) {
-    String masterHostname = conf.get(Constants.MASTER_HOSTNAME, NetworkUtils.getLocalHostName());
+    int hostResolutionTimeout = conf.getInt(Constants.HOST_RESOLUTION_TIMEOUT, 
+        Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
+    String masterHostname = conf.get(Constants.MASTER_HOSTNAME, 
+        NetworkUtils.getLocalHostName(hostResolutionTimeout));
     int masterPort = conf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
     String confFileMasterLoc = masterHostname + ":" + masterPort;
     String masterLocation;
@@ -142,11 +148,14 @@ public class TachyonWorker implements Runnable {
           + "tachyon.Worker [<MasterHost:Port>]");
       System.exit(-1);
     }
-
-    String resolvedWorkerHost = NetworkUtils.getLocalHostName();
+    
+    TachyonConf tachyonConf = new TachyonConf();
+    
+    int hostResolutionTimeout = tachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT,
+        Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
+    String resolvedWorkerHost = NetworkUtils.getLocalHostName(hostResolutionTimeout);
     LOG.info("Resolved local TachyonWorker host to " + resolvedWorkerHost);
 
-    TachyonConf tachyonConf = new TachyonConf();
     TachyonWorker worker = TachyonWorker.createWorker(tachyonConf);
     try {
       worker.start();

--- a/core/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/core/src/main/java/tachyon/worker/TachyonWorker.java
@@ -97,13 +97,9 @@ public class TachyonWorker implements Runnable {
    * @return The new TachyonWorker
    */
   public static synchronized TachyonWorker createWorker(TachyonConf tachyonConf) {
-    int hostResolutionTimeout = tachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT, 
-        Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
-    String masterHostname =
-        tachyonConf.get(Constants.MASTER_HOSTNAME, 
-            NetworkUtils.getLocalHostName(hostResolutionTimeout));
+    String masterHostname = NetworkUtils.getLocalHostName(tachyonConf);
     int masterPort = tachyonConf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
-    String workerHostName = NetworkUtils.getLocalHostName(hostResolutionTimeout);
+    String workerHostName = NetworkUtils.getLocalHostName(tachyonConf);
     int workerPort = tachyonConf.getInt(Constants.WORKER_PORT, Constants.DEFAULT_WORKER_PORT);
     int dataPort =
         tachyonConf.getInt(Constants.WORKER_DATA_PORT, Constants.DEFAULT_WORKER_DATA_SERVER_PORT);
@@ -120,10 +116,7 @@ public class TachyonWorker implements Runnable {
   }
 
   private static String getMasterLocation(String[] args, TachyonConf conf) {
-    int hostResolutionTimeout = conf.getInt(Constants.HOST_RESOLUTION_TIMEOUT, 
-        Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
-    String masterHostname = conf.get(Constants.MASTER_HOSTNAME, 
-        NetworkUtils.getLocalHostName(hostResolutionTimeout));
+    String masterHostname = NetworkUtils.getLocalHostName(conf);
     int masterPort = conf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
     String confFileMasterLoc = masterHostname + ":" + masterPort;
     String masterLocation;
@@ -151,9 +144,7 @@ public class TachyonWorker implements Runnable {
     
     TachyonConf tachyonConf = new TachyonConf();
     
-    int hostResolutionTimeout = tachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT,
-        Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
-    String resolvedWorkerHost = NetworkUtils.getLocalHostName(hostResolutionTimeout);
+    String resolvedWorkerHost = NetworkUtils.getLocalHostName(tachyonConf);
     LOG.info("Resolved local TachyonWorker host to " + resolvedWorkerHost);
 
     TachyonWorker worker = TachyonWorker.createWorker(tachyonConf);

--- a/core/src/main/java/tachyon/worker/WorkerClient.java
+++ b/core/src/main/java/tachyon/worker/WorkerClient.java
@@ -210,9 +210,7 @@ public class WorkerClient implements Closeable {
     if (!mConnected) {
       NetAddress workerNetAddress = null;
       try {
-        int hostResolutionTimeout = mTachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT, 
-            Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
-        String localHostName = NetworkUtils.getLocalHostName(hostResolutionTimeout);
+        String localHostName = NetworkUtils.getLocalHostName(mTachyonConf);
         LOG.info("Trying to get local worker host : " + localHostName);
         workerNetAddress = mMasterClient.user_getWorker(false, localHostName);
         mIsLocal = true;

--- a/core/src/main/java/tachyon/worker/WorkerClient.java
+++ b/core/src/main/java/tachyon/worker/WorkerClient.java
@@ -210,7 +210,9 @@ public class WorkerClient implements Closeable {
     if (!mConnected) {
       NetAddress workerNetAddress = null;
       try {
-        String localHostName = NetworkUtils.getLocalHostName();
+        int hostResolutionTimeout = mTachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT, 
+            Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT);
+        String localHostName = NetworkUtils.getLocalHostName(hostResolutionTimeout);
         LOG.info("Trying to get local worker host : " + localHostName);
         workerNetAddress = mMasterClient.user_getWorker(false, localHostName);
         mIsLocal = true;

--- a/core/src/main/resources/tachyon-default.properties
+++ b/core/src/main/resources/tachyon-default.properties
@@ -31,6 +31,7 @@ tachyon.async.enabled=false
 tachyon.max.columns=1000
 tachyon.test.mode=false
 tachyon.max.table.metadata.byte=5MB
+tachyon.host.resolution.timeout.ms=5000
 
 # Master properties
 tachyon.master.journal.folder=${tachyon.home}/journal/

--- a/core/src/test/java/tachyon/client/TachyonFSTest.java
+++ b/core/src/test/java/tachyon/client/TachyonFSTest.java
@@ -33,6 +33,7 @@ import tachyon.master.LocalTachyonCluster;
 import tachyon.thrift.ClientFileInfo;
 import tachyon.thrift.ClientWorkerInfo;
 import tachyon.util.CommonUtils;
+import tachyon.util.NetworkUtils;
 
 /**
  * Unit tests on TachyonClient (Reuse the LocalTachyonCluster).
@@ -360,8 +361,10 @@ public class TachyonFSTest {
     TachyonFS tfs = null;
     String[] originUrls =
         new String[] {"tachyon://127.0.0.1:19998", "tachyon-ft://127.0.0.1:19998",};
+    String localhost = NetworkUtils.getLocalHostName(Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT_MS);
+    String localIP = NetworkUtils.getLocalIpAddress(Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT_MS);
     String[] resultUrls =
-        new String[] {"tachyon://localhost/127.0.0.1:19998", "tachyon-ft://localhost/127.0.0.1:19998",};
+        new String[] {"tachyon://" + localhost + "/" + localIP + ":19998", "tachyon-ft://" + localhost + "/" + localIP + ":19998",};
     for (int i = 0, n = originUrls.length; i < n; i ++) {
       String originUrl = originUrls[i];
       String resultUrl = resultUrls[i];
@@ -377,10 +380,10 @@ public class TachyonFSTest {
 
     copyConf.set(Constants.USE_ZOOKEEPER, "false");
     tfs = TachyonFS.get(copyConf);
-    Assert.assertEquals("tachyon://localhost/127.0.0.1:19998", tfs.toString());
+    Assert.assertEquals("tachyon://" + localhost + "/" + localIP + ":19998", tfs.toString());
 
     copyConf.set(Constants.USE_ZOOKEEPER, "true");
     tfs = TachyonFS.get(copyConf);
-    Assert.assertEquals("tachyon-ft://localhost/127.0.0.1:19998", tfs.toString());
+    Assert.assertEquals("tachyon-ft://" + localhost + "/" + localIP + ":19998", tfs.toString());
   }
 }

--- a/core/src/test/java/tachyon/command/TFsShellTest.java
+++ b/core/src/test/java/tachyon/command/TFsShellTest.java
@@ -420,8 +420,9 @@ public class TFsShellTest {
   @Test
   public void mkdirTest() throws IOException {
     String qualifiedPath =
-        "tachyon://" + NetworkUtils.getLocalHostName() + ":" + mLocalTachyonCluster.getMasterPort()
-            + "/root/testFile1";
+        "tachyon://" + NetworkUtils.getLocalHostName(Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT)
+        + ":" + mLocalTachyonCluster.getMasterPort()
+        + "/root/testFile1";
     mFsShell.mkdir(new String[] {"mkdir", qualifiedPath});
     TachyonFile tFile = mTfs.getFile(new TachyonURI("/root/testFile1"));
     Assert.assertNotNull(tFile);

--- a/core/src/test/java/tachyon/command/TFsShellTest.java
+++ b/core/src/test/java/tachyon/command/TFsShellTest.java
@@ -420,7 +420,7 @@ public class TFsShellTest {
   @Test
   public void mkdirTest() throws IOException {
     String qualifiedPath =
-        "tachyon://" + NetworkUtils.getLocalHostName(Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT)
+        "tachyon://" + NetworkUtils.getLocalHostName(Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT_MS)
         + ":" + mLocalTachyonCluster.getMasterPort()
         + "/root/testFile1";
     mFsShell.mkdir(new String[] {"mkdir", qualifiedPath});

--- a/core/src/test/java/tachyon/conf/TachyonConfTest.java
+++ b/core/src/test/java/tachyon/conf/TachyonConfTest.java
@@ -96,6 +96,9 @@ public class TachyonConfTest {
 
     int intValue = sDefaultTachyonConf.getInt(Constants.MAX_COLUMNS, 0);
     Assert.assertTrue(intValue == 1000);
+    
+    intValue = sDefaultTachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT, 0);
+    Assert.assertEquals(Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT, intValue);
 
     long longBytesValue = sDefaultTachyonConf.getBytes(Constants.MAX_TABLE_METADATA_BYTE, 0L);
     Assert.assertTrue(longBytesValue == Constants.MB * 5);
@@ -110,10 +113,10 @@ public class TachyonConfTest {
     String value = sDefaultTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER, null);
     Assert.assertTrue(value != null);
     Assert.assertTrue((tachyonHome + "/journal/").equals(value));
-
+    
     value = sDefaultTachyonConf.get(Constants.MASTER_HOSTNAME, null);
     Assert.assertTrue(value != null);
-    Assert.assertTrue(NetworkUtils.getLocalHostName().equals(value));
+    Assert.assertTrue(NetworkUtils.getLocalHostName(100).equals(value));
 
     value = sDefaultTachyonConf.get(Constants.MASTER_TEMPORARY_FOLDER, null);
     Assert.assertTrue(value != null);

--- a/core/src/test/java/tachyon/conf/TachyonConfTest.java
+++ b/core/src/test/java/tachyon/conf/TachyonConfTest.java
@@ -97,8 +97,8 @@ public class TachyonConfTest {
     int intValue = sDefaultTachyonConf.getInt(Constants.MAX_COLUMNS, 0);
     Assert.assertTrue(intValue == 1000);
     
-    intValue = sDefaultTachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT, 0);
-    Assert.assertEquals(Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT, intValue);
+    intValue = sDefaultTachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT_MS, 0);
+    Assert.assertEquals(Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT_MS, intValue);
 
     long longBytesValue = sDefaultTachyonConf.getBytes(Constants.MAX_TABLE_METADATA_BYTE, 0L);
     Assert.assertTrue(longBytesValue == Constants.MB * 5);

--- a/core/src/test/java/tachyon/master/LocalTachyonCluster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonCluster.java
@@ -164,7 +164,7 @@ public final class LocalTachyonCluster {
         File.createTempFile("Tachyon", "U" + System.currentTimeMillis()).getAbsolutePath();
     mWorkerDataFolder = "/datastore";
 
-    mLocalhostName = NetworkUtils.getLocalHostName();
+    mLocalhostName = NetworkUtils.getLocalHostName(100);
 
     mMasterConf = new TachyonConf();
     mMasterConf.set(Constants.IN_TEST_MODE, "true");
@@ -172,6 +172,10 @@ public final class LocalTachyonCluster {
     mMasterConf.set(Constants.USER_QUOTA_UNIT_BYTES, Integer.toString(mQuotaUnitBytes));
     mMasterConf.set(Constants.USER_DEFAULT_BLOCK_SIZE_BYTE, Integer.toString(mUserBlockSize));
     mMasterConf.set(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE, "64");
+    
+    // Since tests are always running on a single host keep the resolution timeout low as otherwise people
+    // running with strange network configurations will see very slow tests
+    mMasterConf.set(Constants.HOST_RESOLUTION_TIMEOUT, "100");
 
     // Lower the number of threads that the cluster will spin off.
     // default thread overhead is too much.
@@ -202,6 +206,10 @@ public final class LocalTachyonCluster {
     mWorkerConf.set(Constants.WORKER_MIN_WORKER_THREADS, Integer.toString(1));
     mWorkerConf.set(Constants.WORKER_MAX_WORKER_THREADS, Integer.toString(100));
     mWorkerConf.set(Constants.WORKER_NETTY_WORKER_THREADS, Integer.toString(2));
+    
+    // Since tests are always running on a single host keep the resolution timeout low as otherwise people
+    // running with strange network configurations will see very slow tests
+    mWorkerConf.set(Constants.HOST_RESOLUTION_TIMEOUT, "100");
 
     mWorkerConf.set("tachyon.worker.hierarchystore.level0.alias", "MEM");
     mWorkerConf.set("tachyon.worker.hierarchystore.level0.dirs.path", mTachyonHome + "/ramdisk");

--- a/core/src/test/java/tachyon/master/LocalTachyonCluster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonCluster.java
@@ -175,7 +175,7 @@ public final class LocalTachyonCluster {
     
     // Since tests are always running on a single host keep the resolution timeout low as otherwise people
     // running with strange network configurations will see very slow tests
-    mMasterConf.set(Constants.HOST_RESOLUTION_TIMEOUT, "100");
+    mMasterConf.set(Constants.HOST_RESOLUTION_TIMEOUT_MS, "250");
 
     // Lower the number of threads that the cluster will spin off.
     // default thread overhead is too much.
@@ -209,7 +209,7 @@ public final class LocalTachyonCluster {
     
     // Since tests are always running on a single host keep the resolution timeout low as otherwise people
     // running with strange network configurations will see very slow tests
-    mWorkerConf.set(Constants.HOST_RESOLUTION_TIMEOUT, "100");
+    mWorkerConf.set(Constants.HOST_RESOLUTION_TIMEOUT_MS, "250");
 
     mWorkerConf.set("tachyon.worker.hierarchystore.level0.alias", "MEM");
     mWorkerConf.set("tachyon.worker.hierarchystore.level0.dirs.path", mTachyonHome + "/ramdisk");

--- a/core/src/test/java/tachyon/master/LocalTachyonClusterMultiMaster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonClusterMultiMaster.java
@@ -159,7 +159,7 @@ public class LocalTachyonClusterMultiMaster {
     
     // Since tests are always running on a single host keep the resolution timeout low as otherwise people
     // running with strange network configurations will see very slow tests
-    mMasterConf.set(Constants.HOST_RESOLUTION_TIMEOUT, "100");
+    mMasterConf.set(Constants.HOST_RESOLUTION_TIMEOUT_MS, "250");
 
     // re-build the dir to set permission to 777
     deleteDir(mTachyonHome);
@@ -191,7 +191,7 @@ public class LocalTachyonClusterMultiMaster {
     
     // Since tests are always running on a single host keep the resolution timeout low as otherwise people
     // running with strange network configurations will see very slow tests
-    mWorkerConf.set(Constants.HOST_RESOLUTION_TIMEOUT, "100");
+    mWorkerConf.set(Constants.HOST_RESOLUTION_TIMEOUT_MS, "250");
 
     for (int level = 1; level < maxLevel; level ++) {
       String tierLevelDirPath = "tachyon.worker.hierarchystore.level" + level + ".dirs.path";

--- a/core/src/test/java/tachyon/master/LocalTachyonClusterMultiMaster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonClusterMultiMaster.java
@@ -145,7 +145,7 @@ public class LocalTachyonClusterMultiMaster {
     String masterDataFolder = mTachyonHome + "/data";
     String masterLogFolder = mTachyonHome + "/logs";
 
-    mLocalhostName = NetworkUtils.getLocalHostName();
+    mLocalhostName = NetworkUtils.getLocalHostName(100);
 
     mMasterConf = new TachyonConf();
     mMasterConf.set(Constants.IN_TEST_MODE, "true");
@@ -156,6 +156,10 @@ public class LocalTachyonClusterMultiMaster {
     mMasterConf.set(Constants.ZOOKEEPER_LEADER_PATH, "/leader");
     mMasterConf.set(Constants.USER_QUOTA_UNIT_BYTES, "10000");
     mMasterConf.set(Constants.USER_DEFAULT_BLOCK_SIZE_BYTE, Integer.toString(mUserBlockSize));
+    
+    // Since tests are always running on a single host keep the resolution timeout low as otherwise people
+    // running with strange network configurations will see very slow tests
+    mMasterConf.set(Constants.HOST_RESOLUTION_TIMEOUT, "100");
 
     // re-build the dir to set permission to 777
     deleteDir(mTachyonHome);
@@ -184,6 +188,10 @@ public class LocalTachyonClusterMultiMaster {
     mWorkerConf.set("tachyon.worker.hierarchystore.level0.alias", "MEM");
     mWorkerConf.set("tachyon.worker.hierarchystore.level0.dirs.path", mTachyonHome + "/ramdisk");
     mWorkerConf.set("tachyon.worker.hierarchystore.level0.dirs.quota", mWorkerCapacityBytes + "");
+    
+    // Since tests are always running on a single host keep the resolution timeout low as otherwise people
+    // running with strange network configurations will see very slow tests
+    mWorkerConf.set(Constants.HOST_RESOLUTION_TIMEOUT, "100");
 
     for (int level = 1; level < maxLevel; level ++) {
       String tierLevelDirPath = "tachyon.worker.hierarchystore.level" + level + ".dirs.path";

--- a/core/src/test/java/tachyon/master/LocalTachyonMaster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonMaster.java
@@ -98,7 +98,7 @@ public final class LocalTachyonMaster {
     
     // Since tests are always running on a single host keep the resolution timeout low as otherwise people
     // running with strange network configurations will see very slow tests
-    tachyonConf.set(Constants.HOST_RESOLUTION_TIMEOUT, "100");
+    tachyonConf.set(Constants.HOST_RESOLUTION_TIMEOUT_MS, "100");
 
     tachyonConf.set(Constants.MASTER_WEB_THREAD_COUNT, "1");
     tachyonConf.set(Constants.WEB_RESOURCES, System.getProperty("user.dir") + "/src/main/webapp");

--- a/core/src/test/java/tachyon/master/LocalTachyonMaster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonMaster.java
@@ -91,7 +91,7 @@ public final class LocalTachyonMaster {
     tachyonConf.set(Constants.MASTER_WEB_PORT, "0");
 
     tachyonConf.set(Constants.MASTER_MIN_WORKER_THREADS, "1");
-    tachyonConf.set(Constants.MASTER_MAX_WORKER_THREADS, "250");
+    tachyonConf.set(Constants.MASTER_MAX_WORKER_THREADS, "100");
     
     // If tests fail to connect they should fail early rather than using the default ridiculously high retries
     tachyonConf.set(Constants.MASTER_RETRY_COUNT, "3");

--- a/core/src/test/java/tachyon/master/LocalTachyonMaster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonMaster.java
@@ -67,7 +67,7 @@ public final class LocalTachyonMaster {
     UnderFileSystemsUtils.mkdirIfNotExists(mDataDir, tachyonConf);
     UnderFileSystemsUtils.mkdirIfNotExists(mLogDir, tachyonConf);
 
-    mHostname = NetworkUtils.getLocalHostName();
+    mHostname = NetworkUtils.getLocalHostName(100);
 
     // To start the UFS either for integration or unit test. If it targets the unit test, UFS is
     // setup over the local file system (see also {@link LocalFilesystemCluster} - under folder of
@@ -95,6 +95,10 @@ public final class LocalTachyonMaster {
     
     // If tests fail to connect they should fail early rather than using the default ridiculously high retries
     tachyonConf.set(Constants.MASTER_RETRY_COUNT, "3");
+    
+    // Since tests are always running on a single host keep the resolution timeout low as otherwise people
+    // running with strange network configurations will see very slow tests
+    tachyonConf.set(Constants.HOST_RESOLUTION_TIMEOUT, "100");
 
     tachyonConf.set(Constants.MASTER_WEB_THREAD_COUNT, "1");
     tachyonConf.set(Constants.WEB_RESOURCES, System.getProperty("user.dir") + "/src/main/webapp");

--- a/core/src/test/java/tachyon/master/LocalTachyonMaster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonMaster.java
@@ -67,7 +67,7 @@ public final class LocalTachyonMaster {
     UnderFileSystemsUtils.mkdirIfNotExists(mDataDir, tachyonConf);
     UnderFileSystemsUtils.mkdirIfNotExists(mLogDir, tachyonConf);
 
-    mHostname = NetworkUtils.getLocalHostName(100);
+    mHostname = NetworkUtils.getLocalHostName(250);
 
     // To start the UFS either for integration or unit test. If it targets the unit test, UFS is
     // setup over the local file system (see also {@link LocalFilesystemCluster} - under folder of
@@ -91,14 +91,14 @@ public final class LocalTachyonMaster {
     tachyonConf.set(Constants.MASTER_WEB_PORT, "0");
 
     tachyonConf.set(Constants.MASTER_MIN_WORKER_THREADS, "1");
-    tachyonConf.set(Constants.MASTER_MAX_WORKER_THREADS, "100");
+    tachyonConf.set(Constants.MASTER_MAX_WORKER_THREADS, "250");
     
     // If tests fail to connect they should fail early rather than using the default ridiculously high retries
     tachyonConf.set(Constants.MASTER_RETRY_COUNT, "3");
     
     // Since tests are always running on a single host keep the resolution timeout low as otherwise people
     // running with strange network configurations will see very slow tests
-    tachyonConf.set(Constants.HOST_RESOLUTION_TIMEOUT_MS, "100");
+    tachyonConf.set(Constants.HOST_RESOLUTION_TIMEOUT_MS, "250");
 
     tachyonConf.set(Constants.MASTER_WEB_THREAD_COUNT, "1");
     tachyonConf.set(Constants.WEB_RESOURCES, System.getProperty("user.dir") + "/src/main/webapp");


### PR DESCRIPTION
Under some network configurations it is possible for Tachyon host name
resolution for the local host to select a host that is not actually
reachable or usable, for example a network broadcast address.  When it
does so Tachyon will hang until such time as the timeout and retry
limits are reached which can be an extremely long time.

This commit improves the local host resolution to ensure that the host
selected is actually reachable and to discount any non-reachable addresses
from use as local hosts.

As part of this it was necessary to add a timeout to the host name
resolution so that it doesn't spend too long waiting to determine if a
particular host name is reachable.  This defaults to 5000 milliseconds
currently, the relevant methods were updated to take a timeout and all
relevant calls updated to pass in the timeout value.

Since host names and IPs shouldn't change over the life of the JVM and
since Tachyon typically only does this resolution once at start up time
we also now cache these values.  This is particularly important when
running the tests under affected network configurations as otherwises
the tests will take substantially longer than normal.