### PR TITLE
[TACHYON-347] Do not promote transitive dependencies.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -392,7 +392,6 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <artifactSet>
                 <includes>
                   <include>org.apache.thrift:libthrift</include>


### PR DESCRIPTION
https://tachyon.atlassian.net/projects/TACHYON/issues/TACHYON-347

Promote transitive dependencies causes everything to be promoted and not just thrift's dependencies.