### PR TITLE
[TACHYON-357] Add workload 'Iterate' to Tachyon Perf

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -9,7 +9,7 @@ The following steps show how to run a Tachyon-Perf test.
 1. Copy `perf/conf/tachyon-perf-env.sh.template` to `perf/conf/tachyon-perf-env.sh` and configure it as prompted.
 2. Edit `perf/conf/slaves` to add testing slave nodes. It's recommended to be the same as `{tachyon.home}/conf/workers`. By the way, duplicate slave name is allowed which implies start multi-processes tests on one slave node.
 3. The running test command is `perf/bin/tachyon-perf <TestCase>`
- * The parameter is the name of test case, and now it should be `Metadata`, `SimpleWrite`, `SimpleRead` or `SkipRead`.
+ * The parameter is the name of test case, and now it should be `Metadata`, `SimpleWrite`, `SimpleRead`, `SkipRead`, `Mixture` or `Iterate`.
  * The test's configurations are in `conf/testSuite/<TestCase>.xml`, and you can modify it as your wish.
 4. When TachyonPerf is running, the status of the testing job will be collected and printed on the console. For some reasons, if you want to abort the tests, you can just press `Ctrl + C` to terminate it and then type the command `perf/bin/tachyon-perf-abort` on the master node to abort test processes on each slave node.
 5. After all the tests finished successfully, each slave node will generate a result report, locates at `result/` by default. You can also generate a total report by the command `./bin/tachyon-perf-collect <TestCase>`.

--- a/perf/bin/tachyon-perf
+++ b/perf/bin/tachyon-perf
@@ -3,7 +3,7 @@
 function printUsage {
   echo "Usage: tachyon-perf <TestCase>"
   echo "now TestCase is one of:"
-  echo -e "  SimpleWrite SimpleRead SkipRead Metadata"
+  echo -e "  SimpleWrite SimpleRead SkipRead Metadata Mixture Iterate"
   echo "the detailed configurations are in conf/testsuite/"
 }
 

--- a/perf/conf/test-case.xml
+++ b/perf/conf/test-case.xml
@@ -35,5 +35,12 @@
     <taskThreadClass>tachyon.perf.benchmark.mixture.MixtureThread</taskThreadClass>
     <totalReportClass>tachyon.perf.benchmark.SimpleTotalReport</totalReportClass>
   </type>
+  <type>
+    <name>Iterate</name>
+    <taskClass>tachyon.perf.benchmark.iterate.IterateTask</taskClass>
+    <taskContextClass>tachyon.perf.benchmark.iterate.IterateTaskContext</taskContextClass>
+    <taskThreadClass>tachyon.perf.benchmark.iterate.IterateThread</taskThreadClass>
+    <totalReportClass>tachyon.perf.benchmark.SimpleTotalReport</totalReportClass>
+  </type>
 </taskTypes>
 

--- a/perf/conf/testsuite/Iterate.xml
+++ b/perf/conf/testsuite/Iterate.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <property>
+    <name>iterations</name>
+    <value>2</value>
+    <description>the number of the write-read iteration</description>
+  </property>
+  <property>
+    <name>shuffle.mode</name>
+    <value>false</value>
+    <description>shuffle mode means it may read remotely</description>
+  </property>
+  <property>
+    <name>read.files.per.thread</name>
+    <value>2</value>
+    <description>the number of files to read for each thread</description>
+  </property>
+  <property>
+    <name>write.files.per.thread</name>
+    <value>2</value>
+    <description>the number of files to write for each thread</description>
+  </property>
+  <property>
+    <name>block.size.bytes</name>
+    <value>134217728</value>
+    <description>the block size of a file</description>
+  </property>
+  <property>
+    <name>file.length.bytes</name>
+    <value>134217728</value>
+    <description>the file size in bytes</description>
+  </property>
+  <property>
+    <name>buffer.size.bytes</name>
+    <value>4194304</value>
+    <description>the size of the buffer read and write once</description>
+  </property>
+  <property>
+    <name>read.type</name>
+    <value>NO_CACHE</value>
+    <description>the ReadType of the read operation, now only used for TachyonFS</description>
+  </property>
+  <property>
+    <name>write.type</name>
+    <value>TRY_CACHE</value>
+    <description>the WriteType of the write operation, now only used for TachyonFS</description>
+  </property>
+</configuration>

--- a/perf/conf/testsuite/Iterate.xml
+++ b/perf/conf/testsuite/Iterate.xml
@@ -3,12 +3,12 @@
   <property>
     <name>iterations</name>
     <value>2</value>
-    <description>the number of the write-read iteration</description>
+    <description>number of write-read iterations</description>
   </property>
   <property>
     <name>shuffle.mode</name>
     <value>false</value>
