### PR TITLE
TACHYON-337: fix tfs rm output for non-existing files

### DIFF
--- a/core/src/main/java/tachyon/command/TFsShell.java
+++ b/core/src/main/java/tachyon/command/TFsShell.java
@@ -583,11 +583,14 @@ public class TFsShell implements Closeable {
     TachyonURI path = new TachyonURI(argv[1]);
     TachyonFS tachyonClient = createFS(path);
     TachyonFile tFile = tachyonClient.getFile(path);
-    if (tFile != null && tFile.isDirectory()) {
-      System.out.println("can't remove a directory, please try rmr <path>");
+    if (tFile == null) {
+      System.out.println("rm: cannot remove '" + path + "': No such file or directory");
       return -1;
     }
-
+    if (tFile.isDirectory()) {
+      System.out.println("rm: cannot remove a directory, please try rmr <path>");
+      return -1;
+    }
     if (tachyonClient.delete(path, false)) {
       System.out.println(path + " has been removed");
       return 0;

--- a/core/src/test/java/tachyon/command/TFsShellTest.java
+++ b/core/src/test/java/tachyon/command/TFsShellTest.java
@@ -477,7 +477,19 @@ public class TFsShellTest {
 
   @Test
   public void rmNotExistingFileTest() throws IOException {
-    Assert.assertEquals(0, mFsShell.rm(new String[] {"rm", "/testFile"}));
+    mFsShell.rm(new String[] {"rm", "/testFile"});
+    String expected= "rm: cannot remove '/testFile': No such file or directory\n";
+    Assert.assertEquals(expected, mOutput.toString());
+  }
+
+  @Test
+  public void rmNotExistingDirTest() throws IOException {
+    StringBuilder toCompare = new StringBuilder();
+    mFsShell.mkdir(new String[] {"mkdir", "/testFolder"});
+    toCompare.append(getCommandOutput(new String[] {"mkdir", "/testFolder"}));
+    mFsShell.rm(new String[] {"rm", "/testFolder"});
+    toCompare.append("rm: cannot remove a directory, please try rmr <path>\n");
+    Assert.assertEquals(toCompare.toString(), mOutput.toString());
   }
 
   @Test


### PR DESCRIPTION
1. Fix the incorrect output for tfs rm on non-exiting files.
2. Modify rmNonexistingFileTest
3. Add rmNonexistingDirTest