### PR TITLE
[TACHYON-219] Removed MasterClient.shutdown() and moved its functionality in the close...

### DIFF
--- a/core/src/main/java/tachyon/master/MasterClientHeartbeatExecutor.java
+++ b/core/src/main/java/tachyon/master/MasterClientHeartbeatExecutor.java
@@ -36,7 +36,7 @@ class MasterClientHeartbeatExecutor implements HeartbeatExecutor {
     try {
       mClient.user_heartbeat();
     } catch (IOException e) {
-      mClient.close();
+      mClient.disconnect();
       Throwables.propagate(e);
     }
   }

--- a/core/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/core/src/main/java/tachyon/worker/WorkerStorage.java
@@ -1013,7 +1013,7 @@ public class WorkerStorage {
    * Disconnect to the Master.
    */
   public void stop() {
-    mMasterClient.shutdown();
+    mMasterClient.close();
     // this will make sure that we don't move on till checkpoint threads are cleaned up
     // needed or tests can get resource issues
     mCheckpointExecutor.shutdownNow();

--- a/core/src/test/java/tachyon/master/MasterClientTest.java
+++ b/core/src/test/java/tachyon/master/MasterClientTest.java
@@ -69,7 +69,6 @@ public class MasterClientTest {
     masterClient.connect();
     Assert.assertTrue(masterClient.isConnected());
     Assert.assertTrue(masterClient.getFileStatus(-1, "/file") != null);
-    masterClient.close();
   }
 
   @Test(timeout = 3000, expected = FileNotFoundException.class)

--- a/core/src/test/java/tachyon/master/MasterClientTest.java
+++ b/core/src/test/java/tachyon/master/MasterClientTest.java
@@ -64,11 +64,12 @@ public class MasterClientTest {
     Assert.assertTrue(masterClient.isConnected());
     masterClient.user_createFile("/file", "", Constants.DEFAULT_BLOCK_SIZE_BYTE, true);
     Assert.assertTrue(masterClient.getFileStatus(-1, "/file") != null);
-    masterClient.close();
+    masterClient.disconnect();
     Assert.assertFalse(masterClient.isConnected());
     masterClient.connect();
     Assert.assertTrue(masterClient.isConnected());
     Assert.assertTrue(masterClient.getFileStatus(-1, "/file") != null);
+    masterClient.close();
   }
 
   @Test(timeout = 3000, expected = FileNotFoundException.class)


### PR DESCRIPTION
...() call. Renamed the previous close() to disconnect(), as it allows the user to temporarily disconnect with the Tachyon Master. Appropriate updates to the unit tests. Minor edits to the comments and log statements.