-    <description>shuffle mode means it may read remotely</description>
+    <description>workers will only read their own dataset by default, set shuffle mode to true to read from the entire dataset</description>
   </property>
   <property>
     <name>read.files.per.thread</name>

--- a/perf/src/main/java/tachyon/perf/benchmark/iterate/IterateTask.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/iterate/IterateTask.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.benchmark.iterate;
+
+import tachyon.perf.basic.PerfTaskContext;
+import tachyon.perf.benchmark.SimpleTask;
+import tachyon.perf.conf.PerfConf;
+
+public class IterateTask extends SimpleTask {
+  @Override
+  public String getCleanupDir() {
+    return PerfConf.get().WORK_DIR + "/iterate";
+  }
+
+  @Override
+  protected boolean setupTask(PerfTaskContext taskContext) {
+    String workDir = PerfConf.get().WORK_DIR + "/iterate";
+    mTaskConf.addProperty("work.dir", workDir);
+    LOG.info("Work dir " + workDir);
+    return true;
+  }
+}

--- a/perf/src/main/java/tachyon/perf/benchmark/iterate/IterateTaskContext.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/iterate/IterateTaskContext.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.benchmark.iterate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import tachyon.perf.basic.PerfThread;
+import tachyon.perf.benchmark.SimpleTaskContext;
+
+public class IterateTaskContext extends SimpleTaskContext {
+  @Override
+  public void setFromThread(PerfThread[] threads) {
+    mAdditiveStatistics = new HashMap<String, List<Double>>(2);
+    List<Double> readThroughputs = new ArrayList<Double>(threads.length);
+    List<Double> writeThroughputs = new ArrayList<Double>(threads.length);
+    for (PerfThread thread : threads) {
+      if (!((IterateThread) thread).getSuccess()) {
+        mSuccess = false;
+      }
+      readThroughputs.add(((IterateThread) thread).getReadThroughput());
+      writeThroughputs.add(((IterateThread) thread).getWriteThroughput());
+    }
+    mAdditiveStatistics.put("ReadThroughput(MB/s)", readThroughputs);
+    mAdditiveStatistics.put("WriteThroughput(MB/s)", writeThroughputs);
+  }
+}

