### PR TITLE
Support custom log directory

### DIFF
--- a/bin/tachyon
+++ b/bin/tachyon
@@ -258,4 +258,4 @@ else
   exit 1
 fi
 
-$JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.master.hostname=$TACHYON_MASTER_ADDRESS -Dtachyon.logger.type=USER_LOGGER $TACHYON_JAVA_OPTS $CLASS $PARAMETER $@
+$JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logs.dir=$TACHYON_LOGS_DIR -Dtachyon.master.hostname=$TACHYON_MASTER_ADDRESS -Dtachyon.logger.type=USER_LOGGER $TACHYON_JAVA_OPTS $CLASS $PARAMETER $@

--- a/bin/tachyon-start.sh
+++ b/bin/tachyon-start.sh
@@ -102,7 +102,7 @@ start_master() {
   fi
 
   echo "Starting master @ $MASTER_ADDRESS"
-  (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="MASTER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_MASTER_JAVA_OPTS tachyon.master.TachyonMaster > $TACHYON_LOGS_DIR/master.out 2>&1) &
+  (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logs.dir=$TACHYON_LOGS_DIR -Dtachyon.logger.type="MASTER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_MASTER_JAVA_OPTS tachyon.master.TachyonMaster > $TACHYON_LOGS_DIR/master.out 2>&1) &
 }
 
 start_worker() {
@@ -117,7 +117,7 @@ start_worker() {
   fi
 
   echo "Starting worker @ `hostname -f`"
-  (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="WORKER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker > $TACHYON_LOGS_DIR/worker.out 2>&1 ) &
+  (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logs.dir=$TACHYON_LOGS_DIR -Dtachyon.logger.type="WORKER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker > $TACHYON_LOGS_DIR/worker.out 2>&1 ) &
 }
 
 restart_worker() {
@@ -128,7 +128,7 @@ restart_worker() {
   RUN=`ps -ef | grep "tachyon.worker.TachyonWorker" | grep "java" | wc | cut -d" " -f7`
   if [[ $RUN -eq 0 ]] ; then
     echo "Restarting worker @ `hostname -f`"
-    (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logger.type="WORKER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker > $TACHYON_LOGS_DIR/worker.out 2>&1) &
+    (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logs.dir=$TACHYON_LOGS_DIR -Dtachyon.logger.type="WORKER_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker > $TACHYON_LOGS_DIR/worker.out 2>&1) &
   fi
 }
 

--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -10,7 +10,7 @@ log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} (%F:%M) -
 
 # Appender for Master
 log4j.appender.MASTER_LOGGER=org.apache.log4j.RollingFileAppender
-log4j.appender.MASTER_LOGGER.File=${tachyon.home}/logs/master.log
+log4j.appender.MASTER_LOGGER.File=${tachyon.logs.dir}/master.log
 log4j.appender.MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
@@ -19,7 +19,7 @@ log4j.appender.MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F
 
 # Appender for Workers
 log4j.appender.WORKER_LOGGER=org.apache.log4j.RollingFileAppender
-log4j.appender.WORKER_LOGGER.File=${tachyon.home}/logs/worker.log
+log4j.appender.WORKER_LOGGER.File=${tachyon.logs.dir}/worker.log
 log4j.appender.WORKER_LOGGER.MaxFileSize=10MB
 log4j.appender.WORKER_LOGGER.MaxBackupIndex=100
 log4j.appender.WORKER_LOGGER.layout=org.apache.log4j.PatternLayout
@@ -28,7 +28,7 @@ log4j.appender.WORKER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F
 
 # Appender for User
 log4j.appender.USER_LOGGER=org.apache.log4j.RollingFileAppender
-log4j.appender.USER_LOGGER.File=${tachyon.home}/logs/user.log
+log4j.appender.USER_LOGGER.File=${tachyon.logs.dir}/user.log
 log4j.appender.USER_LOGGER.MaxFileSize=10MB
 log4j.appender.USER_LOGGER.MaxBackupIndex=10
 log4j.appender.USER_LOGGER.layout=org.apache.log4j.PatternLayout

--- a/conf/tachyon-env.sh.template
+++ b/conf/tachyon-env.sh.template
@@ -62,6 +62,9 @@ export TACHYON_WORKER_SLEEP="0.02"
 # in the Java classpath.  May be necessary if there are jar conflicts
 #export TACHYON_PREPEND_TACHYON_CLASSES="yes"
 
+# Where log files are stored. $TACHYON_HOME/logs by default.
+#export TACHYON_LOGS_DIR=$TACHYON_HOME/logs
+
 CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export TACHYON_JAVA_OPTS+="

--- a/core/src/main/java/tachyon/Constants.java
+++ b/core/src/main/java/tachyon/Constants.java
@@ -94,6 +94,7 @@ public class Constants {
   public static final String TACHYON_HOME = "tachyon.home";
   public static final String WEB_RESOURCES = "tachyon.web.resources";
   public static final String WEB_THREAD_COUNT = "tachyon.web.threads";
+  public static final String LOGS_DIR = "tachyon.logs.dir";
   public static final String UNDERFS_ADDRESS = "tachyon.underfs.address";
   public static final String UNDERFS_DATA_FOLDER = "tachyon.data.folder";
   public static final String UNDERFS_WORKERS_FOLDER = "tachyon.workers.folder";

--- a/core/src/main/java/tachyon/web/WebInterfaceBrowseLogsServlet.java
+++ b/core/src/main/java/tachyon/web/WebInterfaceBrowseLogsServlet.java
@@ -119,8 +119,9 @@ public class WebInterfaceBrowseLogsServlet extends HttpServlet {
     request.setAttribute("baseUrl", "./browseLogs");
     request.setAttribute("currentPath", "");
 
-    String baseDir = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
-    File logsDir = new File(baseDir, "logs");
+    String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
+    String logsPath = mTachyonConf.get(Constants.LOGS_DIR, tachyonHome + "/logs");
+    File logsDir = new File(logsPath);
     String requestFile = request.getParameter("path");
 
     if (requestFile == null || requestFile.isEmpty()) {

--- a/core/src/main/java/tachyon/web/WebInterfaceBrowseLogsServlet.java
+++ b/core/src/main/java/tachyon/web/WebInterfaceBrowseLogsServlet.java
@@ -120,7 +120,8 @@ public class WebInterfaceBrowseLogsServlet extends HttpServlet {
     request.setAttribute("currentPath", "");
 
     String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
-    String logsPath = mTachyonConf.get(Constants.LOGS_DIR, tachyonHome + "/logs");
+    String logsPath =
+        mTachyonConf.get(Constants.LOGS_DIR, CommonUtils.concatPath(tachyonHome, "logs"));
     File logsDir = new File(logsPath);
     String requestFile = request.getParameter("path");
 

--- a/core/src/main/resources/tachyon-default.properties
+++ b/core/src/main/resources/tachyon-default.properties
@@ -22,6 +22,7 @@ tachyon.home=/mnt/tachyon_default_home
 tachyon.debug=false
 tachyon.web.resources=${tachyon.home}/core/src/main/webapp
 tachyon.web.threads=1
+tachyon.logs.dir=${tachyon.home}/logs
 tachyon.underfs.hadoop.prefixes=hdfs://,s3://,s3n://,glusterfs:///
 tachyon.underfs.address=${tachyon.home}/underFSStorage
 tachyon.underfs.hdfs.impl=org.apache.hadoop.hdfs.DistributedFileSystem

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -38,6 +38,11 @@ The common configuration contains constants which specify paths and the log appe
   <td>How many threads to use for the web server.</td>
 </tr>
 <tr>
+  <td>tachyon.logs.dir</td>
+  <td>$tachyon.home + "/logs"</td>
+  <td>Where log files are stored.</td>
+</tr>
+<tr>
   <td>tachyon.underfs.address</td>
   <td>$tachyon.home + "/underFSStorage"</td>
   <td>Tachyon folder in the underlayer file system.</td>


### PR DESCRIPTION
Enable web UI to support custom log directory. 
To use a custom log directory, a user can export TACHYON_LOGS_DIR in tachyon-env.sh