### PR TITLE
Fix errant search and replace

### DIFF
--- a/core/src/main/java/tachyon/Constants.java
+++ b/core/src/main/java/tachyon/Constants.java
@@ -59,6 +59,8 @@ public class Constants {
 
   public static final int DEFAULT_BLOCK_SIZE_BYTE = 512 * MB;
 
+  public static final int DEFAULT_CHECKPOINT_CAP_MB_SEC = 1000;
+
   public static final int WORKER_BLOCKS_QUEUE_SIZE = 10000;
 
   public static final String LOGGER_TYPE = System.getProperty("tachyon.logger.type", "");

--- a/core/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/core/src/main/java/tachyon/worker/WorkerStorage.java
@@ -247,7 +247,7 @@ public class WorkerStorage {
           mMasterClient.addCheckpoint(mWorkerId, fileId, fileSizeByte, dstPath);
           int capMbSec =
               mTachyonConf.getInt(Constants.WORKER_PER_THREAD_CHECKPOINT_CAP_MB_SEC,
-                  Constants.SECOND_MS);
+                  Constants.DEFAULT_CHECKPOINT_CAP_MB_SEC);
           long shouldTakeMs = (long) (1000.0 * fileSizeByte / Constants.MB / capMbSec);
           long currentTimeMs = System.currentTimeMillis();
           if (startCopyTimeMs + shouldTakeMs > currentTimeMs) {


### PR DESCRIPTION
Way back in commit 5186b2b782be56c34e8b06ea9d3932c5a0af654f I believe
there was a search and replace of 1000 with SECOND_MS.  Which was
fine, except for the setting

getIntProperty("tachyon.worker.per.thread.checkpoint.cap.mb.sec", Constants.SECOND_MS);

which makes it confusing b/c this configuration field is a rate (MB/sec)
and not a time (sec).

Replace with a less confusing constant.