### PR TITLE
Fix master address during starting TachyonWorker

### DIFF
--- a/core/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/core/src/main/java/tachyon/worker/TachyonWorker.java
@@ -118,7 +118,7 @@ public class TachyonWorker implements Runnable {
 
   }
 
-  private static String setMasterLocation(String masterUrl, TachyonConf conf) {
+  private static String getMasterLocation(String masterUrl, TachyonConf conf) {
     String masterHostnameConf = conf.get(Constants.MASTER_HOSTNAME,
         NetworkUtils.getLocalHostName(conf));
     String masterPortConf = conf.get(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT + "");
@@ -154,7 +154,7 @@ public class TachyonWorker implements Runnable {
 
     TachyonConf tachyonConf = new TachyonConf();
     if (args.length == 1) {
-      setMasterLocation(args[0], tachyonConf);
+      getMasterLocation(args[0], tachyonConf);
     }
     
     String resolvedWorkerHost = NetworkUtils.getLocalHostName(tachyonConf);

--- a/core/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/core/src/main/java/tachyon/worker/TachyonWorker.java
@@ -118,31 +118,30 @@ public class TachyonWorker implements Runnable {
 
   }
 
-  private static String getMasterLocation(String masterUrl, TachyonConf conf) {
+  private static void setMasterAddress(String masterAddress, TachyonConf conf) {
+    if (masterAddress == null) {
+      return;
+    }
     String masterHostnameConf = conf.get(Constants.MASTER_HOSTNAME,
         NetworkUtils.getLocalHostName(conf));
     String masterPortConf = conf.get(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT + "");
-    if (masterUrl == null) {
-      return masterHostnameConf + ":" + masterPortConf;
-    } else {
-      String[] address = masterUrl.split(":");
-      String masterHostname = address[0];
-      if (!masterHostnameConf.equals(masterHostname)) {
-        LOG.warn("Master host in configuration ({}) is different from the command line ({}).",
-            masterHostnameConf, masterHostname);
-        conf.set(Constants.MASTER_HOSTNAME, masterHostname);
-      }
-      String masterPort = masterPortConf;
-      if (address.length > 1) {
-        masterPort = address[1];
-        if (!masterPortConf.equals(masterPort)) {
-          LOG.warn("Master port in configuration ({}) is different from the command line ({}).",
-              masterPortConf, masterPort);
-          conf.set(Constants.MASTER_PORT, masterPort);
-        }
-      }
-      return masterHostname + ":" + masterPort;
+    String[] address = masterAddress.split(":");
+    String masterHostname = address[0];
+    if (!masterHostnameConf.equals(masterHostname)) {
+      LOG.warn("Master host in configuration ({}) is different from the command line ({}).",
+          masterHostnameConf, masterHostname);
+      conf.set(Constants.MASTER_HOSTNAME, masterHostname);
     }
+    String masterPort = masterPortConf;
+    if (address.length > 1) {
+      masterPort = address[1];
+      if (!masterPortConf.equals(masterPort)) {
+        LOG.warn("Master port in configuration ({}) is different from the command line ({}).",
+            masterPortConf, masterPort);
+        conf.set(Constants.MASTER_PORT, masterPort);
+      }
+    }
+    return;
   }
 
   public static void main(String[] args) throws UnknownHostException {
@@ -154,7 +153,7 @@ public class TachyonWorker implements Runnable {
 
     TachyonConf tachyonConf = new TachyonConf();
     if (args.length == 1) {
-      getMasterLocation(args[0], tachyonConf);
+      setMasterAddress(args[0], tachyonConf);
     }
     
     String resolvedWorkerHost = NetworkUtils.getLocalHostName(tachyonConf);


### PR DESCRIPTION
Currently, when worker starts, the hostname of the master is set to be the worker's host name, which makes Tachyon fail to run on a cluster.