### PR TITLE
Fix default user failed space request limit

### DIFF
--- a/core/src/main/java/tachyon/Constants.java
+++ b/core/src/main/java/tachyon/Constants.java
@@ -57,6 +57,8 @@ public class Constants {
   public static final int DEFAULT_MASTER_MAX_WORKER_THREADS = 2048;
   public static final int DEFAULT_WORKER_MAX_WORKER_THREADS = 2048;
 
+  public static final int DEFAULT_USER_FAILED_SPACE_REQUEST_LIMITS = 4;
+
   public static final int DEFAULT_BLOCK_SIZE_BYTE = 512 * MB;
 
   public static final int DEFAULT_CHECKPOINT_CAP_MB_SEC = 1000;

--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -183,7 +183,8 @@ public class TachyonFS extends AbstractTachyonFS {
         mTachyonConf));
 
     mUserFailedSpaceRequestLimits =
-        mTachyonConf.getInt(Constants.USER_FAILED_SPACE_REQUEST_LIMITS, 0);
+        mTachyonConf.getInt(Constants.USER_FAILED_SPACE_REQUEST_LIMITS,
+            Constants.DEFAULT_USER_FAILED_SPACE_REQUEST_LIMITS);
 
     String scheme = mZookeeperMode ? Constants.SCHEME_FT : Constants.SCHEME;
     String authority = mMasterAddress.getHostName() + ":" + mMasterAddress.getPort();


### PR DESCRIPTION
set default user failed space request limit from 0 to 4.
if setting to 0, no request will be actually executed.