### PR TITLE
Set user remote read buffer size to 8MB for better performance

### DIFF
--- a/core/src/main/java/tachyon/conf/UserConf.java
+++ b/core/src/main/java/tachyon/conf/UserConf.java
@@ -56,7 +56,7 @@ public class UserConf extends Utils {
     DEFAULT_BLOCK_SIZE_BYTE = getLongProperty("tachyon.user.default.block.size.byte",
         Constants.DEFAULT_BLOCK_SIZE_BYTE);
     REMOTE_READ_BUFFER_SIZE_BYTE =
-        getIntProperty("tachyon.user.remote.read.buffer.size.byte", Constants.MB);
+        getIntProperty("tachyon.user.remote.read.buffer.size.byte", 8 * Constants.MB);
     DEFAULT_WRITE_TYPE =
         getEnumProperty("tachyon.user.file.writetype.default", WriteType.CACHE_THROUGH);
   }

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -316,7 +316,7 @@ The user configuration specifies values regarding file system access.
 </tr>
 <tr>
   <td>tachyon.user.remote.read.buffer.size.byte</td>
-  <td>1 MB</td>
+  <td>8 MB</td>
   <td>The size of the file buffer to read data from remote Tachyon worker.</td>
 </tr>
 <tr>


### PR DESCRIPTION
The configuration "tachyon.user.remote.read.buffer.size.byte" has a big effect on the remote read performance. The default setting is 1MB. For reading 1GB data from a remote worker in 1Gb/sec ethernet, the client need send 1000+ requests. So it takes about 17 seconds. If we set this buffer size higher (i.e. 8MB), we can read 1GB data from a remote worker more quickly (about 10.5 seconds). Let's use 8MB for now since it is mainly large sequential read currently. Previous discussion can be found at #702 