### PR TITLE
Simplify call hierarchy of createWorker in TachyonWorker

### DIFF
--- a/core/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/core/src/main/java/tachyon/worker/TachyonWorker.java
@@ -56,7 +56,8 @@ public class TachyonWorker implements Runnable {
   /**
    * Create a new TachyonWorker
    * 
-   * @param masterAddress The TachyonMaster's address. e.g., localhost:19998
+   * @param masterAddress The TachyonMaster's address. e.g., localhost
+   * @param masterPort The TachyonMaster's port. e.g., 19998
    * @param workerPort This TachyonWorker's port. e.g., 29998
    * @param dataPort This TachyonWorker's data server's port
    * @param minWorkerThreads The min number of worker threads used in TThreadPoolServer
@@ -64,17 +65,27 @@ public class TachyonWorker implements Runnable {
    * @param tachyonConf The instance of {@link tachyon.conf.TachyonConf} to used by Worker.
    * @return The new TachyonWorker
    */
-  public static synchronized TachyonWorker createWorker(String masterAddress, int workerPort,
-      int dataPort, int minWorkerThreads, int maxWorkerThreads, TachyonConf tachyonConf) {
-    String[] address = masterAddress.split(":");
-    tachyonConf.set(Constants.MASTER_ADDRESS, address[0]);
-    if (address.length > 1) {
-      tachyonConf.set(Constants.MASTER_PORT, address[1]);
+  public static synchronized TachyonWorker createWorker(String masterAddress, int masterPort,
+      int workerPort, int dataPort, int minWorkerThreads, int maxWorkerThreads,
+      TachyonConf tachyonConf) {
+    if (masterAddress != null) {
+      tachyonConf.set(Constants.MASTER_ADDRESS, masterAddress);
     }
-    tachyonConf.set(Constants.WORKER_PORT, workerPort + "");
-    tachyonConf.set(Constants.WORKER_DATA_PORT, dataPort + "");
-    tachyonConf.set(Constants.WORKER_MIN_WORKER_THREADS, minWorkerThreads + "");
-    tachyonConf.set(Constants.WORKER_MAX_WORKER_THREADS, maxWorkerThreads + "");
+    if (masterPort >= 0) {
+      tachyonConf.set(Constants.MASTER_PORT, masterPort + "");
+    }
+    if (workerPort >= 0) {
+      tachyonConf.set(Constants.WORKER_PORT, workerPort + "");
+    }
+    if (dataPort >= 0) {
+      tachyonConf.set(Constants.WORKER_DATA_PORT, dataPort + "");
+    }
+    if (minWorkerThreads > 0) {
+      tachyonConf.set(Constants.WORKER_MIN_WORKER_THREADS, minWorkerThreads + "");
+    }
+    if (maxWorkerThreads > 0) {
+      tachyonConf.set(Constants.WORKER_MAX_WORKER_THREADS, maxWorkerThreads + "");
+    }
 
     return createWorker(tachyonConf);
   }

--- a/core/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/core/src/main/java/tachyon/worker/TachyonWorker.java
@@ -55,24 +55,6 @@ public class TachyonWorker implements Runnable {
 
   /**
    * Create a new TachyonWorker
-   *
-   * @param masterAddress The TachyonMaster's address
-   * @param workerAddress This TachyonWorker's address
-   * @param dataPort This TachyonWorker's data server's port
-   * @param minWorkerThreads The min number of worker threads used in TThreadPoolServer
-   * @param maxWorkerThreads The max number of worker threads used in TThreadPoolServer
-   * @param tachyonConf The instance of {@link tachyon.conf.TachyonConf} to used by Worker.
-   * @return The new TachyonWorker
-   */
-  public static synchronized TachyonWorker createWorker(InetSocketAddress masterAddress,
-      InetSocketAddress workerAddress, int dataPort, int minWorkerThreads, int maxWorkerThreads,
-      TachyonConf tachyonConf) {
-    return new TachyonWorker(masterAddress, workerAddress, dataPort, minWorkerThreads,
-        maxWorkerThreads, tachyonConf);
-  }
-
-  /**
-   * Create a new TachyonWorker
    * 
    * @param masterAddress The TachyonMaster's address. e.g., localhost:19998
    * @param workerPort This TachyonWorker's port. e.g., 29998

--- a/core/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/core/src/main/java/tachyon/worker/TachyonWorker.java
@@ -75,21 +75,26 @@ public class TachyonWorker implements Runnable {
    * Create a new TachyonWorker
    * 
    * @param masterAddress The TachyonMaster's address. e.g., localhost:19998
-   * @param workerAddress This TachyonWorker's address. e.g., localhost:29998
+   * @param workerPort This TachyonWorker's port. e.g., 29998
    * @param dataPort This TachyonWorker's data server's port
    * @param minWorkerThreads The min number of worker threads used in TThreadPoolServer
    * @param maxWorkerThreads The max number of worker threads used in TThreadPoolServer
    * @param tachyonConf The instance of {@link tachyon.conf.TachyonConf} to used by Worker.
    * @return The new TachyonWorker
    */
-  public static synchronized TachyonWorker createWorker(String masterAddress, String workerAddress,
+  public static synchronized TachyonWorker createWorker(String masterAddress, int workerPort,
       int dataPort, int minWorkerThreads, int maxWorkerThreads, TachyonConf tachyonConf) {
     String[] address = masterAddress.split(":");
-    InetSocketAddress master = new InetSocketAddress(address[0], Integer.parseInt(address[1]));
-    address = workerAddress.split(":");
-    InetSocketAddress worker = new InetSocketAddress(address[0], Integer.parseInt(address[1]));
-    return new TachyonWorker(master, worker, dataPort, minWorkerThreads, maxWorkerThreads,
-        tachyonConf);
+    tachyonConf.set(Constants.MASTER_ADDRESS, address[0]);
+    if (address.length > 1) {
+      tachyonConf.set(Constants.MASTER_PORT, address[1]);
+    }
+    tachyonConf.set(Constants.WORKER_PORT, workerPort + "");
+    tachyonConf.set(Constants.WORKER_DATA_PORT, dataPort + "");
+    tachyonConf.set(Constants.WORKER_MIN_WORKER_THREADS, minWorkerThreads + "");
+    tachyonConf.set(Constants.WORKER_MAX_WORKER_THREADS, maxWorkerThreads + "");
+
+    return createWorker(tachyonConf);
   }
 
   /**

--- a/core/src/test/java/tachyon/master/LocalTachyonCluster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonCluster.java
@@ -23,7 +23,6 @@ import tachyon.Constants;
 import tachyon.UnderFileSystem;
 import tachyon.client.TachyonFS;
 import tachyon.conf.TachyonConf;
-import tachyon.thrift.MasterService.AsyncProcessor.worker_cacheBlock;
 import tachyon.thrift.NetAddress;
 import tachyon.util.CommonUtils;
 import tachyon.util.NetworkUtils;
@@ -229,8 +228,8 @@ public final class LocalTachyonCluster {
     }
 
     mWorker =
-        TachyonWorker.createWorker(new InetSocketAddress(mLocalhostName, getMasterPort()),
-            new InetSocketAddress(mLocalhostName, 0), 0, 1, 100, mWorkerConf);
+        TachyonWorker.createWorker(mLocalhostName + ":" + getMasterPort(), 0, 0, 1, 100,
+            mWorkerConf);
     Runnable runWorker = new Runnable() {
       @Override
       public void run() {

--- a/core/src/test/java/tachyon/master/LocalTachyonCluster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonCluster.java
@@ -195,6 +195,7 @@ public final class LocalTachyonCluster {
     CommonUtils.sleepMs(null, 10);
 
     mWorkerConf = new TachyonConf(mMasterConf);
+    mWorkerConf.set(Constants.MASTER_HOSTNAME, mLocalhostName);
     mWorkerConf.set(Constants.MASTER_PORT, getMasterPort() + "");
     mWorkerConf.set(Constants.MASTER_WEB_PORT, (getMasterPort() + 1) + "");
     mWorkerConf.set(Constants.WORKER_PORT, "0");
@@ -228,8 +229,7 @@ public final class LocalTachyonCluster {
     }
 
     mWorker =
-        TachyonWorker.createWorker(mLocalhostName + ":" + getMasterPort(), 0, 0, 1, 100,
-            mWorkerConf);
+        TachyonWorker.createWorker(mWorkerConf);
     Runnable runWorker = new Runnable() {
       @Override
       public void run() {

--- a/core/src/test/java/tachyon/master/LocalTachyonCluster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonCluster.java
@@ -228,8 +228,7 @@ public final class LocalTachyonCluster {
           newPath.substring(0, newPath.length() - 1));
     }
 
-    mWorker =
-        TachyonWorker.createWorker(mWorkerConf);
+    mWorker = TachyonWorker.createWorker(mWorkerConf);
     Runnable runWorker = new Runnable() {
       @Override
       public void run() {

--- a/core/src/test/java/tachyon/master/LocalTachyonClusterMultiMaster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonClusterMultiMaster.java
@@ -200,7 +200,8 @@ public class LocalTachyonClusterMultiMaster {
     }
 
     mWorker =
-        TachyonWorker.createWorker(mCuratorServer.getConnectString(), 0, 0, 1, 100, mWorkerConf);
+        TachyonWorker.createWorker(mCuratorServer.getConnectString().split(":")[0],
+            mCuratorServer.getPort(), 0, 0, 1, 100, mWorkerConf);
     Runnable runWorker = new Runnable() {
       @Override
       public void run() {

--- a/core/src/test/java/tachyon/master/LocalTachyonClusterMultiMaster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonClusterMultiMaster.java
@@ -65,8 +65,6 @@ public class LocalTachyonClusterMultiMaster {
 
   private Thread mWorkerThread = null;
 
-  private String mLocalhostName = null;
-
   private final List<LocalTachyonMaster> mMasters = new ArrayList<LocalTachyonMaster>();
 
   private final Supplier<String> mClientSuppliers = new Supplier<String>() {
@@ -144,8 +142,6 @@ public class LocalTachyonClusterMultiMaster {
     String masterDataFolder = mTachyonHome + "/data";
     String masterLogFolder = mTachyonHome + "/logs";
 
-    mLocalhostName = NetworkUtils.getLocalHostName(100);
-
     mMasterConf = new TachyonConf();
     mMasterConf.set(Constants.IN_TEST_MODE, "true");
     mMasterConf.set(Constants.TACHYON_HOME, mTachyonHome);
@@ -217,9 +213,6 @@ public class LocalTachyonClusterMultiMaster {
     };
     mWorkerThread = new Thread(runWorker);
     mWorkerThread.start();
-
-    mWorkerConf.set(Constants.WORKER_PORT, mWorker.getMetaPort() + "");
-    mWorkerConf.set(Constants.WORKER_DATA_PORT, mWorker.getDataPort() + "");
   }
 
   public void stop() throws Exception {

--- a/core/src/test/java/tachyon/master/LocalTachyonClusterMultiMaster.java
+++ b/core/src/test/java/tachyon/master/LocalTachyonClusterMultiMaster.java
@@ -16,7 +16,6 @@ package tachyon.master;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -205,9 +204,7 @@ public class LocalTachyonClusterMultiMaster {
     }
 
     mWorker =
-        TachyonWorker.createWorker(
-            CommonUtils.parseInetSocketAddress(mCuratorServer.getConnectString()),
-            new InetSocketAddress(mLocalhostName, 0), 0, 1, 100, mWorkerConf);
+        TachyonWorker.createWorker(mCuratorServer.getConnectString(), 0, 0, 1, 100, mWorkerConf);
     Runnable runWorker = new Runnable() {
       @Override
       public void run() {


### PR DESCRIPTION
Currently, the TachyonConf is not updated when creating worker.
this change makes Tachyon always create worker through createWorker(TachyonConf conf) API.