### PR TITLE
[TACHYON-340] Add workload 'Mixture' to Tachyon Perf

### DIFF
--- a/perf/conf/test-case.xml
+++ b/perf/conf/test-case.xml
@@ -28,5 +28,12 @@
     <taskThreadClass>tachyon.perf.benchmark.skipread.SkipReadThread</taskThreadClass>
     <totalReportClass>tachyon.perf.benchmark.SimpleTotalReport</totalReportClass>
   </type>
+  <type>
+    <name>Mixture</name>
+    <taskClass>tachyon.perf.benchmark.mixture.MixtureTask</taskClass>
+    <taskContextClass>tachyon.perf.benchmark.mixture.MixtureTaskContext</taskContextClass>
+    <taskThreadClass>tachyon.perf.benchmark.mixture.MixtureThread</taskThreadClass>
+    <totalReportClass>tachyon.perf.benchmark.SimpleTotalReport</totalReportClass>
+  </type>
 </taskTypes>
 

--- a/perf/conf/testsuite/Mixture.xml
+++ b/perf/conf/testsuite/Mixture.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <property>
+    <name>basic.files.per.thread</name>
+    <value>1</value>
+    <description>the number of basic files to write at the beginning for each thread</description>
+  </property>
+  <property>
+    <name>read.files.per.thread</name>
+    <value>2</value>
+    <description>the number of files to read for each thread</description>
+  </property>
+  <property>
+    <name>write.files.per.thread</name>
+    <value>1</value>
+    <description>the number of files to write for each thread</description>
+  </property>
+  <property>
+    <name>block.size.bytes</name>
+    <value>134217728</value>
+    <description>the block size of a file</description>
+  </property>
+  <property>
+    <name>file.length.bytes</name>
+    <value>134217728</value>
+    <description>the file size in bytes</description>
+  </property>
+  <property>
+    <name>buffer.size.bytes</name>
+    <value>4194304</value>
+    <description>the size of the buffer read and write once</description>
+  </property>
+  <property>
+    <name>read.type</name>
+    <value>CACHE</value>
+    <description>the ReadType of the read operation, now only used for TachyonFS</description>
+  </property>
+  <property>
+    <name>write.type</name>
+    <value>TRY_CACHE</value>
+    <description>the WriteType of the write operation, now only used for TachyonFS</description>
+  </property>
+</configuration>
+

