### PR TITLE
Fix slaves sort in perf's script

### DIFF
--- a/perf/bin/tachyon-perf
+++ b/perf/bin/tachyon-perf
@@ -22,7 +22,7 @@ TACHYON_PERF_LIBEXEC_DIR=${TACHYON_PERF_LIBEXEC_DIR:-$DEFAULT_PERF_LIBEXEC_DIR}
 NODELIST=$TACHYON_PERF_CONF_DIR/slaves
 
 taskid=0
-SLAVES=`cat "$NODELIST"|sed  "s/#.*$//;/^$/d"`
+SLAVES=`sort "$NODELIST"|sed  "s/#.*$//;/^$/d"`
 UNIQ_SLAVES=`sort "$NODELIST" | uniq | sed  "s/#.*$//;/^$/d"`
 if [ $TACHYON_PERF_SHARED_FS = "true" ]; then
   echo "Installed on a Shared File System, no configuration copy needed"

--- a/perf/bin/tachyon-perf-collect
+++ b/perf/bin/tachyon-perf-collect
@@ -25,7 +25,7 @@ fi
 mkdir -p $TACHYON_PERF_OUT_REPORTS_DIR
 
 taskid=0
-for slave in `cat "$NODELIST"|sed  "s/#.*$//;/^$/d"`; do
+for slave in `sort "$NODELIST"|sed  "s/#.*$//;/^$/d"`; do
   if [ $TACHYON_PERF_SHARED_FS = "true" ]; then
     cp $TACHYON_PERF_OUT_DIR/context$1-$taskid@$slave $TACHYON_PERF_OUT_REPORTS_DIR/context$1-$taskid@$slave
   else 


### PR DESCRIPTION
In tachyon-perf, you can write multi slaves in conf/slaves and they will have different IDs.
This PR fixes the bug that those slaves are sorted in some scripts and not sorted in others. For example, if you set conf/slaves as below:

    slave1
    slave2
    slave1

It must have the same IDs in all the scripts.