### PR TITLE
Improve support for Tachyon Perf on Shared FS

### DIFF
--- a/perf/bin/tachyon-perf
+++ b/perf/bin/tachyon-perf
@@ -24,13 +24,17 @@ NODELIST=$TACHYON_PERF_CONF_DIR/slaves
 taskid=0
 SLAVES=`cat "$NODELIST"|sed  "s/#.*$//;/^$/d"`
 UNIQ_SLAVES=`sort "$NODELIST" | uniq | sed  "s/#.*$//;/^$/d"`
-for slave in $UNIQ_SLAVES; do
-  echo -n "Copy configurations to $slave... "
-  scp $TACHYON_PERF_CONF_DIR/tachyon-perf-env.sh $slave:$TACHYON_PERF_CONF_DIR/tachyon-perf-env.sh
-  scp $TACHYON_PERF_CONF_DIR/testsuite/$1.xml $slave:$TACHYON_PERF_CONF_DIR/testsuite/$1.xml
-  sleep 0.02
-done
-wait
+if [ $TACHYON_PERF_SHARED_FS = "true" ]; then
+  echo "Installed on a Shared File System, no configuration copy needed"
+else
+  for slave in $UNIQ_SLAVES; do
+    echo -n "Copy configurations to $slave... "
+    scp $TACHYON_PERF_CONF_DIR/tachyon-perf-env.sh $slave:$TACHYON_PERF_CONF_DIR/tachyon-perf-env.sh
+    scp $TACHYON_PERF_CONF_DIR/testsuite/$1.xml $slave:$TACHYON_PERF_CONF_DIR/testsuite/$1.xml
+    sleep 0.02
+  done
+  wait
+fi
 
 for slave in $UNIQ_SLAVES; do
   slavenum=`echo $SLAVES | grep -o "$slave" | wc -l`

--- a/perf/bin/tachyon-perf-collect
+++ b/perf/bin/tachyon-perf-collect
@@ -26,9 +26,13 @@ mkdir -p $TACHYON_PERF_OUT_REPORTS_DIR
 
 taskid=0
 for slave in `cat "$NODELIST"|sed  "s/#.*$//;/^$/d"`; do
-  echo -n "Collect from $slave... "
-  scp $slave:$TACHYON_PERF_OUT_DIR/context$1-$taskid@$slave $TACHYON_PERF_OUT_REPORTS_DIR/context$1-$taskid@$slave
-  sleep 0.02
+  if [ $TACHYON_PERF_SHARED_FS = "true" ]; then
+    cp $TACHYON_PERF_OUT_DIR/context$1-$taskid@$slave $TACHYON_PERF_OUT_REPORTS_DIR/context$1-$taskid@$slave
+  else 
+    echo -n "Collect from $slave... "
+    scp $slave:$TACHYON_PERF_OUT_DIR/context$1-$taskid@$slave $TACHYON_PERF_OUT_REPORTS_DIR/context$1-$taskid@$slave
+    sleep 0.02
+  fi
   taskid=`expr $taskid + 1`
 done
 wait

--- a/perf/conf/tachyon-perf-env.sh.template
+++ b/perf/conf/tachyon-perf-env.sh.template
@@ -25,6 +25,10 @@ TACHYON_PERF_STATUS_DEBUG="false"
 TACHYON_PERF_FAILED_ABORT="true"
 TACHYON_PERF_FAILED_PERCENTAGE=1
 
+#if true the perf tool is installed on a shared file system visible to all slaves so copying
+#and collating configurations either is a no-op or a local copy rather than a scp
+TACHYON_PERF_SHARED_FS="false"
+
 PERF_CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export TACHYON_PERF_JAVA_OPTS+="

--- a/perf/libexec/tachyon-perf-config.sh
+++ b/perf/libexec/tachyon-perf-config.sh
@@ -16,7 +16,7 @@ export TACHYON_PERF_PREFIX=`dirname "$this"`/..
 export TACHYON_PERF_HOME=${TACHYON_PERF_PREFIX}
 export TACHYON_PERF_CONF_DIR="$TACHYON_PERF_HOME/conf"
 export TACHYON_PERF_LOGS_DIR="$TACHYON_PERF_HOME/logs"
-export TACHYON_PERF_JAR=$TACHYON_PERF_HOME/target/tachyon-perf-0.6.0-SNAPSHOT-jar-with-dependencies.jar
+export TACHYON_PERF_JAR=$TACHYON_PERF_HOME/target/tachyon-perf-0.7.0-SNAPSHOT-jar-with-dependencies.jar
 export JAVA="$JAVA_HOME/bin/java"
 
 TACHYON_CONF_FILE=$TACHYON_PERF_HOME/../conf/tachyon-env.sh


### PR DESCRIPTION
When Tachyon Perf is installed on a shared file system visible to all nodes
there is no need to do an scp to distribute the config nor to do an scp to
collect the results.

This commit adds a new variable to the config that when set will omit these scp
steps in favour of no-ops (for deploy) and local cp for collect

Also corrects the incorrect version in the JAR specified in `tachyon-perf-config.sh`