--- a/perf/src/main/java/tachyon/perf/benchmark/Operators.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/Operators.java
@@ -143,7 +143,7 @@ public class Operators {
     byte[] content = new byte[bufferSize];
     InputStream is = fs.open(filePath, readType);
     int onceLen = is.read(content);
-    while (onceLen != -1) {
+    while (onceLen > 0) {
       readLen += (long) onceLen;
       onceLen = is.read(content);
     }
@@ -157,7 +157,7 @@ public class Operators {
     int readLen = 0;
     while (remainBytes >= content.length) {
       int once = is.read(content);
-      if (once == -1) {
+      if (once <= 0) {
         return readLen;
       }
       readLen += once;
@@ -165,7 +165,7 @@ public class Operators {
     }
     if (remainBytes > 0) {
       int once = is.read(content, 0, (int) remainBytes);
-      if (once == -1) {
+      if (once <= 0) {
         return readLen;
       }
       readLen += once;

--- a/perf/src/main/java/tachyon/perf/benchmark/mixture/MixtureTask.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/mixture/MixtureTask.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.benchmark.mixture;
+
+import tachyon.perf.basic.PerfTaskContext;
+import tachyon.perf.benchmark.SimpleTask;
+import tachyon.perf.conf.PerfConf;
+
+public class MixtureTask extends SimpleTask {
+  @Override
+  public String getCleanupDir() {
+    return PerfConf.get().WORK_DIR + "/mixture";
+  }
+
+  @Override
+  protected boolean setupTask(PerfTaskContext taskContext) {
+    String workDir = PerfConf.get().WORK_DIR + "/mixture/" + mId;
+    mTaskConf.addProperty("work.dir", workDir);
+    LOG.info("Work dir " + workDir);
+    return true;
+  }
+}

--- a/perf/src/main/java/tachyon/perf/benchmark/mixture/MixtureTaskContext.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/mixture/MixtureTaskContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.benchmark.mixture;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import tachyon.perf.basic.PerfThread;
+import tachyon.perf.benchmark.SimpleTaskContext;
+
+public class MixtureTaskContext extends SimpleTaskContext {
+  @Override
+  public void setFromThread(PerfThread[] threads) {
+    mAdditiveStatistics = new HashMap<String, List<Double>>(3);
+    List<Double> basicThroughputs = new ArrayList<Double>(threads.length);
+    List<Double> readThroughputs = new ArrayList<Double>(threads.length);
+    List<Double> writeThroughputs = new ArrayList<Double>(threads.length);
+    for (PerfThread thread : threads) {
+      if (!((MixtureThread) thread).getSuccess()) {
+        mSuccess = false;
+      }
+      basicThroughputs.add(((MixtureThread) thread).getBasicWriteThroughput());
+      readThroughputs.add(((MixtureThread) thread).getReadThroughput());
+      writeThroughputs.add(((MixtureThread) thread).getWriteThroughput());
+    }
+    mAdditiveStatistics.put("BasicWriteThroughput(MB/s)", basicThroughputs);
+    mAdditiveStatistics.put("ReadThroughput(MB/s)", readThroughputs);
+    mAdditiveStatistics.put("WriteThroughput(MB/s)", writeThroughputs);
+  }
+}

--- a/perf/src/main/java/tachyon/perf/benchmark/mixture/MixtureThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/mixture/MixtureThread.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.benchmark.mixture;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+
+import tachyon.perf.basic.PerfThread;
+import tachyon.perf.basic.TaskConfiguration;
+import tachyon.perf.benchmark.ListGenerator;
+import tachyon.perf.benchmark.Operators;
+import tachyon.perf.fs.PerfFileSystem;
+
+public class MixtureThread extends PerfThread {
+  private Random mRand;
+
+  private int mBasicFilesNum;
+  private int mBufferSize;
+  private long mFileLength;
+  private PerfFileSystem mFileSystem;
+  private int mReadFilesNum;
+  private String mWorkDir;
+  private int mWriteFilesNum;
+
+  private double mBasicWriteThroughput; // in MB/s
+  private double mReadThroughput; // in MB/s
+  private boolean mSuccess;
+  private double mWriteThroughput; // in MB/s
+
+  @Override
+  public boolean cleanupThread(TaskConfiguration taskConf) {
+    try {
+      mFileSystem.close();
+    } catch (IOException e) {
+      LOG.warn("Error when close file system, task " + mTaskId + " - thread " + mId, e);
+    }
+    return true;
+  }
+
+  public double getBasicWriteThroughput() {
+    return mBasicWriteThroughput;
+  }
+
+  public double getReadThroughput() {
+    return mReadThroughput;
+  }
+
+  public boolean getSuccess() {
+    return mSuccess;
+  }
+
+  public double getWriteThroughput() {
+    return mWriteThroughput;
+  }
+
+  private void initSyncBarrier() throws IOException {
+    mFileSystem.create(mWorkDir + "/sync/" + mId);
+  }
+
+  @Override
+  public void run() {
+    long basicBytes = 0;
+    long basicTimeMs = 0;
+    long readBytes = 0;
+    long readTimeMs = 0;
+    long writeBytes = 0;
+    long writeTimeMs = 0;
+    mSuccess = true;
+    String dataDir = mWorkDir + "/data";
+    String tmpDir = mWorkDir + "/tmp";
+
+    long tTimeMs = System.currentTimeMillis();
+    for (int b = 0; b < mBasicFilesNum; b ++) {
+      try {
+        String fileName = mId + "-" + b;
+        Operators.writeSingleFile(mFileSystem, dataDir + "/" + fileName, mFileLength, mBufferSize);
+        basicBytes += mFileLength;
+      } catch (IOException e) {
+        LOG.error("Failed to write basic file", e);
+        mSuccess = false;
+        break;
+      }
+    }
+    tTimeMs = System.currentTimeMillis() - tTimeMs;
+    basicTimeMs += tTimeMs;
+
+    try {
+      syncBarrier();
+    } catch (IOException e) {
+      LOG.error("Error in Sync Barrier", e);
+      mSuccess = false;
+    }
+    int index = 0;
+    while ((mReadFilesNum + mWriteFilesNum) > 0) {
+      tTimeMs = System.currentTimeMillis();
+      if (mRand.nextInt(mReadFilesNum + mWriteFilesNum) < mReadFilesNum) { // read
+        try {
+          List<String> candidates = mFileSystem.listFullPath(dataDir);
+          String readFilePath = ListGenerator.generateRandomReadFiles(1, candidates).get(0);
+          readBytes += Operators.readSingleFile(mFileSystem, readFilePath, mBufferSize);
+        } catch (IOException e) {
+          LOG.error("Failed to read file", e);
+          mSuccess = false;
+        }
+        readTimeMs += System.currentTimeMillis() - tTimeMs;
+        mReadFilesNum --;
+      } else { // write
+        try {
+          String writeFileName = mId + "--" + index;
+          Operators.writeSingleFile(mFileSystem, tmpDir + "/" + writeFileName, mFileLength,
+              mBufferSize);
+          writeBytes += mFileLength;
+          mFileSystem.rename(tmpDir + "/" + writeFileName, dataDir + "/" + writeFileName);
+        } catch (IOException e) {
+          LOG.error("Failed to write file", e);
+          mSuccess = false;
+        }
+        writeTimeMs += System.currentTimeMillis() - tTimeMs;
+        mWriteFilesNum --;
+      }
+      index ++;
+    }
+
+    mBasicWriteThroughput =
+        (basicBytes == 0) ? 0 : (basicBytes / 1024.0 / 1024.0) / (basicTimeMs / 1000.0);
+    mReadThroughput = (readBytes == 0) ? 0 : (readBytes / 1024.0 / 1024.0) / (readTimeMs / 1000.0);
+    mWriteThroughput =
+        (writeBytes == 0) ? 0 : (writeBytes / 1024.0 / 1024.0) / (writeTimeMs / 1000.0);
+  }
+
+  @Override
+  public boolean setupThread(TaskConfiguration taskConf) {
+    mRand = new Random(System.currentTimeMillis() + mTaskId + mId);
+    mBasicFilesNum = taskConf.getIntProperty("basic.files.per.thread");
+    mBufferSize = taskConf.getIntProperty("buffer.size.bytes");
+    mFileLength = taskConf.getLongProperty("file.length.bytes");
+    mReadFilesNum = taskConf.getIntProperty("read.files.per.thread");
+    mWorkDir = taskConf.getProperty("work.dir");
+    mWriteFilesNum = taskConf.getIntProperty("write.files.per.thread");
+    try {
+      mFileSystem = PerfFileSystem.get();
+      initSyncBarrier();
+    } catch (IOException e) {
+      LOG.error("Failed to setup thread, task " + mTaskId + " - thread " + mId, e);
+      return false;
+    }
+    mSuccess = false;
+    mBasicWriteThroughput = 0;
+    mReadThroughput = 0;
+    mWriteThroughput = 0;
+    return true;
+  }
+
+  private void syncBarrier() throws IOException {
+    String syncDirPath = mWorkDir + "/sync";
+    String syncFileName = "" + mId;
+    mFileSystem.delete(syncDirPath + "/" + syncFileName, false);
+    while (!mFileSystem.listFullPath(syncDirPath).isEmpty()) {
+      try {
+        Thread.sleep(300);
+      } catch (InterruptedException e) {
+        LOG.error("Error in Sync Barrier", e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a workload named 'Mixture'.
In this workload, each Perf Slave reads and writes files in a configured ratio. Different from SimpleRead and SimpleWrite workloads, this workload may read and write files at one time.