### PR TITLE
[TACHYON-341] Use slaves file for Vagrant deploys with hadoop

### DIFF
--- a/deploy/vagrant/ufs/hadoop1/init.sh
+++ b/deploy/vagrant/ufs/hadoop1/init.sh
@@ -22,10 +22,10 @@ then
     ln -s `pwd`/hadoop-${HADOOP_VERSION} /hadoop
 
     # setup hadoop
-    rm -f /hadoop/conf/workers
+    rm -f /hadoop/conf/slaves
     for i in ${NODES[@]}
     do 
-        echo $i >> /hadoop/conf/workers
+        echo $i >> /hadoop/conf/slaves
     done
 
     # choose the last node as namenode

--- a/deploy/vagrant/ufs/hadoop2/init.sh
+++ b/deploy/vagrant/ufs/hadoop2/init.sh
@@ -19,10 +19,10 @@ then
     ln -s `pwd`/hadoop-${HADOOP_VERSION} /hadoop
 
     # setup hadoop
-    rm -f /hadoop/etc/hadoop/workers
+    rm -f /hadoop/etc/hadoop/slaves
     for i in ${nodes[@]}
     do 
-        echo $i >> /hadoop/etc/hadoop/workers
+        echo $i >> /hadoop/etc/hadoop/slaves
     done
 
     # choose the last node as namenode


### PR DESCRIPTION
https://tachyon.atlassian.net/projects/TACHYON/issues/TACHYON-341

Previously the workers file would be ignored and hdfs would run with only 1 data node (localhost).