### PR TITLE
Perf FileSystem Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ logs/
 script/
 target/
 **/tachyon-site.properties
+perf/result
+perf/conf/tachyon-perf-env.sh

--- a/perf/conf/tachyon-perf-env.sh.template
+++ b/perf/conf/tachyon-perf-env.sh.template
@@ -31,6 +31,9 @@ TACHYON_PERF_SHARED_FS="false"
 
 PERF_CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Specify this value and add to OPTS to test against another fs client impl.
+# TACHYON_PERF_UFS="Tachyon"
+
 export TACHYON_PERF_JAVA_OPTS+="
   -Dlog4j.configuration=file:$PERF_CONF_DIR/log4j.properties
   -Dtachyon.perf.failed.abort=$TACHYON_PERF_FAILED_ABORT

--- a/perf/conf/tachyon-perf-env.sh.template
+++ b/perf/conf/tachyon-perf-env.sh.template
@@ -32,6 +32,9 @@ TACHYON_PERF_SHARED_FS="false"
 PERF_CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Specify this value and add to the java opts to test against another fs client impl.
+# 'HDFS' will use HDFS's native FileSystem client
+# 'THCI' will use Tachyon's implementation (AbstractTFS) of HDFS's FileSystem interface
+# Any other value, including empty, will default to Tachyon's native FileSystem client.
 #TACHYON_PERF_UFS="Tachyon"
 #export TACHYON_PERF_JAVA_OPTS+="-Dtachyon.perf.ufs=$TACHYON_PERF_UFS"
 

--- a/perf/conf/tachyon-perf-env.sh.template
+++ b/perf/conf/tachyon-perf-env.sh.template
@@ -2,37 +2,38 @@
 
 # The following gives an example:
 
-#the workspace dir in Tachyon
+# The workspace dir in Tachyon
 export TACHYON_PERF_WORKSPACE="/tmp/tachyon-perf-workspace"
 
-#the report output path
+# The report output path
 export TACHYON_PERF_OUT_DIR="$TACHYON_PERF_HOME/result"
 
-#the tachyon-perf master service address
+# The tachyon-perf master service address
 TACHYON_PERF_MASTER_HOSTNAME="master"
 TACHYON_PERF_MASTER_PORT=23333
 
-#the threads num
+# The number of threads per worker
 TACHYON_PERF_THREADS_NUM=1
 
-#the slave is considered to be failed if not register in this time
+# The slave is considered to be failed if not register in this time
 TACHYON_PERF_UNREGISTER_TIMEOUT_MS=10000
 
-#if true, the TachyonPerfSupervision will print the names of those running and remaining nodes
+# If true, the TachyonPerfSupervision will print the names of those running and remaining nodes
 TACHYON_PERF_STATUS_DEBUG="false"
 
-#if true, the test will abort when the number of failed nodes more than the threshold
+# If true, the test will abort when the number of failed nodes more than the threshold
 TACHYON_PERF_FAILED_ABORT="true"
 TACHYON_PERF_FAILED_PERCENTAGE=1
 
-#if true the perf tool is installed on a shared file system visible to all slaves so copying
-#and collating configurations either is a no-op or a local copy rather than a scp
+# If true the perf tool is installed on a shared file system visible to all slaves so copying
+# and collating configurations either is a no-op or a local copy rather than a scp
 TACHYON_PERF_SHARED_FS="false"
 
 PERF_CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Specify this value and add to OPTS to test against another fs client impl.
-# TACHYON_PERF_UFS="Tachyon"
+# Specify this value and add to the java opts to test against another fs client impl.
+#TACHYON_PERF_UFS="Tachyon"
+#export TACHYON_PERF_JAVA_OPTS+="-Dtachyon.perf.ufs=$TACHYON_PERF_UFS"
 
 export TACHYON_PERF_JAVA_OPTS+="
   -Dlog4j.configuration=file:$PERF_CONF_DIR/log4j.properties

--- a/perf/src/main/java/tachyon/perf/PerfConstants.java
+++ b/perf/src/main/java/tachyon/perf/PerfConstants.java
@@ -15,10 +15,20 @@
 
 package tachyon.perf;
 
+import java.io.IOException;
+
+import tachyon.perf.fs.PerfFS;
+import tachyon.perf.fs.TachyonPerfFS;
+
+
 /**
  * Tachyon-Perf constants
  */
 public class PerfConstants {
   public static final String PERF_LOGGER_TYPE = System.getProperty("tachyon.perf.logger.type", "");
   public static final String PERF_CONTEXT_FILE_NAME_PREFIX = "context";
+
+  public static PerfFS getFileSystem() throws IOException {
+    return TachyonPerfFS.get();
+  }
 }

--- a/perf/src/main/java/tachyon/perf/PerfConstants.java
+++ b/perf/src/main/java/tachyon/perf/PerfConstants.java
@@ -17,7 +17,9 @@ package tachyon.perf;
 
 import java.io.IOException;
 
+import tachyon.perf.fs.HDFSPerfFS;
 import tachyon.perf.fs.PerfFS;
+import tachyon.perf.fs.THCIPerfFS;
 import tachyon.perf.fs.TachyonPerfFS;
 
 
@@ -27,8 +29,18 @@ import tachyon.perf.fs.TachyonPerfFS;
 public class PerfConstants {
   public static final String PERF_LOGGER_TYPE = System.getProperty("tachyon.perf.logger.type", "");
   public static final String PERF_CONTEXT_FILE_NAME_PREFIX = "context";
+  public static final String PERF_UFS = System.getProperty("tachyon.perf.ufs", "Tachyon");
 
   public static PerfFS getFileSystem() throws IOException {
+    if (PERF_UFS.equalsIgnoreCase("Tachyon")) {
+      return TachyonPerfFS.get();
+    }
+    if (PERF_UFS.equalsIgnoreCase("THCI")) {
+      return THCIPerfFS.get();
+    }
+    if (PERF_UFS.equalsIgnoreCase("HDFS")) {
+      return HDFSPerfFS.get();
+    }
     return TachyonPerfFS.get();
   }
 }

