### PR TITLE
Code cleanup. Remove unnessary function calls/operations

### DIFF
--- a/core/src/main/java/tachyon/client/FileOutStream.java
+++ b/core/src/main/java/tachyon/client/FileOutStream.java
@@ -159,12 +159,10 @@ public class FileOutStream extends OutStream {
     }
 
     if (mWriteType.isCache()) {
-      mCurrentBlockId = mFile.getBlockIdBasedOnOffset(mCachedBytes);
+      int offset = (int) (mCachedBytes / mBlockCapacityByte);
+      mCurrentBlockId = mFile.getBlockId(offset);
       mCurrentBlockLeftByte = mBlockCapacityByte;
-
-      mCurrentBlockOutStream =
-          new BlockOutStream(mFile, mWriteType, (int) (mCachedBytes / mBlockCapacityByte),
-              mTachyonConf);
+      mCurrentBlockOutStream = new BlockOutStream(mFile, mWriteType, offset, mTachyonConf);
     }
   }
 
@@ -197,7 +195,6 @@ public class FileOutStream extends OutStream {
             mCurrentBlockOutStream.write(b, tOff, tLen);
             mCurrentBlockLeftByte -= tLen;
             mCachedBytes += tLen;
-            tOff += tLen;
             tLen = 0;
           } else {
             mCurrentBlockOutStream.write(b, tOff, (int) mCurrentBlockLeftByte);


### PR DESCRIPTION
getBlockIdBasedOnOffset should be avoided when getBlockId(offset) can be used. tOff += tLen statement is redundant. 