### PR TITLE
[TACHYON-350] Clean up contract test profile.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -279,14 +279,13 @@
         </property>
       </activation>
       <properties>
-        <ufs>tachyon.LocalMiniDFSCluster</ufs>
-        <hadoop.version>2.6.0</hadoop.version>
+        <ufs></ufs>
       </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-minicluster</artifactId>
-          <version>${hadoop.version}</version>
+          <version>2.6.0</version>
           <exclusions>
             <exclusion>
               <groupId>asm</groupId>


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-350

Removes the ufs for contract test profile (property still required) and fixes the hadoop version to 2.6.0 so it can be run automatically by Jenkins (which will vary the hadoop.version property).