--- a/perf/src/main/java/tachyon/perf/SlaveStatus.java
+++ b/perf/src/main/java/tachyon/perf/SlaveStatus.java
@@ -21,7 +21,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
+import tachyon.perf.fs.TachyonPerfFS;
 import tachyon.perf.thrift.SlaveAlreadyRegisterException;
 import tachyon.perf.thrift.SlaveNotRegisterException;
 
@@ -75,7 +76,7 @@ public class SlaveStatus {
    * @throws IOException
    */
   public void cleanup() throws IOException {
-    PerfFileSystem fs = PerfFileSystem.get();
+    PerfFS fs = TachyonPerfFS.get();
     synchronized (this) {
       for (String dir : mCleanupDirs) {
         if (fs.exists(dir)) {

--- a/perf/src/main/java/tachyon/perf/benchmark/Operators.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/Operators.java
@@ -20,7 +20,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Random;
 
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
+import tachyon.perf.fs.TachyonPerfFS;
 
 /**
  * This class contains a set of file operators which can be used in different benchmarks.
@@ -41,7 +42,7 @@ public class Operators {
    * @return the actual number of bytes read
    * @throws IOException
    */
-  public static long forwardSkipRead(PerfFileSystem fs, String filePath, int bufferSize,
+  public static long forwardSkipRead(PerfFS fs, String filePath, int bufferSize,
       long skipBytes, long readBytes, String readType, int times) throws IOException {
     byte[] content = new byte[bufferSize];
     long readLen = 0;
@@ -63,7 +64,7 @@ public class Operators {
    * @return the actual number of finished metadata operations
    * @throws IOException
    */
-  public static int metadataSample(PerfFileSystem fs, String filePath) throws IOException {
+  public static int metadataSample(PerfFS fs, String filePath) throws IOException {
     String emptyFilePath = filePath + "/metadata-test-file";
     if (!fs.mkdirs(filePath, true)) {
       return 0;
@@ -95,7 +96,7 @@ public class Operators {
    * @return the actual number of bytes read
    * @throws IOException
    */
-  public static long randomSkipRead(PerfFileSystem fs, String filePath, int bufferSize,
+  public static long randomSkipRead(PerfFS fs, String filePath, int bufferSize,
       long readBytes, String readType, int times) throws IOException {
     byte[] content = new byte[bufferSize];
     long readLen = 0;
@@ -122,7 +123,7 @@ public class Operators {
    * @return the actual number of bytes read
    * @throws IOException
    */
-  public static long readSingleFile(PerfFileSystem fs, String filePath, int bufferSize)
+  public static long readSingleFile(PerfFS fs, String filePath, int bufferSize)
       throws IOException {
     return readSingleFile(fs, filePath, bufferSize, "NO_CACHE");
   }
@@ -137,7 +138,7 @@ public class Operators {
    * @return the actual number of bytes read
    * @throws IOException
    */
-  public static long readSingleFile(PerfFileSystem fs, String filePath, int bufferSize,
+  public static long readSingleFile(PerfFS fs, String filePath, int bufferSize,
       String readType) throws IOException {
     long readLen = 0;
     byte[] content = new byte[bufferSize];
@@ -195,7 +196,7 @@ public class Operators {
    * @param bufferSize
    * @throws IOException
    */
-  public static void writeSingleFile(PerfFileSystem fs, String filePath, long fileSize,
+  public static void writeSingleFile(PerfFS fs, String filePath, long fileSize,
       int bufferSize) throws IOException {
     OutputStream os = fs.create(filePath);
     writeContentToFile(os, fileSize, bufferSize);
@@ -212,7 +213,7 @@ public class Operators {
    * @param bufferSize
    * @throws IOException
    */
-  public static void writeSingleFile(PerfFileSystem fs, String filePath, long fileSize,
+  public static void writeSingleFile(PerfFS fs, String filePath, long fileSize,
       int blockSize, int bufferSize) throws IOException {
     OutputStream os = fs.create(filePath, blockSize);
     writeContentToFile(os, fileSize, bufferSize);
@@ -230,7 +231,7 @@ public class Operators {
    * @param writeType
    * @throws IOException
    */
-  public static void writeSingleFile(PerfFileSystem fs, String filePath, long fileSize,
+  public static void writeSingleFile(PerfFS fs, String filePath, long fileSize,
       int blockSize, int bufferSize, String writeType) throws IOException {
     OutputStream os = fs.create(filePath, blockSize, writeType);
     writeContentToFile(os, fileSize, bufferSize);

--- a/perf/src/main/java/tachyon/perf/benchmark/iterate/IterateThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/iterate/IterateThread.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -18,16 +18,17 @@ package tachyon.perf.benchmark.iterate;
 import java.io.IOException;
 import java.util.List;
 
+import tachyon.perf.PerfConstants;
 import tachyon.perf.basic.PerfThread;
 import tachyon.perf.basic.TaskConfiguration;
 import tachyon.perf.benchmark.ListGenerator;
 import tachyon.perf.benchmark.Operators;
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
 
 public class IterateThread extends PerfThread {
   protected int mBufferSize;
   protected long mFileLength;
-  protected PerfFileSystem mFileSystem;
+  protected PerfFS mFileSystem;
   protected int mIterations;
   protected int mReadFilesNum;
   protected boolean mShuffle;
@@ -134,7 +135,7 @@ public class IterateThread extends PerfThread {
     mWorkDir = taskConf.getProperty("work.dir");
     mWriteFilesNum = taskConf.getIntProperty("write.files.per.thread");
     try {
-      mFileSystem = PerfFileSystem.get();
+      mFileSystem = PerfConstants.getFileSystem();
       initSyncBarrier();
     } catch (IOException e) {
       LOG.error("Failed to setup thread, task " + mTaskId + " - thread " + mId, e);

--- a/perf/src/main/java/tachyon/perf/benchmark/metadata/MetadataThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/metadata/MetadataThread.java
@@ -17,13 +17,14 @@ package tachyon.perf.benchmark.metadata;
 
 import java.io.IOException;
 
+import tachyon.perf.PerfConstants;
 import tachyon.perf.basic.PerfThread;
 import tachyon.perf.basic.TaskConfiguration;
 import tachyon.perf.benchmark.Operators;
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
 
 public class MetadataThread extends PerfThread {
-  private PerfFileSystem[] mClients;
+  private PerfFS[] mClients;
   private int mClientsNum;
   private int mOpTimeMs;
   private String mWorkDir;
@@ -76,9 +77,9 @@ public class MetadataThread extends PerfThread {
     mOpTimeMs = taskConf.getIntProperty("op.second.per.thread") * 1000;
     mWorkDir = taskConf.getProperty("work.dir");
     try {
-      mClients = new PerfFileSystem[mClientsNum];
+      mClients = new PerfFS[mClientsNum];
       for (int i = 0; i < mClientsNum; i ++) {
-        mClients[i] = PerfFileSystem.get();
+        mClients[i] = PerfConstants.getFileSystem();
       }
     } catch (IOException e) {
       LOG.error("Failed to setup thread, task " + mTaskId + " - thread " + mId, e);

--- a/perf/src/main/java/tachyon/perf/benchmark/mixture/MixtureThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/mixture/MixtureThread.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -19,11 +19,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Random;
 
+import tachyon.perf.PerfConstants;
 import tachyon.perf.basic.PerfThread;
 import tachyon.perf.basic.TaskConfiguration;
 import tachyon.perf.benchmark.ListGenerator;
 import tachyon.perf.benchmark.Operators;
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
 
 public class MixtureThread extends PerfThread {
   private Random mRand;
@@ -31,7 +32,7 @@ public class MixtureThread extends PerfThread {
   private int mBasicFilesNum;
   private int mBufferSize;
   private long mFileLength;
-  private PerfFileSystem mFileSystem;
+  private PerfFS mFileSystem;
   private int mReadFilesNum;
   private String mWorkDir;
   private int mWriteFilesNum;
@@ -152,7 +153,7 @@ public class MixtureThread extends PerfThread {
     mWorkDir = taskConf.getProperty("work.dir");
     mWriteFilesNum = taskConf.getIntProperty("write.files.per.thread");
     try {
-      mFileSystem = PerfFileSystem.get();
+      mFileSystem = PerfConstants.getFileSystem();
       initSyncBarrier();
     } catch (IOException e) {
       LOG.error("Failed to setup thread, task " + mTaskId + " - thread " + mId, e);

--- a/perf/src/main/java/tachyon/perf/benchmark/simpleread/SimpleReadTask.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/simpleread/SimpleReadTask.java
@@ -17,16 +17,17 @@ package tachyon.perf.benchmark.simpleread;
 
 import java.io.IOException;
 
+import tachyon.perf.PerfConstants;
 import tachyon.perf.basic.PerfTaskContext;
 import tachyon.perf.benchmark.SimpleTask;
 import tachyon.perf.conf.PerfConf;
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
 
 public class SimpleReadTask extends SimpleTask {
   @Override
   protected boolean setupTask(PerfTaskContext taskContext) {
     try {
-      PerfFileSystem fs = PerfFileSystem.get();
+      PerfFS fs = PerfConstants.getFileSystem();
       String readDir = PerfConf.get().WORK_DIR + "/simple-read-write/" + mId;
       if (!fs.exists(readDir)) {
         throw new IOException("No data to read at " + readDir);

--- a/perf/src/main/java/tachyon/perf/benchmark/simpleread/SimpleReadThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/simpleread/SimpleReadThread.java
@@ -18,16 +18,17 @@ package tachyon.perf.benchmark.simpleread;
 import java.io.IOException;
 import java.util.List;
 
+import tachyon.perf.PerfConstants;
 import tachyon.perf.basic.PerfThread;
 import tachyon.perf.basic.TaskConfiguration;
 import tachyon.perf.benchmark.ListGenerator;
 import tachyon.perf.benchmark.Operators;
 import tachyon.perf.conf.PerfConf;
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
 
 public class SimpleReadThread extends PerfThread {
   private int mBufferSize;
-  private PerfFileSystem mFileSystem;
+  private PerfFS mFileSystem;
   private List<String> mReadFiles;
   private String mReadType;
 
@@ -74,7 +75,7 @@ public class SimpleReadThread extends PerfThread {
     mBufferSize = taskConf.getIntProperty("buffer.size.bytes");
     mReadType = taskConf.getProperty("read.type");
     try {
-      mFileSystem = PerfFileSystem.get();
+      mFileSystem = PerfConstants.getFileSystem();
       String readDir = taskConf.getProperty("read.dir");
       List<String> candidates = mFileSystem.listFullPath(readDir);
       if (candidates == null || candidates.isEmpty()) {

--- a/perf/src/main/java/tachyon/perf/benchmark/simplewrite/SimpleWriteThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/simplewrite/SimpleWriteThread.java
@@ -18,17 +18,18 @@ package tachyon.perf.benchmark.simplewrite;
 import java.io.IOException;
 import java.util.List;
 
+import tachyon.perf.PerfConstants;
 import tachyon.perf.basic.PerfThread;
 import tachyon.perf.basic.TaskConfiguration;
 import tachyon.perf.benchmark.ListGenerator;
 import tachyon.perf.benchmark.Operators;
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
 
 public class SimpleWriteThread extends PerfThread {
   private int mBlockSize;
   private int mBufferSize;
   private long mFileLength;
-  private PerfFileSystem mFileSystem;
+  private PerfFS mFileSystem;
   private List<String> mWriteFiles;
   private String mWriteType;
 
@@ -79,7 +80,7 @@ public class SimpleWriteThread extends PerfThread {
     mFileLength = taskConf.getLongProperty("file.length.bytes");
     mWriteType = taskConf.getProperty("write.type");
     try {
-      mFileSystem = PerfFileSystem.get();
+      mFileSystem = PerfConstants.getFileSystem();
       String writeDir = taskConf.getProperty("write.dir");
       int filesNum = taskConf.getIntProperty("files.per.thread");
       mWriteFiles = ListGenerator.generateWriteFiles(mId, filesNum, writeDir);

--- a/perf/src/main/java/tachyon/perf/benchmark/skipread/SkipReadTask.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/skipread/SkipReadTask.java
@@ -17,16 +17,17 @@ package tachyon.perf.benchmark.skipread;
 
 import java.io.IOException;
 
+import tachyon.perf.PerfConstants;
 import tachyon.perf.basic.PerfTaskContext;
 import tachyon.perf.benchmark.SimpleTask;
 import tachyon.perf.conf.PerfConf;
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
 
 public class SkipReadTask extends SimpleTask {
   @Override
   protected boolean setupTask(PerfTaskContext taskContext) {
     try {
-      PerfFileSystem fs = PerfFileSystem.get();
+      PerfFS fs = PerfConstants.getFileSystem();
       // use the SimpleWrite test data
       String readDir = PerfConf.get().WORK_DIR + "/simple-read-write/" + mId;
       if (!fs.exists(readDir)) {

--- a/perf/src/main/java/tachyon/perf/benchmark/skipread/SkipReadThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/skipread/SkipReadThread.java
@@ -18,16 +18,17 @@ package tachyon.perf.benchmark.skipread;
 import java.io.IOException;
 import java.util.List;
 
+import tachyon.perf.PerfConstants;
 import tachyon.perf.basic.PerfThread;
 import tachyon.perf.basic.TaskConfiguration;
 import tachyon.perf.benchmark.ListGenerator;
 import tachyon.perf.benchmark.Operators;
 import tachyon.perf.conf.PerfConf;
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
 
 public class SkipReadThread extends PerfThread {
   private int mBufferSize;
-  private PerfFileSystem mFileSystem;
+  private PerfFS mFileSystem;
   private long mReadBytes;
   private List<String> mReadFiles;
   private String mReadType;
@@ -90,7 +91,7 @@ public class SkipReadThread extends PerfThread {
     mSkipMode = taskConf.getProperty("skip.mode");
     mReadType = taskConf.getProperty("read.type");
     try {
-      mFileSystem = PerfFileSystem.get();
+      mFileSystem = PerfConstants.getFileSystem();
       String readDir = taskConf.getProperty("read.dir");
       List<String> candidates = mFileSystem.listFullPath(readDir);
       if (candidates == null || candidates.isEmpty()) {

--- a/perf/src/main/java/tachyon/perf/fs/HDFSPerfFS.java
+++ b/perf/src/main/java/tachyon/perf/fs/HDFSPerfFS.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.fs;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.common.base.Throwables;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+import tachyon.Constants;
+import tachyon.client.ReadType;
+import tachyon.client.WriteType;
+import tachyon.conf.TachyonConf;
+import tachyon.perf.PerfConstants;
+
+public class HDFSPerfFS implements PerfFS {
+  protected static final Logger LOG = Logger.getLogger(PerfConstants.PERF_LOGGER_TYPE);
+
+  public static HDFSPerfFS get() throws IOException {
+    return new HDFSPerfFS();
+  }
+
+  private TachyonConf mTachyonConf;
+  private FileSystem mTfs;
+
+  private HDFSPerfFS() {
+    try {
+      mTachyonConf = new TachyonConf();
+      Configuration conf = new Configuration();
+      String masterAddr = mTachyonConf.get(Constants.UNDERFS_ADDRESS, "");
+      URI u = new URI(masterAddr);
+      mTfs = FileSystem.get(u, conf);
+    } catch (IOException e) {
+      LOG.error("Failed to get HDFS client", e);
+      Throwables.propagate(e);
+    } catch (URISyntaxException u) {
+      LOG.error("Failed to parse underfs uri", u);
+      Throwables.propagate(u);
+    }
+  }
+
+  /**
+   * Close the connection to Tachyon
+   *
+   * @throws IOException
+   */
+  public void close() throws IOException {
+    mTfs.close();
+  }
+
+  /**
+   * Create a file. Use the default block size and TRY_CACHE write type.
+   *
+   * @param  path the file's full cPath
+   * @return the output stream of the created file
+   * @throws IOException
+   */
+  public OutputStream create(String path) throws IOException {
+    Path p = new Path(path);
+    return mTfs.create(p);
+  }
+
+  /**
+   * Create a file with the specified block size. Use the TRY_CACHE write type.
+   *
+   * @param path the file's full path
+   * @param blockSizeByte the block size of the file
+   * @return the output stream of the created file
+   * @throws IOException
+   */
+  public OutputStream create(String path, int blockSizeByte) throws IOException {
+    Path p = new Path(path);
+    return mTfs.create(p);
+  }
+
+  /**
+   * Create a file with the specified block size and write type.
+   *
+   * @param path the file's full path
+   * @param blockSizeByte the block size of the file
+   * @param writeType the write type of the file
+   * @return the output stream of the created file
+   * @throws IOException
+   */
+  public OutputStream create(String path, int blockSizeByte, String writeType) throws IOException {
+    WriteType type = WriteType.valueOf(writeType);
+    Path p = new Path(path);
+    return mTfs.create(p);
+  }
+
+  /**
+   * Create an empty file
+   *
+   * @param path the file's full path
+   * @return true if success, false otherwise.
+   * @throws IOException
+   */
+  public boolean createEmptyFile(String path) throws IOException {
+    Path p = new Path(path);
+    if (mTfs.exists(p)) {
+      return false;
+    }
+    mTfs.create(p).close();
+    return true;
+  }
+
+  /**
+   * Delete the file. If recursive and the path is a directory, it will delete all the files under
+   * the path.
+   *
+   * @param path the file's full path
+   * @param recursive It true, delete recursively
+   * @return true if success, false otherwise.
+   * @throws IOException
+   */
+  public boolean delete(String path, boolean recursive) throws IOException {
+    return mTfs.delete(new Path(path), recursive);
+  }
+
+  /**
+   * Check whether the file exists or not.
+   *
+   * @param path the file's full path
+   * @return true if exists, false otherwise
+   * @throws IOException
+   */
+  public boolean exists(String path) throws IOException {
+    return mTfs.exists(new Path(path));
+  }
+
+  /**
+   * Get the length of the file, in bytes.
+   *
+   * @param path
+   * @return the length of the file in bytes
+   * @throws IOException
+   */
+  public long getLength(String path) throws IOException {
+    Path p = new Path(path);
+    if (!mTfs.exists(p)) {
+      return 0;
+    }
+    return mTfs.getFileStatus(p).getLen();
+  }
+
+  /**
+   * Check if the path is a directory.
+   *
+   * @param path the file's full path
+   * @return true if it's a directory, false otherwise
+   * @throws IOException
+   */
+  public boolean isDirectory(String path) throws IOException {
+    Path p = new Path(path);
+    if (!mTfs.exists(p)) {
+      return false;
+    }
+    return mTfs.getFileStatus(p).isDir();
+  }
+
+  /**
+   * Check if the path is a file.
+   *
+   * @param path the file's full path
+   * @return true if it's a file, false otherwise
+   * @throws IOException
+   */
+  public boolean isFile(String path) throws IOException {
+    Path p = new Path(path);
+    if (!mTfs.exists(p)) {
+      return false;
+    }
+    return !mTfs.getFileStatus(p).isDir();
+  }
+
+  /**
+   * List the files under the path. If the path is a file, return the full path of the file. if the
+   * path is a directory, return the full paths of all the files under the path. Otherwise return
+   * null.
+   *
+   * @param path the file's full path
+   * @return the list contains the full paths of the listed files
+   * @throws IOException
+   */
+  public List<String> listFullPath(String path) throws IOException {
+    List<FileStatus> files = Arrays.asList(mTfs.listStatus(new Path(path)));
+    if (files == null) {
+      return null;
+    }
+    ArrayList<String> ret = new ArrayList<String>(files.size());
+    for (FileStatus fileInfo : files) {
+      ret.add(fileInfo.getPath().toString());
+    }
+    return ret;
+  }
+
+  /**
+   * Creates the directory named by the path. If the folder already exists, the method returns
+   * false.
+   *
+   * @param path the file's full path
+   * @param createParent If true, the method creates any necessary but nonexistent parent
+   *        directories. Otherwise, the method does not create nonexistent parent directories.
+   * @return true if success, false otherwise
+   * @throws IOException
+   */
+  public boolean mkdirs(String path, boolean createParent) throws IOException {
+    Path p = new Path(path);
+    if (mTfs.exists(p)) {
+      return false;
+    }
+    return mTfs.mkdirs(p);
+  }
+
+  /**
+   * Open a file and return it's input stream. Use the NO_CACHE read type.
+   *
+   * @param path the file's full path
+   * @return the input stream of the opened file
+   * @throws IOException
+   */
+  public InputStream open(String path) throws IOException {
+    Path p = new Path(path);
+    if (!mTfs.exists(p)) {
+      throw new FileNotFoundException("File not exists " + path);
+    }
+    return mTfs.open(p);
+  }
+
+  /**
+   * Open a file and return it's input stream, with the specified read type.
+   *
+   * @param path the file's full path
+   * @param readType the read type of the file
+   * @return the input stream of the opened file
+   * @throws IOException
+   */
+  public InputStream open(String path, String readType) throws IOException {
+    ReadType type = ReadType.valueOf(readType);
+    Path p = new Path(path);
+    if (!mTfs.exists(p)) {
+      throw new FileNotFoundException("File not exists " + path);
+    }
+    return mTfs.open(p);
+  }
+
+  /**
+   * Rename the file.
+   *
+   * @param src the src full path
+   * @param dst the dst full path
+   * @return true if success, false otherwise
+   * @throws IOException
+   */
+  public boolean rename(String src, String dst) throws IOException {
+    Path srcPath = new Path(src);
+    Path dstPath = new Path(dst);
+    return mTfs.rename(srcPath, dstPath);
+  }
+}

--- a/perf/src/main/java/tachyon/perf/fs/HDFSPerfFS.java
+++ b/perf/src/main/java/tachyon/perf/fs/HDFSPerfFS.java
@@ -33,8 +33,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Logger;
 
 import tachyon.Constants;
-import tachyon.client.ReadType;
-import tachyon.client.WriteType;
 import tachyon.conf.TachyonConf;
 import tachyon.perf.PerfConstants;
 
@@ -108,7 +106,7 @@ public class HDFSPerfFS implements PerfFS {
    * @throws IOException
    */
   public OutputStream create(String path, int blockSizeByte, String writeType) throws IOException {
-    WriteType type = WriteType.valueOf(writeType);
+    // Write type not applicable
     Path p = new Path(path);
     return mTfs.create(p);
   }
@@ -261,7 +259,7 @@ public class HDFSPerfFS implements PerfFS {
    * @throws IOException
    */
   public InputStream open(String path, String readType) throws IOException {
-    ReadType type = ReadType.valueOf(readType);
+    // Read type not applicable
     Path p = new Path(path);
     if (!mTfs.exists(p)) {
       throw new FileNotFoundException("File not exists " + path);

--- a/perf/src/main/java/tachyon/perf/fs/PerfFS.java
+++ b/perf/src/main/java/tachyon/perf/fs/PerfFS.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.fs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+public interface PerfFS {
+
+  public abstract void close() throws IOException;
+
+  public abstract OutputStream create(String path) throws IOException;
+
+  public abstract OutputStream create(String path, int blockSize) throws IOException;
+
+  public abstract OutputStream create(String path, int blockSize, String writeType)
+      throws IOException;
+
+  public abstract boolean createEmptyFile(String path) throws IOException;
+
+  public abstract boolean delete(String path, boolean recursive) throws IOException;
+
+  public abstract boolean exists(String path) throws IOException;
+
+  public abstract long getLength(String path) throws IOException;
+
+  public abstract boolean isDirectory(String path) throws IOException;
+
+  public abstract boolean isFile(String path) throws IOException;
+
+  public abstract List<String> listFullPath(String path) throws IOException;
+
+  public abstract boolean mkdirs(String path, boolean createParent) throws IOException;
+
+  public abstract InputStream open(String path) throws IOException;
+
+  public abstract InputStream open(String path, String readType) throws IOException;
+
+  public abstract boolean rename(String src, String dst) throws IOException;
+}

--- a/perf/src/main/java/tachyon/perf/fs/THCIPerfFS.java
+++ b/perf/src/main/java/tachyon/perf/fs/THCIPerfFS.java
@@ -33,8 +33,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Logger;
 
 import tachyon.Constants;
-import tachyon.client.ReadType;
-import tachyon.client.WriteType;
 import tachyon.conf.TachyonConf;
 import tachyon.hadoop.TFS;
 import tachyon.perf.PerfConstants;
@@ -110,7 +108,7 @@ public class THCIPerfFS implements PerfFS {
    * @throws IOException
    */
   public OutputStream create(String path, int blockSizeByte, String writeType) throws IOException {
-    WriteType type = WriteType.valueOf(writeType);
+    System.setProperty("tachyon.user.file.writetype.default", writeType);
     Path p = new Path(path);
     return mTfs.create(p);
   }
@@ -263,7 +261,7 @@ public class THCIPerfFS implements PerfFS {
    * @throws IOException
    */
   public InputStream open(String path, String readType) throws IOException {
-    ReadType type = ReadType.valueOf(readType);
+    // Read type hardcoded in thci
     Path p = new Path(path);
     if (!mTfs.exists(p)) {
       throw new FileNotFoundException("File not exists " + path);

--- a/perf/src/main/java/tachyon/perf/fs/THCIPerfFS.java
+++ b/perf/src/main/java/tachyon/perf/fs/THCIPerfFS.java
@@ -108,7 +108,7 @@ public class THCIPerfFS implements PerfFS {
    * @throws IOException
    */
   public OutputStream create(String path, int blockSizeByte, String writeType) throws IOException {
-    System.setProperty("tachyon.user.file.writetype.default", writeType);
+    // Write type needs to be set with Tachyon Java option in tachyon-perf-env.sh
     Path p = new Path(path);
     return mTfs.create(p);
   }

--- a/perf/src/main/java/tachyon/perf/fs/THCIPerfFS.java
+++ b/perf/src/main/java/tachyon/perf/fs/THCIPerfFS.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.fs;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.common.base.Throwables;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+import tachyon.Constants;
+import tachyon.client.ReadType;
+import tachyon.client.WriteType;
+import tachyon.conf.TachyonConf;
+import tachyon.hadoop.TFS;
+import tachyon.perf.PerfConstants;
+
+public class THCIPerfFS implements PerfFS {
+  protected static final Logger LOG = Logger.getLogger(PerfConstants.PERF_LOGGER_TYPE);
+
+  public static THCIPerfFS get() throws IOException {
+    return new THCIPerfFS();
+  }
+
+  private TachyonConf mTachyonConf;
+  private FileSystem mTfs;
+
+  private THCIPerfFS() {
+    try {
+      mTachyonConf = new TachyonConf();
+      Configuration conf = new Configuration();
+      conf.set("fs.tachyon.impl", TFS.class.getName());
+      String masterAddr = mTachyonConf.get(Constants.MASTER_ADDRESS, "");
+      URI u = new URI(masterAddr);
+      mTfs = FileSystem.get(u, conf);
+    } catch (IOException e) {
+      LOG.error("Failed to get TachyonFS", e);
+      Throwables.propagate(e);
+    } catch (URISyntaxException u) {
+      LOG.error("Failed to parse underfs uri", u);
+      Throwables.propagate(u);
+    }
+  }
+
+  /**
+   * Close the connection to Tachyon
+   *
+   * @throws IOException
+   */
+  public void close() throws IOException {
+    mTfs.close();
+  }
+
+  /**
+   * Create a file. Use the default block size and TRY_CACHE write type.
+   *
+   * @param  path the file's full cPath
+   * @return the output stream of the created file
+   * @throws IOException
+   */
+  public OutputStream create(String path) throws IOException {
+    Path p = new Path(path);
+    return mTfs.create(p);
+  }
+
+  /**
+   * Create a file with the specified block size. Use the TRY_CACHE write type.
+   *
+   * @param path the file's full path
+   * @param blockSizeByte the block size of the file
+   * @return the output stream of the created file
+   * @throws IOException
+   */
+  public OutputStream create(String path, int blockSizeByte) throws IOException {
+    Path p = new Path(path);
+    return mTfs.create(p);
+  }
+
+  /**
+   * Create a file with the specified block size and write type.
+   *
+   * @param path the file's full path
+   * @param blockSizeByte the block size of the file
+   * @param writeType the write type of the file
+   * @return the output stream of the created file
+   * @throws IOException
+   */
+  public OutputStream create(String path, int blockSizeByte, String writeType) throws IOException {
+    WriteType type = WriteType.valueOf(writeType);
+    Path p = new Path(path);
+    return mTfs.create(p);
+  }
+
+  /**
+   * Create an empty file
+   *
+   * @param path the file's full path
+   * @return true if success, false otherwise.
+   * @throws IOException
+   */
+  public boolean createEmptyFile(String path) throws IOException {
+    Path p = new Path(path);
+    if (mTfs.exists(p)) {
+      return false;
+    }
+    mTfs.create(p).close();
+    return true;
+  }
+
+  /**
+   * Delete the file. If recursive and the path is a directory, it will delete all the files under
+   * the path.
+   *
+   * @param path the file's full path
+   * @param recursive It true, delete recursively
+   * @return true if success, false otherwise.
+   * @throws IOException
+   */
+  public boolean delete(String path, boolean recursive) throws IOException {
+    return mTfs.delete(new Path(path), recursive);
+  }
+
+  /**
+   * Check whether the file exists or not.
+   *
+   * @param path the file's full path
+   * @return true if exists, false otherwise
+   * @throws IOException
+   */
+  public boolean exists(String path) throws IOException {
+    return mTfs.exists(new Path(path));
+  }
+
+  /**
+   * Get the length of the file, in bytes.
+   *
+   * @param path
+   * @return the length of the file in bytes
+   * @throws IOException
+   */
+  public long getLength(String path) throws IOException {
+    Path p = new Path(path);
+    if (!mTfs.exists(p)) {
+      return 0;
+    }
+    return mTfs.getFileStatus(p).getLen();
+  }
+
+  /**
+   * Check if the path is a directory.
+   *
+   * @param path the file's full path
+   * @return true if it's a directory, false otherwise
+   * @throws IOException
+   */
+  public boolean isDirectory(String path) throws IOException {
+    Path p = new Path(path);
+    if (!mTfs.exists(p)) {
+      return false;
+    }
+    return mTfs.getFileStatus(p).isDir();
+  }
+
+  /**
+   * Check if the path is a file.
+   *
+   * @param path the file's full path
+   * @return true if it's a file, false otherwise
+   * @throws IOException
+   */
+  public boolean isFile(String path) throws IOException {
+    Path p = new Path(path);
+    if (!mTfs.exists(p)) {
+      return false;
+    }
+    return !mTfs.getFileStatus(p).isDir();
+  }
+
+  /**
+   * List the files under the path. If the path is a file, return the full path of the file. if the
+   * path is a directory, return the full paths of all the files under the path. Otherwise return
+   * null.
+   *
+   * @param path the file's full path
+   * @return the list contains the full paths of the listed files
+   * @throws IOException
+   */
+  public List<String> listFullPath(String path) throws IOException {
+    List<FileStatus> files = Arrays.asList(mTfs.listStatus(new Path(path)));
+    if (files == null) {
+      return null;
+    }
+    ArrayList<String> ret = new ArrayList<String>(files.size());
+    for (FileStatus fileInfo : files) {
+      ret.add(fileInfo.getPath().toString());
+    }
+    return ret;
+  }
+
+  /**
+   * Creates the directory named by the path. If the folder already exists, the method returns
+   * false.
+   *
+   * @param path the file's full path
+   * @param createParent If true, the method creates any necessary but nonexistent parent
+   *        directories. Otherwise, the method does not create nonexistent parent directories.
+   * @return true if success, false otherwise
+   * @throws IOException
+   */
+  public boolean mkdirs(String path, boolean createParent) throws IOException {
+    Path p = new Path(path);
+    if (mTfs.exists(p)) {
+      return false;
+    }
+    return mTfs.mkdirs(p);
+  }
+
+  /**
+   * Open a file and return it's input stream. Use the NO_CACHE read type.
+   *
+   * @param path the file's full path
+   * @return the input stream of the opened file
+   * @throws IOException
+   */
+  public InputStream open(String path) throws IOException {
+    Path p = new Path(path);
+    if (!mTfs.exists(p)) {
+      throw new FileNotFoundException("File not exists " + path);
+    }
+    return mTfs.open(p);
+  }
+
+  /**
+   * Open a file and return it's input stream, with the specified read type.
+   *
+   * @param path the file's full path
+   * @param readType the read type of the file
+   * @return the input stream of the opened file
+   * @throws IOException
+   */
+  public InputStream open(String path, String readType) throws IOException {
+    ReadType type = ReadType.valueOf(readType);
+    Path p = new Path(path);
+    if (!mTfs.exists(p)) {
+      throw new FileNotFoundException("File not exists " + path);
+    }
+    return mTfs.open(p);
+  }
+
+  /**
+   * Rename the file.
+   *
+   * @param src the src full path
+   * @param dst the dst full path
+   * @return true if success, false otherwise
+   * @throws IOException
+   */
+  public boolean rename(String src, String dst) throws IOException {
+    Path srcPath = new Path(src);
+    Path dstPath = new Path(dst);
+    return mTfs.rename(srcPath, dstPath);
+  }
+}

--- a/perf/src/main/java/tachyon/perf/fs/TachyonPerfFS.java
+++ b/perf/src/main/java/tachyon/perf/fs/TachyonPerfFS.java
@@ -38,17 +38,17 @@ import tachyon.thrift.ClientFileInfo;
  * The interface layer to communicate with Tachyon. Now Tachyon Client APIs may change and this
  * layer can keep the modifications of Tachyon-Perf in this single file.
  */
-public class PerfFileSystem {
+public class TachyonPerfFS implements PerfFS {
   protected static final Logger LOG = Logger.getLogger(PerfConstants.PERF_LOGGER_TYPE);
 
-  public static PerfFileSystem get() throws IOException {
-    return new PerfFileSystem();
+  public static TachyonPerfFS get() throws IOException {
+    return new TachyonPerfFS();
   }
 
   private TachyonConf mTachyonConf;
   private TachyonFS mTfs;
 
-  private PerfFileSystem() {
+  private TachyonPerfFS() {
     try {
       mTachyonConf = new TachyonConf();
       mTfs = TachyonFS.get(mTachyonConf);

--- a/perf/src/main/java/tachyon/perf/fs/TachyonPerfFS.java
+++ b/perf/src/main/java/tachyon/perf/fs/TachyonPerfFS.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -60,7 +60,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Close the connection to Tachyon
-   * 
+   *
    * @throws IOException
    */
   public void close() throws IOException {
@@ -69,7 +69,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Create a file. Use the default block size and TRY_CACHE write type.
-   * 
+   *
    * @param path the file's full path
    * @return the output stream of the created file
    * @throws IOException
@@ -84,7 +84,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Create a file with the specified block size. Use the TRY_CACHE write type.
-   * 
+   *
    * @param path the file's full path
    * @param blockSizeByte the block size of the file
    * @return the output stream of the created file
@@ -100,7 +100,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Create a file with the specified block size and write type.
-   * 
+   *
    * @param path the file's full path
    * @param blockSizeByte the block size of the file
    * @param writeType the write type of the file
@@ -118,7 +118,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Create an empty file
-   * 
+   *
    * @param path the file's full path
    * @return true if success, false otherwise.
    * @throws IOException
@@ -134,7 +134,7 @@ public class TachyonPerfFS implements PerfFS {
   /**
    * Delete the file. If recursive and the path is a directory, it will delete all the files under
    * the path.
-   * 
+   *
    * @param path the file's full path
    * @param recursive It true, delete recursively
    * @return true if success, false otherwise.
@@ -146,7 +146,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Check whether the file exists or not.
-   * 
+   *
    * @param path the file's full path
    * @return true if exists, false otherwise
    * @throws IOException
@@ -157,7 +157,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Get the length of the file, in bytes.
-   * 
+   *
    * @param path
    * @return the length of the file in bytes
    * @throws IOException
@@ -172,7 +172,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Check if the path is a directory.
-   * 
+   *
    * @param path the file's full path
    * @return true if it's a directory, false otherwise
    * @throws IOException
@@ -187,7 +187,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Check if the path is a file.
-   * 
+   *
    * @param path the file's full path
    * @return true if it's a file, false otherwise
    * @throws IOException
@@ -204,7 +204,7 @@ public class TachyonPerfFS implements PerfFS {
    * List the files under the path. If the path is a file, return the full path of the file. if the
    * path is a directory, return the full paths of all the files under the path. Otherwise return
    * null.
-   * 
+   *
    * @param path the file's full path
    * @return the list contains the full paths of the listed files
    * @throws IOException
@@ -224,7 +224,7 @@ public class TachyonPerfFS implements PerfFS {
   /**
    * Creates the directory named by the path. If the folder already exists, the method returns
    * false.
-   * 
+   *
    * @param path the file's full path
    * @param createParent If true, the method creates any necessary but nonexistent parent
    *        directories. Otherwise, the method does not create nonexistent parent directories.
@@ -241,7 +241,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Open a file and return it's input stream. Use the NO_CACHE read type.
-   * 
+   *
    * @param path the file's full path
    * @return the input stream of the opened file
    * @throws IOException
@@ -256,7 +256,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Open a file and return it's input stream, with the specified read type.
-   * 
+   *
    * @param path the file's full path
    * @param readType the read type of the file
    * @return the input stream of the opened file
@@ -273,7 +273,7 @@ public class TachyonPerfFS implements PerfFS {
 
   /**
    * Rename the file.
-   * 
+   *
    * @param src the src full path
    * @param dst the dst full path
    * @return true if success, false otherwise

--- a/perf/src/main/java/tachyon/perf/tools/TachyonPerfCleaner.java
+++ b/perf/src/main/java/tachyon/perf/tools/TachyonPerfCleaner.java
@@ -18,8 +18,9 @@ package tachyon.perf.tools;
 import java.io.IOException;
 
 import tachyon.conf.TachyonConf;
+import tachyon.perf.PerfConstants;
 import tachyon.perf.conf.PerfConf;
-import tachyon.perf.fs.PerfFileSystem;
+import tachyon.perf.fs.PerfFS;
 
 /**
  * A tool to clean the workspace on Tachyon.
@@ -28,7 +29,7 @@ public class TachyonPerfCleaner {
   public static void main(String[] args) {
     String tachyonAddress = new TachyonConf().get(tachyon.Constants.MASTER_ADDRESS, "");
     try {
-      PerfFileSystem fs = PerfFileSystem.get();
+      PerfFS fs = PerfConstants.getFileSystem();
       fs.delete(PerfConf.get().WORK_DIR, true);
       fs.close();
     } catch (IOException e) {


### PR DESCRIPTION
Some code I wrote when benchmarking different client implementations in Tachyon Perf (specifically AbstractTFS and Hadoop's File System client).

The overall idea was to extract the current implementation of `PerfFileSystem` and make it into an interface, `PerfFS`. Then implement that interface with various different clients (ie. `TachyonPerfFS`, `THCIPerfFS`). This will allow tests to be made using the common interface and be extended to a variety of client implementations.

The filesystem to be used is specified through the config `TACHYON_PERF_UFS`. Currently it is just a string matching switch in `PerfConstants`, but it can be refactored to be more versatile if needed.