### PR TITLE
[TACHYON-335] Vagrant block device mapping for AWS

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -61,6 +61,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           SECURITY_GROUP=@ec2['Security_Group']
           INSTANCE_TYPE = @ec2['Instance_Type']
           AVAILABILITY_ZONE  = @ec2['Availability_Zone']
+          BLOCK_DEVICE_MAPPING = @ec2['Block_Device_Mapping']
           TAG = @ec2['Tag']
         end
         config_aws(n, i, Total, name, Version)

--- a/deploy/vagrant/conf/ec2-config.yml
+++ b/deploy/vagrant/conf/ec2-config.yml
@@ -25,11 +25,11 @@ Instance_Type: "m1.small"
 # Block Device Mapping, modify this if you want your instance to have more than
 # 10 GB Storage. For more info see:
 # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
-Block_Device_Mapping:
-  - DeviceName: "/dev/sda1"
-    VirtualName: "root"
-    Ebs.VolumeSize: "100"
-    Ebs.DeleteOnTermination: "true"
+Block_Device_Mapping: []
+#  - DeviceName: "/dev/sda1"
+#    VirtualName: "root"
+#    Ebs.VolumeSize: "100"
+#    Ebs.DeleteOnTermination: "true"
 
 # tag to the instance name
 # to avoid name conflict during mutiple deployment

--- a/deploy/vagrant/conf/ec2-config.yml
+++ b/deploy/vagrant/conf/ec2-config.yml
@@ -22,6 +22,14 @@ Availability_Zone: "us-east-1b"
 
 Instance_Type: "m1.small"
 
+# Block Device Mapping, modify this if you want your instance to have more than
+# 10.7 GB Storage
+Block_Device_Mapping:
+  - DeviceName: "/dev/sda1"
+    VirtualName: "root"
+    Ebs.VolumeSize: "75"
+    Ebs.DeleteOnTermination: "true"
+
 # tag to the instance name
 # to avoid name conflict during mutiple deployment
 Tag: "my-"

--- a/deploy/vagrant/conf/ec2-config.yml
+++ b/deploy/vagrant/conf/ec2-config.yml
@@ -23,11 +23,12 @@ Availability_Zone: "us-east-1b"
 Instance_Type: "m1.small"
 
 # Block Device Mapping, modify this if you want your instance to have more than
-# 10.7 GB Storage
+# 10 GB Storage. For more info see:
+# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
 Block_Device_Mapping:
   - DeviceName: "/dev/sda1"
     VirtualName: "root"
-    Ebs.VolumeSize: "75"
+    Ebs.VolumeSize: "100"
     Ebs.DeleteOnTermination: "true"
 
 # tag to the instance name

--- a/deploy/vagrant/core/config_aws.rb
+++ b/deploy/vagrant/core/config_aws.rb
@@ -22,6 +22,7 @@ def config_aws(config, i, total, name, version)
     aws.ami = AMI
     aws.region = REGION
     aws.instance_type = INSTANCE_TYPE
+    aws.block_device_mapping = BLOCK_DEVICE_MAPPING
     aws.tags = {
       'Name' => TAG + name,
     }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-335

This isn't a complete fix for this issue, but this will allow the user to make larger/more ebs volumes. Without specifying block device mappings, the disk provided will only be 10GB.