### PR TITLE
Ignore .DS_STORE files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ tests.log*
 .classpath
 .project
 *.iml
+.DS_STORE
 .idea/
 .metadata/
 .settings/


### PR DESCRIPTION
Adds .DS_STORE to gitignore so mac users won't see those untracked files.