### PR TITLE
Remove promote transitive dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -333,7 +333,6 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <artifactSet>
                 <includes>
                   <include>org.apache.thrift:libthrift</include>


### PR DESCRIPTION
It is no longer necessary and causes the dependency tree to become excessively large.