### PR TITLE
[TACHYON-359] fix for tachyon 359

### DIFF
--- a/core/src/main/java/tachyon/master/MasterInfo.java
+++ b/core/src/main/java/tachyon/master/MasterInfo.java
@@ -33,7 +33,7 @@ import java.util.Map.Entry;
 import java.util.Queue;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -276,7 +276,7 @@ public class MasterInfo extends ImageWriter {
   private final Map<NetAddress, Long> mWorkerAddressToId = new HashMap<NetAddress, Long>();
 
   private final BlockingQueue<MasterWorkerInfo> mLostWorkers =
-      new ArrayBlockingQueue<MasterWorkerInfo>(32);
+      new LinkedBlockingQueue<MasterWorkerInfo>();
 
   // TODO Check the logic related to this two lists.
   private final PrefixList mWhitelist;


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-359

In MasterInfo,  mLostWorkers is initialized to a fixed size queue (size = 32), when we have more than 32 failed workers, it would throw an exception as follows:

2015-04-02 17:30:29,144 ERROR server.TThreadPoolServer (TThreadPoolServer.java:run) - Error occurred during processing of message.
java.lang.IllegalStateException: Queue full
        at java.util.AbstractQueue.add(AbstractQueue.java:71)
        at java.util.concurrent.ArrayBlockingQueue.add(ArrayBlockingQueue.java:209)
        at tachyon.master.MasterInfo.registerWorker(MasterInfo.java:2065)
        at tachyon.master.MasterServiceHandler.worker_register(MasterServiceHandler.java:3
26)        at tachyon.thrift.MasterService$Processor$worker_register.getResult(MasterService.java:2445)
        at tachyon.thrift.MasterService$Processor$worker_register.getResult(MasterService.java:2429)
        at tachyon.org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
        at tachyon.org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
        at tachyon.org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:225)
        at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
        at java.lang.Thread.run(Thread.java:662)
2015-04-02 17:30:29,144 ERROR server.TThreadPoolServer (TThreadPoolServer.java:run) - Error occurred during processing of message.


Suggested Fix: change it to use LinkedBlockingQueue