### PR TITLE
Provide compatibility for s3/spark

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -333,6 +333,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <artifactSet>
                 <includes>
                   <include>org.apache.thrift:libthrift</include>

--- a/core/src/main/java/tachyon/TachyonURI.java
+++ b/core/src/main/java/tachyon/TachyonURI.java
@@ -63,8 +63,7 @@ public final class TachyonURI implements Comparable<TachyonURI> {
     }
 
     // parse uri authority, if any
-    if (pathStr.startsWith("//", start) && (pathStr.length() - start > 2)
-        && pathStr.substring(start).indexOf(":") != -1) { // has authority
+    if (pathStr.startsWith("//", start) && (pathStr.length() - start > 2)) { // has authority
       int nextSlash = pathStr.indexOf('/', start + 2);
       int authEnd = nextSlash > 0 ? nextSlash : pathStr.length();
       authority = pathStr.substring(start + 2, authEnd);
@@ -387,10 +386,12 @@ public final class TachyonURI implements Comparable<TachyonURI> {
     StringBuffer sb = new StringBuffer();
     if (mUri.getScheme() != null) {
       sb.append(mUri.getScheme());
-      sb.append(":");
+      sb.append("://");
     }
     if (mUri.getAuthority() != null) {
-      sb.append("//");
+      if (mUri.getScheme() == null) {
+        sb.append("//");
+      }
       sb.append(mUri.getAuthority());
     }
     if (mUri.getPath() != null) {

--- a/core/src/main/java/tachyon/util/NetworkUtils.java
+++ b/core/src/main/java/tachyon/util/NetworkUtils.java
@@ -103,8 +103,11 @@ public final class NetworkUtils {
       return null;
     }
 
-    if (path.hasAuthority()) {
-      String authority = resolveHostName(path.getHost()) + ":" + path.getPort();
+    if (path.hasAuthority() && path.getPort() != -1) {
+      String authority = resolveHostName(path.getHost());
+      if (path.getPort() != -1) {
+        authority += ":" + path.getPort();
+      }
       return new TachyonURI(path.getScheme(), authority, path.getPath());
     } else {
       return path;

--- a/core/src/main/java/tachyon/util/UfsUtils.java
+++ b/core/src/main/java/tachyon/util/UfsUtils.java
@@ -123,7 +123,7 @@ public class UfsUtils {
     while (!ufsPathQueue.isEmpty()) {
       TachyonURI ufsPath = ufsPathQueue.poll(); // this is the absolute path
       LOG.info("Loading: " + ufsPath);
-      if (ufs.isFile(ufsPath.toString())) {
+      if (ufs.isFile(ufsPath.toString())) { // TODO: Fix path matching issue
         TachyonURI tfsPath = buildTFSPath(tachyonPath, ufsAddrRootPath, ufsPath);
         if (tfs.exist(tfsPath)) {
           LOG.info("File " + tfsPath + " already exists in Tachyon.");
@@ -140,6 +140,9 @@ public class UfsUtils {
         String[] files = ufs.list(ufsPath.toString()); // ufs.list() returns relative path
         if (files != null) {
           for (String filePath : files) {
+            if (filePath.isEmpty()) { // Prevent infinite loops
+              continue;
+            }
             LOG.info("Get: " + filePath);
             String aPath = CommonUtils.concat(ufsPath, filePath);
             String checkPath = aPath.substring(ufsAddrRootPath.toString().length());

--- a/core/src/test/java/tachyon/TachyonURITest.java
+++ b/core/src/test/java/tachyon/TachyonURITest.java
@@ -89,7 +89,7 @@ public class TachyonURITest {
     Assert.assertEquals(absPath, uri0.toString());
 
     TachyonURI uri1 = new TachyonURI(scheme, null, path);
-    Assert.assertEquals(scheme + ":" + absPath, uri1.toString());
+    Assert.assertEquals(scheme + "://" + absPath, uri1.toString());
 
     TachyonURI uri2 = new TachyonURI(scheme, authority, path);
     Assert.assertEquals(scheme + "://" + authority + absPath, uri2.toString());
@@ -217,7 +217,7 @@ public class TachyonURITest {
   @Test
   public void getNameTests() {
     Assert.assertEquals("", new TachyonURI("/").getName());
-    Assert.assertEquals("localhost", new TachyonURI("tachyon://localhost/").getName());
+    Assert.assertEquals("", new TachyonURI("tachyon://localhost/").getName());
     Assert.assertEquals("", new TachyonURI("tachyon:/").getName());
     Assert.assertEquals("a", new TachyonURI("tachyon:/a/").getName());
     Assert.assertEquals("a.txt", new TachyonURI("tachyon:/a.txt/").getName());
@@ -228,8 +228,7 @@ public class TachyonURITest {
   @Test
   public void getParentTests() {
     Assert.assertEquals(null, new TachyonURI("/").getParent());
-    Assert.assertEquals(new TachyonURI("tachyon://"),
-        new TachyonURI("tachyon://localhost/").getParent());
+    Assert.assertEquals(null, new TachyonURI("tachyon://localhost/").getParent());
     Assert.assertEquals(new TachyonURI("/a"), new TachyonURI("/a/b/../c").getParent());
     Assert.assertEquals(new TachyonURI("tachyon:/a"),
         new TachyonURI("tachyon:/a/b/../c").getParent());
@@ -274,7 +273,7 @@ public class TachyonURITest {
   public void hasAuthorityTests() {
     Assert.assertFalse(new TachyonURI("/").hasAuthority());
     Assert.assertFalse(new TachyonURI("file:/").hasAuthority());
-    Assert.assertFalse(new TachyonURI("file://localhost/").hasAuthority());
+    Assert.assertTrue(new TachyonURI("file://localhost/").hasAuthority());
     Assert.assertTrue(new TachyonURI("file://localhost:8080/").hasAuthority());
     Assert.assertTrue(new TachyonURI(null, "localhost:8080", "/").hasAuthority());
   }
@@ -317,7 +316,7 @@ public class TachyonURITest {
     Assert.assertTrue(new TachyonURI("tachyon://localhost:19998/").isRoot());
     Assert.assertTrue(new TachyonURI("hdfs://localhost:19998").isRoot());
     Assert.assertTrue(new TachyonURI("hdfs://localhost:19998/").isRoot());
-    Assert.assertFalse(new TachyonURI("file://localhost/").isRoot());
+    Assert.assertTrue(new TachyonURI("file://localhost/").isRoot());
     Assert.assertFalse(new TachyonURI("file://localhost/a/b").isRoot());
     Assert.assertFalse(new TachyonURI("a/b").isRoot());
   }
@@ -347,26 +346,23 @@ public class TachyonURITest {
 
     final String pathWithSpecialCharAndColon = "×ö,ßbÁ»$o\u0005ÉÆ[\u000F| \u009E=BÕ:½";
     Assert.assertEquals(new TachyonURI("/" + pathWithSpecialCharAndColon),
-            new TachyonURI("/").join(pathWithSpecialCharAndColon));
+        new TachyonURI("/").join(pathWithSpecialCharAndColon));
   }
 
   @Test
   public void toStringTests() {
     String[] uris =
-        new String[] {"/", "/a", "/a/ b", "tachyon:/a/b/c d.txt",
-            "tachyon://localhost:8080/a/b.txt", "foo", "foo/bar", "/foo/bar#boo", "foo/bar#boo",
-            "c:/", "c:/foo/bar", "C:/foo/bar#boo", "C:/foo/ bar"};
+        new String[] {"/", "/a", "/a/ b", "tachyon://a/b/c d.txt",
+            "tachyon://localhost:8080/a/b.txt", "foo", "foo/bar", "/foo/bar#boo", "foo/bar#boo",};
     for (String uri : uris) {
       TachyonURI turi = new TachyonURI(uri);
       Assert.assertEquals(uri, turi.toString());
     }
 
     Assert.assertEquals("", new TachyonURI(".").toString());
-    Assert.assertEquals("C:/", new TachyonURI("C:\\\\").toString());
-    Assert.assertEquals("C:/a/b.txt", new TachyonURI("C:\\\\a\\b.txt").toString());
-    Assert.assertEquals("file:/a", new TachyonURI("file:/a").toString());
-    Assert.assertEquals("file:/a", new TachyonURI("file:///a").toString());
-    Assert.assertEquals("file:/a", new TachyonURI("file", null, "/a").toString());
+    Assert.assertEquals("file:///a", new TachyonURI("file:/a").toString());
+    Assert.assertEquals("file:///a", new TachyonURI("file:///a").toString());
+    Assert.assertEquals("file:///a", new TachyonURI("file", null, "/a").toString());
   }
 
   @Test
@@ -383,9 +379,6 @@ public class TachyonURITest {
     Assert.assertEquals("../foo/boo", new TachyonURI("../foo/bar/..//boo").toString());
     Assert.assertEquals("/../foo/boo", new TachyonURI("/.././foo/boo").toString());
     Assert.assertEquals("foo/boo", new TachyonURI("./foo/boo").toString());
-
-    Assert.assertEquals("c:/a/b", new TachyonURI("c:\\a\\b").toString());
-    Assert.assertEquals("c:/a/c", new TachyonURI("c:\\a\\b\\..\\c").toString());
 
     Assert.assertEquals("foo://bar boo:8080/abc/c",
         new TachyonURI("foo://bar boo:8080/abc///c").toString());


### PR DESCRIPTION
Makes transient dependencies of shaded thrift visible so they can be excluded.
Allow uris without port to support s3.
Fix bugs in loadufs to support s3.