### PR TITLE
[TACHYON-368] Listen on wildcard address on master

### DIFF
--- a/core/src/main/java/tachyon/master/TachyonMaster.java
+++ b/core/src/main/java/tachyon/master/TachyonMaster.java
@@ -94,9 +94,10 @@ public class TachyonMaster {
   public TachyonMaster(TachyonConf tachyonConf) {
     mTachyonConf = tachyonConf;
 
-    String hostName = mTachyonConf.get(Constants.MASTER_HOSTNAME, "localhost");
     int port = mTachyonConf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
-    InetSocketAddress address = new InetSocketAddress(hostName, port);
+    //HOSTNAME may be be different in complex setups
+    //so it's probably better to run on a wildcard IP, listening on all interfaces
+    InetSocketAddress address = new InetSocketAddress(port);
     int webPort =
         mTachyonConf.getInt(Constants.MASTER_WEB_PORT, Constants.DEFAULT_MASTER_WEB_PORT);
 


### PR DESCRIPTION
In case of complex network configuration for Tachyon cluster, like when working in AWS with Elastic IP attached to Tachyon master machine, external IP or DNS may not be related to addresses attached to the instance. Moreover, in such case external IP is undiscoverable at the instance itself. Same happen when working behind NATs or load balancers.