--- a/perf/src/main/java/tachyon/perf/benchmark/iterate/IterateThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/iterate/IterateThread.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.benchmark.iterate;
+
+import java.io.IOException;
+import java.util.List;
+
+import tachyon.perf.basic.PerfThread;
+import tachyon.perf.basic.TaskConfiguration;
+import tachyon.perf.benchmark.ListGenerator;
+import tachyon.perf.benchmark.Operators;
+import tachyon.perf.fs.PerfFileSystem;
+
+public class IterateThread extends PerfThread {
+  protected int mBufferSize;
+  protected long mFileLength;
+  protected PerfFileSystem mFileSystem;
+  protected int mIterations;
+  protected int mReadFilesNum;
+  protected boolean mShuffle;
+  protected String mWorkDir;
+  protected int mWriteFilesNum;
+
+  protected double mReadThroughput; // in MB/s
+  protected boolean mSuccess;
+  protected double mWriteThroughput; // in MB/s
+
+  public double getReadThroughput() {
+    return mReadThroughput;
+  }
+
+  public boolean getSuccess() {
+    return mSuccess;
+  }
+
+  public double getWriteThroughput() {
+    return mWriteThroughput;
+  }
+
+  protected void initSyncBarrier() throws IOException {
+    String syncFileName = mTaskId + "-" + mId;
+    for (int i = 0; i < mIterations; i ++) {
+      mFileSystem.create(mWorkDir + "/sync/" + i + "/" + syncFileName);
+    }
+  }
+
+  protected void syncBarrier(int iteration) throws IOException {
+    String syncDirPath = mWorkDir + "/sync/" + iteration;
+    String syncFileName = mTaskId + "-" + mId;
+    mFileSystem.delete(syncDirPath + "/" + syncFileName, false);
+    while (!mFileSystem.listFullPath(syncDirPath).isEmpty()) {
+      try {
+        Thread.sleep(300);
+      } catch (InterruptedException e) {
+        LOG.error("Error in Sync Barrier", e);
+      }
+    }
+  }
+
+  @Override
+  public void run() {
+    long readBytes = 0;
+    long readTimeMs = 0;
+    long writeBytes = 0;
+    long writeTimeMs = 0;
+    mSuccess = true;
+    for (int i = 0; i < mIterations; i ++) {
+      String dataDir;
+      if (mShuffle) {
+        dataDir = mWorkDir + "/data/" + i;
+      } else {
+        dataDir = mWorkDir + "/data/" + mTaskId + "/" + i;
+      }
+
+      long tTimeMs = System.currentTimeMillis();
+      for (int w = 0; w < mWriteFilesNum; w ++) {
+        try {
+          String fileName = mTaskId + "-" + mId + "-" + w;
+          Operators.writeSingleFile(mFileSystem, dataDir + "/" + fileName, mFileLength,
+              mBufferSize);
+          writeBytes += mFileLength;
+        } catch (IOException e) {
+          LOG.error("Failed to write file", e);
+          mSuccess = false;
+        }
+      }
+      tTimeMs = System.currentTimeMillis() - tTimeMs;
+      writeTimeMs += tTimeMs;
+
+      try {
+        syncBarrier(i);
+      } catch (IOException e) {
+        LOG.error("Error in Sync Barrier", e);
+        mSuccess = false;
+      }
+      tTimeMs = System.currentTimeMillis();
+      try {
+        List<String> candidates = mFileSystem.listFullPath(dataDir);
+        List<String> readList = ListGenerator.generateRandomReadFiles(mReadFilesNum, candidates);
+        for (String fileName : readList) {
+          readBytes += Operators.readSingleFile(mFileSystem, fileName, mBufferSize);
+        }
+      } catch (Exception e) {
+        LOG.error("Failed to read file", e);
+        mSuccess = false;
+      }
+      tTimeMs = System.currentTimeMillis() - tTimeMs;
+      readTimeMs += tTimeMs;
+    }
+    mReadThroughput = (readBytes / 1024.0 / 1024.0) / (readTimeMs / 1000.0);
+    mWriteThroughput = (writeBytes / 1024.0 / 1024.0) / (writeTimeMs / 1000.0);
+  }
+
+  @Override
+  public boolean setupThread(TaskConfiguration taskConf) {
+    mBufferSize = taskConf.getIntProperty("buffer.size.bytes");
+    mFileLength = taskConf.getLongProperty("file.length.bytes");
+    mIterations = taskConf.getIntProperty("iterations");
+    mReadFilesNum = taskConf.getIntProperty("read.files.per.thread");
+    mShuffle = taskConf.getBooleanProperty("shuffle.mode");
+    mWorkDir = taskConf.getProperty("work.dir");
+    mWriteFilesNum = taskConf.getIntProperty("write.files.per.thread");
+    try {
+      mFileSystem = PerfFileSystem.get();
+      initSyncBarrier();
+    } catch (IOException e) {
+      LOG.error("Failed to setup thread, task " + mTaskId + " - thread " + mId, e);
+      return false;
+    }
+    mSuccess = false;
+    mReadThroughput = 0;
+    mWriteThroughput = 0;
+    return true;
+  }
+
+  @Override
+  public boolean cleanupThread(TaskConfiguration taskConf) {
+    try {
+      mFileSystem.close();
+    } catch (IOException e) {
+      LOG.warn("Error when close file system, task " + mTaskId + " - thread " + mId, e);
+    }
+    return true;
+  }
+
+}

--- a/perf/src/main/java/tachyon/perf/benchmark/iterate/IterateThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/iterate/IterateThread.java
@@ -97,8 +97,7 @@ public class IterateThread extends PerfThread {
           mSuccess = false;
         }
       }
-      tTimeMs = System.currentTimeMillis() - tTimeMs;
-      writeTimeMs += tTimeMs;
+      writeTimeMs += System.currentTimeMillis() - tTimeMs;
 
       try {
         syncBarrier(i);
@@ -117,11 +116,12 @@ public class IterateThread extends PerfThread {
         LOG.error("Failed to read file", e);
         mSuccess = false;
       }
-      tTimeMs = System.currentTimeMillis() - tTimeMs;
-      readTimeMs += tTimeMs;
+      readTimeMs += System.currentTimeMillis() - tTimeMs;
     }
-    mReadThroughput = (readBytes / 1024.0 / 1024.0) / (readTimeMs / 1000.0);
-    mWriteThroughput = (writeBytes / 1024.0 / 1024.0) / (writeTimeMs / 1000.0);
+    mReadThroughput =
+        (readTimeMs == 0) ? 0 : (readBytes / 1024.0 / 1024.0) / (readTimeMs / 1000.0);
+    mWriteThroughput =
+        (writeTimeMs == 0) ? 0 : (writeBytes / 1024.0 / 1024.0) / (writeTimeMs / 1000.0);
   }
 
   @Override


### PR DESCRIPTION
This workload tests in an iterative way - the output of the former iteration is the input of the next one.
Besides, two modes called _Shuffle_ and _Non-Shuffle_ are provided. In the _Shuffle_ mode, it reads files from the whole workspace, which may lead to remote reading across the cluster network. In the _Non-Shuffle_ mode, it only reads the files written by itself, which keeps good locality.