### PR TITLE
 add warning message to UnderFileSystemHdfs list()

### DIFF
--- a/core/src/main/java/tachyon/UnderFileSystemHdfs.java
+++ b/core/src/main/java/tachyon/UnderFileSystemHdfs.java
@@ -296,10 +296,6 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
       for (FileStatus status : files) {
         TachyonURI filePathURI = new TachyonURI(status.getPath().toUri().toString());
         String filePath =  NetworkUtils.replaceHostName(filePathURI).toString();
-        if (filePath.length() < path.length()) {
-          LOG.warn("File Path should not be shorter than base dir path.  File Path: "
-              + filePath + " and Base Dir Path: " + path);
-        }
         // only return the relative path, to keep consistent with java.io.File.list()
         rtn[i ++] = filePath.substring(path.length()); // mUfsPrefix
       }

--- a/core/src/main/java/tachyon/UnderFileSystemHdfs.java
+++ b/core/src/main/java/tachyon/UnderFileSystemHdfs.java
@@ -38,6 +38,7 @@ import com.google.common.base.Throwables;
 
 import tachyon.conf.TachyonConf;
 import tachyon.hadoop.Utils;
+import tachyon.util.NetworkUtils;
 
 /**
  * HDFS UnderFilesystem implementation.
@@ -293,7 +294,8 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
       String[] rtn = new String[files.length];
       int i = 0;
       for (FileStatus status : files) {
-        String filePath = status.getPath().toUri().toString();
+        TachyonURI filePathURI = new TachyonURI(status.getPath().toUri().toString());
+        String filePath =  NetworkUtils.replaceHostName(filePathURI).toString();
         if (filePath.length() < path.length()) {
           LOG.warn("File Path should not be shorter than base dir path.  File Path: "
               + filePath + " and Base Dir Path: " + path);

--- a/core/src/main/java/tachyon/UnderFileSystemHdfs.java
+++ b/core/src/main/java/tachyon/UnderFileSystemHdfs.java
@@ -293,8 +293,14 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
       String[] rtn = new String[files.length];
       int i = 0;
       for (FileStatus status : files) {
+        String filePath = status.getPath().toUri().toString();
+        if (filePath.length() < path.length()) {
+          LOG.warn("File Path should not be shorter than base dir path.  File Path: "
+          + status.getPath().toUri().toString() + " and Base Dir Path: "
+          + path.toString());
+        }
         // only return the relative path, to keep consistent with java.io.File.list()
-        rtn[i ++] = status.getPath().toUri().toString().substring(path.length()); // mUfsPrefix
+        rtn[i ++] = filePath.substring(path.length()); // mUfsPrefix
       }
       return rtn;
     } else {

--- a/core/src/main/java/tachyon/UnderFileSystemHdfs.java
+++ b/core/src/main/java/tachyon/UnderFileSystemHdfs.java
@@ -296,8 +296,7 @@ public class UnderFileSystemHdfs extends UnderFileSystem {
         String filePath = status.getPath().toUri().toString();
         if (filePath.length() < path.length()) {
           LOG.warn("File Path should not be shorter than base dir path.  File Path: "
-          + status.getPath().toUri().toString() + " and Base Dir Path: "
-          + path.toString());
+              + filePath + " and Base Dir Path: " + path);
         }
         // only return the relative path, to keep consistent with java.io.File.list()
         rtn[i ++] = filePath.substring(path.length()); // mUfsPrefix


### PR DESCRIPTION
we have seen cases where the path gets mapped to another URL, leading to a base dir path that is longer than the file path.  Add this warning message to catch it early. 