### PR TITLE
[TACHYON-282] New evict framework

### DIFF
--- a/core/src/main/java/tachyon/worker/eviction/EvictLRU.java
+++ b/core/src/main/java/tachyon/worker/eviction/EvictLRU.java
@@ -36,7 +36,6 @@ public final class EvictLRU extends EvictLRUBase {
     super(lastTier);
   }
 
-  @Override
   public synchronized Pair<StorageDir, List<BlockInfo>> getDirCandidate(StorageDir[] storageDirs,
       Set<Integer> pinList, long requestBytes) {
     List<BlockInfo> blockInfoList = new ArrayList<BlockInfo>();

--- a/core/src/main/java/tachyon/worker/eviction/EvictLRUBase.java
+++ b/core/src/main/java/tachyon/worker/eviction/EvictLRUBase.java
@@ -26,7 +26,7 @@ import tachyon.worker.hierarchy.StorageDir;
 /**
  * Base class for evicting blocks by LRU strategy.
  */
-public abstract class EvictLRUBase implements EvictStrategy {
+public abstract class EvictLRUBase extends EvictStrategy {
   private final boolean mLastTier;
 
   protected EvictLRUBase(boolean lastTier) {

--- a/core/src/main/java/tachyon/worker/eviction/EvictPartialLRU.java
+++ b/core/src/main/java/tachyon/worker/eviction/EvictPartialLRU.java
@@ -33,7 +33,6 @@ public final class EvictPartialLRU extends EvictLRUBase {
     super(lastTier);
   }
 
-  @Override
   public synchronized Pair<StorageDir, List<BlockInfo>> getDirCandidate(StorageDir[] storageDirs,
       Set<Integer> pinList, long requestBytes) {
     List<BlockInfo> blockInfoList = new ArrayList<BlockInfo>();

--- a/core/src/main/java/tachyon/worker/eviction/EvictStrategy.java
+++ b/core/src/main/java/tachyon/worker/eviction/EvictStrategy.java
@@ -28,7 +28,51 @@ import tachyon.worker.hierarchy.StorageDir;
  * when actually evicting blocks, some blocks may be not allowed to be evicted, it may result in
  * having to try more than one time to get enough space.
  */
-public interface EvictStrategy {
+public abstract class EvictStrategy {
+  /**
+   * Actions to take when the new block is added
+   */
+  public void onAdd(long blockId) {}
+
+  /**
+   * Actions to take when delete the block
+   */
+  public void onDelete(long blockId) {}
+
+  /**
+   * Actions to take when read the block
+   */
+  public void onRead(long blockId) {}
+
+  /**
+   * Actions to take when cache the block
+   */
+  public void onCache(long blockId) {}
+
+  /**
+   * Actions to take when cancel the block
+   */
+  public void onCancel(long blockId) {}
+
+  /**
+   * Actions to take when copy the block
+   */
+  public void onCopy(long blockId) {}
+
+  /**
+   * Actions to take when move the block
+   */
+  public void onMove(long blockId) {}
+
+  /**
+   * Actions to take when lock the block
+   */
+  public void onLock(long blockId) {}
+
+  /**
+   * Actions to take when unlock the block
+   */
+  public void onUnLock(long blockId) {}
 
   /**
    * Get StorageDir allocated and also get blocks to be evicted among StorageDir candidates
@@ -39,6 +83,6 @@ public interface EvictStrategy {
    * @return Pair of StorageDir allocated and blockInfoList which contains information of blocks to
    *         be evicted, null if no allocated directory is found
    */
-  public Pair<StorageDir, List<BlockInfo>> getDirCandidate(StorageDir[] storageDirs,
+  public abstract Pair<StorageDir, List<BlockInfo>> getDirCandidate(StorageDir[] storageDirs,
       Set<Integer> pinList, long requestBytes);
 }

--- a/core/src/main/java/tachyon/worker/eviction/EvictStrategy.java
+++ b/core/src/main/java/tachyon/worker/eviction/EvictStrategy.java
@@ -30,19 +30,21 @@ import tachyon.worker.hierarchy.StorageDir;
  */
 public abstract class EvictStrategy {
   /**
+   * Get StorageDir allocated and also get blocks to be evicted among StorageDir candidates
+   *
+   * @param storageDirs StorageDir candidates that the space will be allocated in
+   * @param pinList list of pinned file
+   * @param requestBytes requested space size in bytes
+   * @return Pair of StorageDir allocated and blockInfoList which contains information of blocks to
+   *         be evicted, null if no allocated directory is found
+   */
+  public abstract Pair<StorageDir, List<BlockInfo>> getDirCandidate(StorageDir[] storageDirs,
+      Set<Integer> pinList, long requestBytes);
+
+  /**
    * Actions to take when the new block is added
    */
   public void onAdd(long blockId) {}
-
-  /**
-   * Actions to take when delete the block
-   */
-  public void onDelete(long blockId) {}
-
-  /**
-   * Actions to take when read the block
-   */
-  public void onRead(long blockId) {}
 
   /**
    * Actions to take when cache the block
@@ -60,9 +62,9 @@ public abstract class EvictStrategy {
   public void onCopy(long blockId) {}
 
   /**
-   * Actions to take when move the block
+   * Actions to take when delete the block
    */
-  public void onMove(long blockId) {}
+  public void onDelete(long blockId) {}
 
   /**
    * Actions to take when lock the block
@@ -70,19 +72,17 @@ public abstract class EvictStrategy {
   public void onLock(long blockId) {}
 
   /**
+   * Actions to take when move the block
+   */
+  public void onMove(long blockId) {}
+
+  /**
+   * Actions to take when read the block
+   */
+  public void onRead(long blockId) {}
+
+  /**
    * Actions to take when unlock the block
    */
   public void onUnLock(long blockId) {}
-
-  /**
-   * Get StorageDir allocated and also get blocks to be evicted among StorageDir candidates
-   *
-   * @param storageDirs StorageDir candidates that the space will be allocated in
-   * @param pinList list of pinned file
-   * @param requestBytes requested space size in bytes
-   * @return Pair of StorageDir allocated and blockInfoList which contains information of blocks to
-   *         be evicted, null if no allocated directory is found
-   */
-  public abstract Pair<StorageDir, List<BlockInfo>> getDirCandidate(StorageDir[] storageDirs,
-      Set<Integer> pinList, long requestBytes);
 }

--- a/core/src/main/java/tachyon/worker/hierarchy/StorageTier.java
+++ b/core/src/main/java/tachyon/worker/hierarchy/StorageTier.java
@@ -82,20 +82,25 @@ public class StorageTier {
     mAlias = storageLevelAlias;
     mDirs = new StorageDir[storageDirNum];
 
+    mBlockEvictor =
+        EvictStrategies.getEvictStrategy(
+            mTachyonConf.getEnum(Constants.WORKER_EVICT_STRATEGY_TYPE, EvictStrategyType.LRU),
+            isLastTier());
+
     long quotaBytes = 0;
-    for (int i = 0; i < dirPaths.length; i++) {
+    for (int i = 0; i < dirPaths.length; i ++) {
       long storageDirId = StorageDirId.getStorageDirId(storageLevel, mAlias.getValue(), i);
       mDirs[i] =
           new StorageDir(storageDirId, dirPaths[i], dirCapacityBytes[i], dataFolder,
               userTempFolder, conf, mTachyonConf);
+      mDirs[i].setEvictStrategy(mBlockEvictor);
       quotaBytes += dirCapacityBytes[i];
     }
     mCapacityBytes = quotaBytes;
     mNextTier = nextTier;
-    mSpaceAllocator = AllocateStrategies.getAllocateStrategy(mTachyonConf.getEnum(
-        Constants.WORKER_ALLOCATE_STRATEGY_TYPE, AllocateStrategyType.MAX_FREE));
-    mBlockEvictor = EvictStrategies.getEvictStrategy(mTachyonConf.getEnum(
-        Constants.WORKER_EVICT_STRATEGY_TYPE, EvictStrategyType.LRU), isLastTier());
+    mSpaceAllocator =
+        AllocateStrategies.getAllocateStrategy(mTachyonConf.getEnum(
+            Constants.WORKER_ALLOCATE_STRATEGY_TYPE, AllocateStrategyType.MAX_FREE));
   }
 
   /**


### PR DESCRIPTION
This is a minimum modification to existing codes to fix [TACHYON-282](https://tachyon.atlassian.net/browse/TACHYON-282) 

I didn't modify EvictLRU, didn't move mLastBlockAccessTimeMS for these reasons:

1. all explicit synchronizations in StorageDir are involved with this field, modification to this field means the redesign of synchronization, prune to error, not core to the re-design of Evition Framework
2. access time is basic information for a block in a filesystem, with further Tachyon monitoring support, maybe we can display this information via a web UI like file explorer on PCs
3. do not want to modify existed EvictLRU* too much

I think the `Map<BlockId, ExtraBlockInfo>` mentioned in discussion in JIRA should be the implementation details of subclasses of EvictStrategy, I've tried to provide an API with this field but failed to design it as flexible as the current API design.

I went through the [former PR to provide LFU](https://github.com/amplab/tachyon/pull/663) and think it can be implemented with current API. 