### PR TITLE
Parameterize Perf slave log file names

### DIFF
--- a/perf/bin/tachyon-perf
+++ b/perf/bin/tachyon-perf
@@ -46,4 +46,4 @@ for slave in $UNIQ_SLAVES; do
 done
 wait
 
-$JAVA -cp $TACHYON_PERF_CONF_DIR/:$TACHYON_PERF_JAR -Dtachyon.perf.home=$TACHYON_PERF_HOME -Dtachyon.perf.logger.type="PERF_MASTER_LOGGER" -Dlog4j.configuration=file:$TACHYON_PERF_CONF_DIR/log4j.properties $TACHYON_JAVA_OPTS $TACHYON_PERF_JAVA_OPTS tachyon.perf.TachyonPerfMaster $taskid $SLAVES $1
+$JAVA -cp $TACHYON_PERF_CONF_DIR/:$TACHYON_PERF_JAR -Dtachyon.perf.home=$TACHYON_PERF_HOME -Dtachyon.perf.logger.type="PERF_MASTER_LOGGER" -Dtachyon.perf.slave.id="" -Dlog4j.configuration=file:$TACHYON_PERF_CONF_DIR/log4j.properties $TACHYON_JAVA_OPTS $TACHYON_PERF_JAVA_OPTS tachyon.perf.TachyonPerfMaster $taskid $SLAVES $1

--- a/perf/bin/tachyon-perf-start.sh
+++ b/perf/bin/tachyon-perf-start.sh
@@ -22,7 +22,7 @@ if [ ! -d "$TACHYON_PERF_LOGS_DIR" ]; then
   mkdir -p $TACHYON_PERF_LOGS_DIR
 fi
 
-JAVACOMMAND="$JAVA -cp $TACHYON_PERF_CONF_DIR/:$TACHYON_PERF_JAR -Dtachyon.perf.home=$TACHYON_PERF_HOME -Dtachyon.perf.logger.type=PERF_SLAVE_LOGGER -Dlog4j.configuration=file:$TACHYON_PERF_CONF_DIR/log4j.properties $TACHYON_JAVA_OPTS $TACHYON_PERF_JAVA_OPTS tachyon.perf.TachyonPerfSlave"
+JAVACOMMAND="$JAVA -cp $TACHYON_PERF_CONF_DIR/:$TACHYON_PERF_JAR -Dtachyon.perf.home=$TACHYON_PERF_HOME -Dtachyon.perf.logger.type=PERF_SLAVE_LOGGER -Dtachyon.perf.slave.id="-$2" -Dlog4j.configuration=file:$TACHYON_PERF_CONF_DIR/log4j.properties $TACHYON_JAVA_OPTS $TACHYON_PERF_JAVA_OPTS tachyon.perf.TachyonPerfSlave"
 
 for (( i = $2; i <= $3; i ++))
 do

--- a/perf/bin/tachyon-perf-start.sh
+++ b/perf/bin/tachyon-perf-start.sh
@@ -22,7 +22,7 @@ if [ ! -d "$TACHYON_PERF_LOGS_DIR" ]; then
   mkdir -p $TACHYON_PERF_LOGS_DIR
 fi
 
-JAVACOMMAND="$JAVA -cp $TACHYON_PERF_CONF_DIR/:$TACHYON_PERF_JAR -Dtachyon.perf.home=$TACHYON_PERF_HOME -Dtachyon.perf.logger.type=PERF_SLAVE_LOGGER -Dtachyon.perf.slave.id="-$2" -Dlog4j.configuration=file:$TACHYON_PERF_CONF_DIR/log4j.properties $TACHYON_JAVA_OPTS $TACHYON_PERF_JAVA_OPTS tachyon.perf.TachyonPerfSlave"
+JAVACOMMAND="$JAVA -cp $TACHYON_PERF_CONF_DIR/:$TACHYON_PERF_JAR -Dtachyon.perf.home=$TACHYON_PERF_HOME -Dtachyon.perf.logger.type=PERF_SLAVE_LOGGER -Dtachyon.perf.slave.id="$2" -Dlog4j.configuration=file:$TACHYON_PERF_CONF_DIR/log4j.properties $TACHYON_JAVA_OPTS $TACHYON_PERF_JAVA_OPTS tachyon.perf.TachyonPerfSlave"
 
 for (( i = $2; i <= $3; i ++))
 do

--- a/perf/conf/log4j.properties
+++ b/perf/conf/log4j.properties
@@ -10,7 +10,7 @@ log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} (%F:%M) -
 
 # Appender for Tachyon-Perf
 log4j.appender.PERF_SLAVE_LOGGER=org.apache.log4j.RollingFileAppender
-log4j.appender.PERF_SLAVE_LOGGER.File=${tachyon.perf.home}/logs/slave${tachyon.perf.slave.id}.log
+log4j.appender.PERF_SLAVE_LOGGER.File=${tachyon.perf.home}/logs/slave-${tachyon.perf.slave.id}.log
 log4j.appender.PERF_SLAVE_LOGGER.MaxFileSize=10MB
 log4j.appender.PERF_SLAVE_LOGGER.MaxBackupIndex=100
 log4j.appender.PERF_SLAVE_LOGGER.layout=org.apache.log4j.PatternLayout

--- a/perf/conf/log4j.properties
+++ b/perf/conf/log4j.properties
@@ -10,7 +10,7 @@ log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} (%F:%M) -
 
 # Appender for Tachyon-Perf
 log4j.appender.PERF_SLAVE_LOGGER=org.apache.log4j.RollingFileAppender
-log4j.appender.PERF_SLAVE_LOGGER.File=${tachyon.perf.home}/logs/slave.log
+log4j.appender.PERF_SLAVE_LOGGER.File=${tachyon.perf.home}/logs/slave${tachyon.perf.slave.id}.log
 log4j.appender.PERF_SLAVE_LOGGER.MaxFileSize=10MB
 log4j.appender.PERF_SLAVE_LOGGER.MaxBackupIndex=100
 log4j.appender.PERF_SLAVE_LOGGER.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
When running Tachyon perf on a shared file system all the slaves log to a single
log file `slaves.log` which means their logging is interleaved and hard to read.

This commit parameterizes the name of the slaves log file to add the slave ID to
the log file name e.g. `slave-1.log`