### PR TITLE
[TACHYON-373] Add a script which helps with the configuration of test cases

### DIFF
--- a/perf/bin/configure.xsl
+++ b/perf/bin/configure.xsl
@@ -1,0 +1,27 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:param name="name" />
+  <xsl:param name="value" />
+
+  <xsl:output indent="yes" />
+  <xsl:preserve-space elements="*" />
+
+  <xsl:template match="configuration">
+    <configuration>
+      <xsl:for-each select="./property">
+        <xsl:choose>
+           <xsl:when test="./name/text() = $name">
+             <property>
+               <name><xsl:value-of select="$name" /></name>
+               <value><xsl:value-of select="$value" /></value>
+               <description><xsl:value-of select="./description/text()" /></description>
+             </property>
+           </xsl:when>
+
+           <xsl:otherwise>
+             <xsl:copy-of select="." />
+           </xsl:otherwise>
+        </xsl:choose>
+      </xsl:for-each>
+    </configuration>
+  </xsl:template>
+</xsl:stylesheet>

--- a/perf/bin/tachyon-perf-configure
+++ b/perf/bin/tachyon-perf-configure
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+function printUsage() {
+  cat << EOF 
+Usage: tachyon-perf-configure <TestCase> [Name=Value ...]
+
+The TestCase is the same as tachyon-perf
+
+Each Name=Value pair will be used to change the given configuration setting for the
+given test case.  This allows for scriptable changes to the configuration which can
+be used to script running the same test case with a variety of different
+configurations.
+
+This script uses the xsltproc tool to apply the configuration changes and will fail
+if the tool is not available in your environment.
+EOF
+}
+
+TEST=$1
+if [ -z "${TEST}" ]; then
+  echo "No test case specified"
+  printUsage
+  exit 1
+fi
+
+# Ensure we have the required tools available
+which xsltproc > /dev/null 2>&1
+if [ $? != 0 ]; then
+  echo "Required tool xsltproc is not available on your system"
+  exit 1
+fi
+
+bin=`cd "$( dirname "$0" )"; pwd`
+
+# Pull in standard perf setup
+DEFAULT_PERF_LIBEXEC_DIR="$bin"/../libexec
+TACHYON_PERF_LIBEXEC_DIR=${TACHYON_PERF_LIBEXEC_DIR:-$DEFAULT_PERF_LIBEXEC_DIR}
+. $TACHYON_PERF_LIBEXEC_DIR/tachyon-perf-config.sh
+
+# Locate the configurationn file
+CONFIG_FILE="${TACHYON_PERF_HOME}/conf/testsuite/${TEST}.xml"
+
+if [ ! -e "${CONFIG_FILE}" ]; then
+  echo "Failed to locate test case configuration file for test ${TEST}"
+  exit 1
+fi
+
+# Create temporary files
+ORIG_FILE="${TACHYON_PERF_HOME}/conf/testsuite/${TEST}.xml.original"
+TEMP_FILE="${TACHYON_PERF_HOME}/conf/testsuite/${TEST}.xml.temp"
+cp "${CONFIG_FILE}" "${ORIG_FILE}"
+touch "${TEMP_FILE}"
+
+shift
+
+# Apply transforms
+IFS="="
+while [ $# -gt 0 ]
+do
+  NVP=(${1})
+
+  if [ ${#NVP[@]} -lt 2 ]; then
+    echo "Invalid NVP ${NVP}"
+  fi
+
+  NAME=${NVP[0]}
+  VALUE=${NVP[1]}
+
+  # Apply this parameter
+  xsltproc --stringparam name "${NAME}" --stringparam value "${VALUE}" --nonet "${TACHYON_PERF_HOME}/bin/configure.xsl" "${CONFIG_FILE}" > "${TEMP_FILE}"
+  RET=$?
+  if [ $RET != 0 ]; then
+    echo "Failed to set parameter ${NAME} to ${VALUE}"
+    cp "${ORIG_FILE}" "${CONFIG_FILE}"
+    exit 1
+  fi
+
+  # Replace configuration file with the updated file
+  mv "${TEMP_FILE}" "${CONFIG_FILE}"
+
+  shift
+done
+
+# Clean up
+if [ -e "${TEMP_FILE}" ]; then
+  rm "${TEMP_FILE}"
+fi
+rm "${ORIG_FILE}"
+
+echo "Successfully configured ${TEST} configuration ${CONFIG_FILE}"
+

--- a/perf/bin/tachyon-perf-configure
+++ b/perf/bin/tachyon-perf-configure
@@ -8,7 +8,7 @@ The TestCase is the same as tachyon-perf
 
 Each Name=Value pair will be used to change the given configuration setting for the
 given test case.  This allows for scriptable changes to the configuration which can
-be used to script running the same test case with a variety of different
+be used to automate running the same test case with a variety of different
 configurations.
 
 This script uses the xsltproc tool to apply the configuration changes and will fail
@@ -41,7 +41,7 @@ TACHYON_PERF_LIBEXEC_DIR=${TACHYON_PERF_LIBEXEC_DIR:-$DEFAULT_PERF_LIBEXEC_DIR}
 CONFIG_FILE="${TACHYON_PERF_HOME}/conf/testsuite/${TEST}.xml"
 
 if [ ! -e "${CONFIG_FILE}" ]; then
-  echo "Failed to locate test case configuration file for test ${TEST}"
+  echo "Failed to locate the configuration file for test case ${TEST}"
   exit 1
 fi
 
@@ -59,8 +59,9 @@ while [ $# -gt 0 ]
 do
   NVP=(${1})
 
-  if [ ${#NVP[@]} -lt 2 ]; then
+  if [ ${#NVP[@]} != 2 ]; then
     echo "Invalid NVP ${NVP}"
+    exit 1
   fi
 
   NAME=${NVP[0]}
@@ -87,5 +88,5 @@ if [ -e "${TEMP_FILE}" ]; then
 fi
 rm "${ORIG_FILE}"
 
-echo "Successfully configured ${TEST} configuration ${CONFIG_FILE}"
+echo "Successfully configured test case ${TEST} configuration file ${CONFIG_FILE}"
 

--- a/perf/bin/tachyon-perf-repeat
+++ b/perf/bin/tachyon-perf-repeat
@@ -50,7 +50,7 @@ PRECLEAN=0
 CLEAN=0
 shift
 
-while [[ $# > 1 ]]
+while [ $# -gt 0 ]
 do
   OPTION=$1
   shift

--- a/perf/bin/tachyon-perf-repeat
+++ b/perf/bin/tachyon-perf-repeat
@@ -4,7 +4,7 @@ function printUsage() {
   cat << EOF 
 Usage: tachyon-perf-repeat <TestCase> [Options]
 
-The TestCase is the same as ./tachyon-perf
+The TestCase is the same as tachyon-perf
 
 Options are as follows:
 


### PR DESCRIPTION
Test cases as they stand are configured via XML files which while nice
for humans to edit are something of a pain to script against.  This
commit adds a script that levarages the `xsltproc` command line tool to
automatically transform a configuration file.

The intent of the script is to make it easy for end users to script up
their benchmarks so that they can script a set of runs with different
configuration parameters without having to manually edit the XML files
between each run.