### PR TITLE
Omit non-exist blocks in the eviction algorithm

### DIFF
--- a/core/src/main/java/tachyon/worker/eviction/EvictLRU.java
+++ b/core/src/main/java/tachyon/worker/eviction/EvictLRU.java
@@ -57,7 +57,7 @@ public final class EvictLRU extends EvictLRUBase {
       long blockId = candidate.getSecond();
       long blockSize = dir.getBlockSize(blockId);
       long evictBytes = sizeToEvict.containsKey(dir) ? sizeToEvict.get(dir) : 0L;
-      if (blockSize > 0) {
+      if (blockSize != -1) {
         // Add info of the block to the list
         blockInfoList.add(new BlockInfo(dir, blockId, blockSize));
         dir2BlocksToEvict.put(dir, blockId);

--- a/core/src/main/java/tachyon/worker/eviction/EvictLRU.java
+++ b/core/src/main/java/tachyon/worker/eviction/EvictLRU.java
@@ -56,18 +56,16 @@ public final class EvictLRU extends EvictLRUBase {
       }
       long blockId = candidate.getSecond();
       long blockSize = dir.getBlockSize(blockId);
-      // Add info of the block to the list
-      blockInfoList.add(new BlockInfo(dir, blockId, blockSize));
-      dir2BlocksToEvict.put(dir, blockId);
-      dir2LRUBlocks.remove(dir);
-      long evictBytes;
-      // Update eviction size for this StorageDir
-      if (sizeToEvict.containsKey(dir)) {
-        evictBytes = sizeToEvict.get(dir) + blockSize;
-      } else {
-        evictBytes = blockSize;
+      long evictBytes = sizeToEvict.containsKey(dir) ? sizeToEvict.get(dir) : 0L;
+      if (blockSize > 0) {
+        // Add info of the block to the list
+        blockInfoList.add(new BlockInfo(dir, blockId, blockSize));
+        dir2BlocksToEvict.put(dir, blockId);
+        evictBytes += blockSize;
+        sizeToEvict.put(dir, evictBytes);
       }
-      sizeToEvict.put(dir, evictBytes);
+      dir2LRUBlocks.remove(dir);
+
       if (evictBytes + dir.getAvailableBytes() >= requestBytes) {
         return new Pair<StorageDir, List<BlockInfo>>(dir, blockInfoList);
       }

--- a/core/src/main/java/tachyon/worker/eviction/EvictPartialLRU.java
+++ b/core/src/main/java/tachyon/worker/eviction/EvictPartialLRU.java
@@ -46,9 +46,11 @@ public final class EvictPartialLRU extends EvictLRUBase {
         Pair<Long, Long> oldestAccess = getLRUBlock(dirSelected, blockIdSet, pinList);
         if (oldestAccess.getFirst() != -1) {
           long blockSize = dirSelected.getBlockSize(oldestAccess.getFirst());
-          sizeToEvict += blockSize;
-          blockInfoList.add(new BlockInfo(dirSelected, oldestAccess.getFirst(), blockSize));
-          blockIdSet.add(oldestAccess.getFirst());
+          if (blockSize > 0) {
+            sizeToEvict += blockSize;
+            blockInfoList.add(new BlockInfo(dirSelected, oldestAccess.getFirst(), blockSize));
+            blockIdSet.add(oldestAccess.getFirst());
+          }
         } else {
           break;
         }

--- a/core/src/main/java/tachyon/worker/eviction/EvictPartialLRU.java
+++ b/core/src/main/java/tachyon/worker/eviction/EvictPartialLRU.java
@@ -46,7 +46,7 @@ public final class EvictPartialLRU extends EvictLRUBase {
         Pair<Long, Long> oldestAccess = getLRUBlock(dirSelected, blockIdSet, pinList);
         if (oldestAccess.getFirst() != -1) {
           long blockSize = dirSelected.getBlockSize(oldestAccess.getFirst());
-          if (blockSize > 0) {
+          if (blockSize != -1) {
             sizeToEvict += blockSize;
             blockInfoList.add(new BlockInfo(dirSelected, oldestAccess.getFirst(), blockSize));
             blockIdSet.add(oldestAccess.getFirst());


### PR DESCRIPTION
It's possible that a block is deleted just after we think it as a candidate to evict. For a non-exist block, getBlockSize return -1. It doesn't make sense to use -1 as block size and continue other calculations. 