### PR TITLE
Support TACHYON_PREPEND_TACHYON_CLASSES environment option

### DIFF
--- a/conf/tachyon-env.sh.template
+++ b/conf/tachyon-env.sh.template
@@ -58,6 +58,10 @@ export TACHYON_MASTER_MAX_WORKER_THREADS=2048
 export TACHYON_SSH_FOREGROUND="yes"
 export TACHYON_WORKER_SLEEP="0.02"
 
+# Prepend Tachyon classes before classes specified by TACHYON_CLASSPATH
+# in the Java classpath.  May be necessary if there are jar conflicts
+#export TACHYON_PREPEND_TACHYON_CLASSES="yes"
+
 CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export TACHYON_JAVA_OPTS+="

--- a/libexec/tachyon-config.sh
+++ b/libexec/tachyon-config.sh
@@ -34,4 +34,9 @@ if [ -e $TACHYON_CONF_DIR/tachyon-env.sh ] ; then
   . $TACHYON_CONF_DIR/tachyon-env.sh
 fi
 
-export CLASSPATH="$TACHYON_CONF_DIR/:$TACHYON_JAR:$TACHYON_CLASSPATH"
+# A developer option to prepend Tachyon jars before TACHYON_CLASSPATH jars
+if [ -n "$TACHYON_PREPEND_TACHYON_CLASSES" ]; then
+  export CLASSPATH="$TACHYON_CONF_DIR/:$TACHYON_JAR:$TACHYON_CLASSPATH"
+else
+  export CLASSPATH="$TACHYON_CONF_DIR/:$TACHYON_CLASSPATH:$TACHYON_JAR"
+fi


### PR DESCRIPTION
This option may be used to change the ordering of jars in the Java
classpath in the event of jar conflicts.

This option should help solve TACHYON-291

https://tachyon.atlassian.net/browse/TACHYON-291