### PR TITLE
Fix debugging in tachyon-workers.sh

### DIFF
--- a/bin/tachyon-workers.sh
+++ b/bin/tachyon-workers.sh
@@ -21,9 +21,9 @@ TACHYON_LIBEXEC_DIR=${TACHYON_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
 
 HOSTLIST=$TACHYON_CONF_DIR/workers
 
-for worker in `cat "$HOSTLIST"|sed  "s/#.*$//;/^$/d"`; do
+for worker in `cat "$HOSTLIST" | sed  "s/#.*$//;/^$/d"`; do
+  echo -n "Connecting to $worker as $USER... "
   if [ -n "${TACHYON_SSH_FOREGROUND}" ]; then
-    echo -n "Connection to $worker as $USER... "
     ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t $worker $LAUNCHER $"${@// /\\ }" 2>&1
   else
     ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -t $worker $LAUNCHER $"${@// /\\ }" 2>&1 &


### PR DESCRIPTION
The debug statement placed in tachyon-workers.ssh to state which user
account is being used to SSH to the remote workers was wrapped inside an
if by a later commit so it only fired when using non-background SSH
which doesn't aid debugging.  Moved the echo outside of the offending if statement

Also made minor white space changes for readability