### PR TITLE
[TACHYON-348]Modify if condition for reducing buffer copy and write frequency in BlockOutStream

### DIFF
--- a/core/src/main/java/tachyon/client/BlockOutStream.java
+++ b/core/src/main/java/tachyon/client/BlockOutStream.java
@@ -213,14 +213,14 @@ public class BlockOutStream extends OutStream {
 
     long userFileBufferBytes = mTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES,
         Constants.MB);
-    if (mBuffer.position() + len >= userFileBufferBytes && mBuffer.position() > 0) {
+    if (mBuffer.position() > 0 && mBuffer.position() + len > userFileBufferBytes) {
       appendCurrentBuffer(mBuffer.array(), 0, mBuffer.position());
       mBuffer.clear();
     }
 
-    if (len >= userFileBufferBytes) {
+    if (len > userFileBufferBytes/2) {
       appendCurrentBuffer(b, off, len);
-    } else {
+    } else if (len > 0) {
       mBuffer.put(b, off, len);
     }
 

--- a/core/src/main/java/tachyon/client/BlockOutStream.java
+++ b/core/src/main/java/tachyon/client/BlockOutStream.java
@@ -218,7 +218,7 @@ public class BlockOutStream extends OutStream {
       mBuffer.clear();
     }
 
-    if (len > userFileBufferBytes/2) {
+    if (len > userFileBufferBytes / 2) {
       appendCurrentBuffer(b, off, len);
     } else if (len > 0) {
       mBuffer.put(b, off, len);


### PR DESCRIPTION
JIRA Issue: https://tachyon.atlassian.net/browse/TACHYON-348

Changing if condition for reducing the buffer copy and write frequency.

For input byte array is consitent and capacity is `userFileBufferBytes/2`, it should be put into Buffer twice for making full use of the Buffer.

For input byte array is consistent and capacity greater than `userFileBufferBytes/2` and less than `userFileBufferBytes`, it should be written to mapped file directly instead of copying to Buffer.



