### PR TITLE
[Tachyon-101] Refactor Blockhandler

### DIFF
--- a/core/src/main/java/tachyon/worker/BlockHandler.java
+++ b/core/src/main/java/tachyon/worker/BlockHandler.java
@@ -15,89 +15,44 @@
 
 package tachyon.worker;
 
-import java.io.Closeable;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import io.netty.channel.FileRegion;
 
 import tachyon.TachyonURI;
 
 /**
- * Base class for handling block I/O. Block handlers for different under file systems can be
+ * General interface for handling block I/O. Block handlers for different under file systems can be
  * implemented by extending this class. It is not thread safe, the caller must guarantee thread
  * safe. This class is internal and subject to changes.
  */
-public abstract class BlockHandler implements Closeable {
+public interface BlockHandler extends ByteChannel {
 
-  /**
-   * Create a block handler according to path scheme
-   * 
-   * @param path the block path
-   * @return the handler of the block
-   * @throws IOException
-   * @throws IllegalArgumentException
-   */
-  public static BlockHandler get(String path) throws IOException, IllegalArgumentException {
-    if (path.startsWith(TachyonURI.SEPARATOR) || path.startsWith("file://")) {
-      return new BlockHandlerLocal(path);
+  class Factory {
+
+    public static BlockHandler get(String path)
+        throws IOException, IllegalArgumentException {
+      if (path.startsWith(TachyonURI.SEPARATOR) || path.startsWith("file://")) {
+        return new BlockHandlerLocal(path);
+      }
+      throw new IllegalArgumentException("Unsupported block file path: " + path);
     }
-    throw new IllegalArgumentException("Unsupported block file path: " + path);
   }
-
-  /**
-   * Append data to the block from a byte array
-   * 
-   * @param blockOffset starting position of the block file
-   * @param buf the data buffer
-   * @param offset the offset of the buffer
-   * @param length the length of the data
-   * @return the size of data that was written
-   * @throws IOException
-   */
-  public int append(long blockOffset, byte[] buf, int offset, int length) throws IOException {
-    return append(blockOffset, ByteBuffer.wrap(buf, offset, length));
-  }
-
-  /**
-   * Appends data to the block from a ByteBuffer
-   * 
-   * @param blockOffset starting position of the block file
-   * @param srcBuf ByteBuffer that data is stored in
-   * @return the size of data that was written
-   * @throws IOException
-   */
-  public abstract int append(long blockOffset, ByteBuffer srcBuf) throws IOException;
-
   /**
    * Deletes the block
    * 
    * @return true if success, otherwise false
    * @throws IOException
    */
-  public abstract boolean delete() throws IOException;
+  boolean delete() throws IOException;
 
-  /**
-   * Gets channel used to access block
-   * 
-   * @return the channel bounded with the block file
-   */
-  public abstract ByteChannel getChannel();
+  long position() throws IOException;
 
-  /**
-   * Gets the length of the block
-   * 
-   * @return the length of the block
-   * @throws IOException
-   */
-  public abstract long getLength() throws IOException;
+  BlockHandler position(long newPosition) throws IOException;
 
-  /**
-   * Reads data from block
-   * 
-   * @param offset the offset from starting of the block file
-   * @param length the length of data to read, -1 represents reading the rest of the block
-   * @return ByteBuffer the data that was read
-   * @throws IOException
-   */
-  public abstract ByteBuffer read(long offset, int length) throws IOException;
+  long transferTo(long position, long count, WritableByteChannel target) throws IOException;
+
+  FileRegion getFileRegion(long offset, long length);
 }

--- a/core/src/main/java/tachyon/worker/BlockHandler.java
+++ b/core/src/main/java/tachyon/worker/BlockHandler.java
@@ -32,6 +32,14 @@ public interface BlockHandler extends ByteChannel {
 
   class Factory {
 
+    /**
+     * Create a block handler according to path scheme
+     * 
+     * @param path the path of the block
+     * @return the handler for the block
+     * @throws IOException
+     * @throws IllegalArgumentException
+     */
     public static BlockHandler get(String path)
         throws IOException, IllegalArgumentException {
       if (path.startsWith(TachyonURI.SEPARATOR) || path.startsWith("file://")) {
@@ -48,11 +56,40 @@ public interface BlockHandler extends ByteChannel {
    */
   boolean delete() throws IOException;
 
+  /**
+   * Get the block position of current handler
+   * 
+   * @return the block position of current handler
+   * @throws IOException
+   */
   long position() throws IOException;
 
+  /**
+   * Set the block position for current handler
+   * 
+   * @param newPosition the position that will be set
+   * @return the handler with new position
+   * @throws IOException
+   */
   BlockHandler position(long newPosition) throws IOException;
 
+  /**
+   * Transfer a part of block to anther writable channel
+   * 
+   * @param position the starting position
+   * @param count the size of data to be transfered
+   * @param target the destination channel
+   * @return the size that is actually transfered
+   * @throws IOException
+   */
   long transferTo(long position, long count, WritableByteChannel target) throws IOException;
 
+  /**
+   * Get some file region for some part of block
+   * 
+   * @param offset the starting position
+   * @param length the length of the region
+   * @return file region for the specific part of block
+   */
   FileRegion getFileRegion(long offset, long length);
 }

--- a/core/src/main/java/tachyon/worker/BlockHandler.java
+++ b/core/src/main/java/tachyon/worker/BlockHandler.java
@@ -15,20 +15,20 @@
 
 package tachyon.worker;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.ByteChannel;
 
 import io.netty.channel.FileRegion;
 
 import tachyon.TachyonURI;
 
 /**
- * General interface for handling block I/O. Block handlers for different under file systems can be
- * implemented by extending this class. It is not thread safe, the caller must guarantee thread
- * safe. This class is internal and subject to changes.
+ * General interface for handling block I/O. Block handlers for different under file systems
+ * implement this interface. It is not thread safe, the caller must guarantee thread safe.
+ * This interface is internal and subject to changes.
  */
-public interface BlockHandler extends ByteChannel {
+public interface BlockHandler extends Closeable {
 
   class Factory {
 
@@ -40,8 +40,7 @@ public interface BlockHandler extends ByteChannel {
      * @throws IOException
      * @throws IllegalArgumentException
      */
-    public static BlockHandler get(String path)
-        throws IOException, IllegalArgumentException {
+    public static BlockHandler get(String path) throws IOException, IllegalArgumentException {
       if (path.startsWith(TachyonURI.SEPARATOR) || path.startsWith("file://")) {
         return new BlockHandlerLocal(path);
       }
@@ -50,7 +49,7 @@ public interface BlockHandler extends ByteChannel {
   }
 
   /**
-   * Deletes the block
+   * Delete the block
    * 
    * @return true if success, otherwise false
    * @throws IOException
@@ -58,7 +57,7 @@ public interface BlockHandler extends ByteChannel {
   boolean delete() throws IOException;
 
   /**
-   * Get some file region for some part of block
+   * Get file region for some part of block
    * 
    * @param offset the starting position
    * @param length the length of the region
@@ -82,10 +81,11 @@ public interface BlockHandler extends ByteChannel {
    * @param position the starting position in the block
    * @param length the size of the data to be transferred
    * @param dest the destination handler
+   * @param offset the offset in the destination handler
    * @return the size of data that is transferred
    * @throws IOException
    */
-  long transferTo(long position, long length, BlockHandler dest) throws IOException;
+  int transferTo(long position, int length, BlockHandler dest, long offset) throws IOException;
 
   /**
    * Write data to a block

--- a/core/src/main/java/tachyon/worker/BlockHandler.java
+++ b/core/src/main/java/tachyon/worker/BlockHandler.java
@@ -59,11 +59,11 @@ public interface BlockHandler extends Closeable {
   /**
    * Get file region for some part of block
    * 
-   * @param offset the starting position
+   * @param position the starting position
    * @param length the length of the region
    * @return file region for the specific part of block
    */
-  FileRegion getFileRegion(long offset, long length);
+  FileRegion getFileRegion(long position, long length);
 
   /**
    * Read data from a block

--- a/core/src/main/java/tachyon/worker/BlockHandler.java
+++ b/core/src/main/java/tachyon/worker/BlockHandler.java
@@ -16,8 +16,8 @@
 package tachyon.worker;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.ByteChannel;
-import java.nio.channels.WritableByteChannel;
 
 import io.netty.channel.FileRegion;
 
@@ -48,6 +48,7 @@ public interface BlockHandler extends ByteChannel {
       throw new IllegalArgumentException("Unsupported block file path: " + path);
     }
   }
+
   /**
    * Deletes the block
    * 
@@ -57,34 +58,6 @@ public interface BlockHandler extends ByteChannel {
   boolean delete() throws IOException;
 
   /**
-   * Get the block position of current handler
-   * 
-   * @return the block position of current handler
-   * @throws IOException
-   */
-  long position() throws IOException;
-
-  /**
-   * Set the block position for current handler
-   * 
-   * @param newPosition the position that will be set
-   * @return the handler with new position
-   * @throws IOException
-   */
-  BlockHandler position(long newPosition) throws IOException;
-
-  /**
-   * Transfer a part of block to anther writable channel
-   * 
-   * @param position the starting position
-   * @param count the size of data to be transfered
-   * @param target the destination channel
-   * @return the size that is actually transfered
-   * @throws IOException
-   */
-  long transferTo(long position, long count, WritableByteChannel target) throws IOException;
-
-  /**
    * Get some file region for some part of block
    * 
    * @param offset the starting position
@@ -92,4 +65,35 @@ public interface BlockHandler extends ByteChannel {
    * @return file region for the specific part of block
    */
   FileRegion getFileRegion(long offset, long length);
+
+  /**
+   * Read data from a block
+   * 
+   * @param position the starting position in the block
+   * @param length the size of the data to be read
+   * @return the ByteBuffer that contains the data
+   * @throws IOException
+   */
+  ByteBuffer read(long position, int length) throws IOException;
+
+  /**
+   * Transfer data from this handler to another handler
+   * 
+   * @param position the starting position in the block
+   * @param length the size of the data to be transferred
+   * @param dest the destination handler
+   * @return the size of data that is transferred
+   * @throws IOException
+   */
+  long transferTo(long position, long length, BlockHandler dest) throws IOException;
+
+  /**
+   * Write data to a block
+   * 
+   * @param position the starting position in the block
+   * @param buf the ByteBuffer that contains the data
+   * @return the size of data that is written
+   * @throws IOException
+   */
+  int write(long position, ByteBuffer buf) throws IOException;
 }

--- a/core/src/main/java/tachyon/worker/BlockHandlerLocal.java
+++ b/core/src/main/java/tachyon/worker/BlockHandlerLocal.java
@@ -78,6 +78,11 @@ final class BlockHandlerLocal implements BlockHandler {
     mCloser.close();
   }
 
+  /**
+   * Check the permission of the block, if not set, set the permission
+   * 
+   * @throws IOException
+   */
   private void checkPermission() throws IOException {
     if (!mPermission) {
       // change the permission of the file and use the sticky bit

--- a/core/src/main/java/tachyon/worker/BlockHandlerLocal.java
+++ b/core/src/main/java/tachyon/worker/BlockHandlerLocal.java
@@ -107,8 +107,8 @@ final class BlockHandlerLocal implements BlockHandler {
     return new File(mFilePath).delete();
   }
 
-  public FileRegion getFileRegion(long offset, long length) {
-    return new DefaultFileRegion(mLocalFileChannel, offset, length);
+  public FileRegion getFileRegion(long position, long length) {
+    return new DefaultFileRegion(mLocalFileChannel, position, length);
   }
 
   public ByteBuffer read(long position, int length) throws IOException {

--- a/core/src/main/java/tachyon/worker/netty/BlockResponse.java
+++ b/core/src/main/java/tachyon/worker/netty/BlockResponse.java
@@ -77,7 +77,8 @@ public final class BlockResponse {
             ByteBuffer buffer = handler.read(msg.getOffset(), (int)msg.getLength());
             out.add(Unpooled.wrappedBuffer(buffer));
             break;
-          default: // TRANSFER
+          case TRANSFER: // intend to fall through as TRANSFER is the default type.
+          default:
             out.add(handler.getFileRegion(msg.getOffset(), (int)msg.getLength()));
             break;
         }

--- a/core/src/main/java/tachyon/worker/netty/BlockResponse.java
+++ b/core/src/main/java/tachyon/worker/netty/BlockResponse.java
@@ -16,13 +16,11 @@
 package tachyon.worker.netty;
 
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.DefaultFileRegion;
 import io.netty.handler.codec.MessageToMessageEncoder;
 
 import com.google.common.primitives.Longs;
@@ -76,18 +74,11 @@ public final class BlockResponse {
                 .getEnum(Constants.WORKER_NETTY_FILE_TRANSFER_TYPE, FileTransferType.TRANSFER);
         switch (type) {
           case MAPPED:
-            ByteBuffer buffer = ByteBuffer.allocate((int)msg.getLength());
-            try {
-              handler.position(msg.getOffset()).read(buffer);
-            } finally {
-              handler.close();
-            }
-            buffer.flip();
+            ByteBuffer buffer = handler.read(msg.getOffset(), (int)msg.getLength());
             out.add(Unpooled.wrappedBuffer(buffer));
             break;
           default: // TRANSFER
             out.add(handler.getFileRegion(msg.getOffset(), (int)msg.getLength()));
-            handler.close();
             break;
         }
       }

--- a/core/src/main/java/tachyon/worker/tiered/StorageDir.java
+++ b/core/src/main/java/tachyon/worker/tiered/StorageDir.java
@@ -267,7 +267,7 @@ public final class StorageDir {
     try {
       BlockHandler srcBH = closer.register(getBlockHandler(blockId));
       dstBH = closer.register(dstDir.getBlockHandler(blockId));
-      copySuccess = srcBH.transferTo(0L, size, dstBH) > -1;
+      copySuccess = srcBH.transferTo(0L, (int)size, dstBH, 0) > -1;
     } finally {
       closer.close();
     }

--- a/core/src/main/java/tachyon/worker/tiered/StorageDir.java
+++ b/core/src/main/java/tachyon/worker/tiered/StorageDir.java
@@ -509,11 +509,11 @@ public final class StorageDir {
   }
 
   /**
-   * Get current StorageDir's file system
+   * Get current StorageDir's under file system
    * 
    * @return StorageDir's under file system
    */
-  public UnderFileSystem getFs() {
+  public UnderFileSystem getUfs() {
     return mFs;
   }
 
@@ -522,7 +522,7 @@ public final class StorageDir {
    *
    * @return configuration of the under file system
    */
-  public Object getFsConf() {
+  public Object getUfsConf() {
     return mConf;
   }
 

--- a/core/src/test/java/tachyon/worker/BlockHandlerLocalTest.java
+++ b/core/src/test/java/tachyon/worker/BlockHandlerLocalTest.java
@@ -49,84 +49,66 @@ public class BlockHandlerLocalTest {
     mTfs = mLocalTachyonCluster.getClient();
   }
 
-  @Test
-  public void directByteBufferWriteTest() throws IOException {
-    ByteBuffer buf = ByteBuffer.allocateDirect(100);
-    buf.put(TestUtils.getIncreasingByteArray(100));
-
-    int fileId = mTfs.createFile(new TachyonURI(TestUtils.uniqPath()));
-    long blockId = mTfs.getBlockId(fileId, 0);
-    String filename = mTfs.getLocalBlockTemporaryPath(blockId, 100);
-    BlockHandler handler = BlockHandler.get(filename);
-    try {
-      handler.append(0, buf);
-      mTfs.cacheBlock(blockId);
-      TachyonFile file = mTfs.getFile(fileId);
-      long fileLen = file.length();
-      Assert.assertEquals(100, fileLen);
-    } finally {
-      handler.close();
-    }
-  }
-
-  @Test
-  public void heapByteBufferwriteTest() throws IOException {
-    int fileId = mTfs.createFile(new TachyonURI(TestUtils.uniqPath()));
-    long blockId = mTfs.getBlockId(fileId, 0);
-    String filename = mTfs.getLocalBlockTemporaryPath(blockId, 100);
-    BlockHandler handler = BlockHandler.get(filename);
-    byte[] buf = TestUtils.getIncreasingByteArray(100);
-    try {
-      handler.append(0, ByteBuffer.wrap(buf));
-      mTfs.cacheBlock(blockId);
-      TachyonFile file = mTfs.getFile(fileId);
-      long fileLen = file.length();
-      Assert.assertEquals(100, fileLen);
-    } finally {
-      handler.close();
-    }
-  }
-
-  @Test
-  public void readExceptionTest() throws IOException {
+  private void bufferReadTest(boolean direct) throws IOException {
     int fileId = TestUtils.createByteFile(mTfs, TestUtils.uniqPath(), WriteType.MUST_CACHE, 100);
     TachyonFile file = mTfs.getFile(fileId);
     String filename = file.getLocalFilename(0);
-    BlockHandler handler = BlockHandler.get(filename);
+    BlockHandler handler = BlockHandler.Factory.get(filename);
+    ByteBuffer buf;
+    if (direct) {
+      buf = ByteBuffer.allocateDirect(100);
+    } else {
+      buf = ByteBuffer.allocate(100);
+    }
     try {
-      Exception exception = null;
-      try {
-        handler.read(101, 10);
-      } catch (IOException e) {
-        exception = e;
-      }
-      Assert.assertEquals("offset(101) is larger than file length(100)",
-          exception.getMessage());
-      try {
-        handler.read(10, 100);
-      } catch (IOException e) {
-        exception = e;
-      }
-      Assert.assertEquals("offset(10) plus length(100) is larger than file length(100)",
-          exception.getMessage());
+      long pos = handler.position();
+      Assert.assertEquals(0, pos);
+      int len = handler.read(buf);
+      buf.flip();
+      Assert.assertEquals(TestUtils.getIncreasingByteBuffer(100), buf);
+      Assert.assertEquals(100, handler.position());
+      Assert.assertEquals(100, len);
+      handler.position(10);
+      Assert.assertEquals(10, handler.position());
     } finally {
       handler.close();
     }
+  }
+
+  private void bufferWriteTest(boolean direct) throws IOException {
+    ByteBuffer buf;
+    if (direct) {
+      buf = ByteBuffer.allocateDirect(100);
+    } else {
+      buf = ByteBuffer.allocate(100);
+    }
+    buf.put(TestUtils.getIncreasingByteArray(100));
+    buf.flip();
+
+    int fileId = mTfs.createFile(new TachyonURI(TestUtils.uniqPath()));
+    long blockId = mTfs.getBlockId(fileId, 0);
+    String filename = mTfs.getLocalBlockTemporaryPath(blockId, 100);
+    BlockHandler handler = BlockHandler.Factory.get(filename);
+    try {
+      handler.write(buf);
+    } finally {
+      handler.close();
+    }
+    mTfs.cacheBlock(blockId);
+    TachyonFile file = mTfs.getFile(fileId);
+    long fileLen = file.length();
+    Assert.assertEquals(100, fileLen);
   }
 
   @Test
   public void readTest() throws IOException {
-    int fileId = TestUtils.createByteFile(mTfs, TestUtils.uniqPath(), WriteType.MUST_CACHE, 100);
-    TachyonFile file = mTfs.getFile(fileId);
-    String filename = file.getLocalFilename(0);
-    BlockHandler handler = BlockHandler.get(filename);
-    try {
-      ByteBuffer buf = handler.read(0, 100);
-      Assert.assertEquals(TestUtils.getIncreasingByteBuffer(100), buf);
-      buf = handler.read(0, -1);
-      Assert.assertEquals(TestUtils.getIncreasingByteBuffer(100), buf);
-    } finally {
-      handler.close();
-    }
+    bufferReadTest(false);
+    bufferReadTest(true);
+  }
+
+  @Test
+  public void writeTest() throws IOException {
+    bufferWriteTest(false);
+    bufferWriteTest(true);
   }
 }

--- a/core/src/test/java/tachyon/worker/WorkerServiceHandlerTest.java
+++ b/core/src/test/java/tachyon/worker/WorkerServiceHandlerTest.java
@@ -16,6 +16,7 @@ package tachyon.worker;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.apache.thrift.TException;
 import org.junit.After;
@@ -112,8 +113,8 @@ public class WorkerServiceHandlerTest {
   private void createBlockFile(String filename, int fileLen)
       throws IOException, InvalidPathException {
     UnderFileSystem.get(filename, mMasterTachyonConf).mkdirs(CommonUtils.getParent(filename), true);
-    BlockHandler handler = BlockHandler.get(filename);
-    handler.append(0, TestUtils.getIncreasingByteArray(fileLen), 0, fileLen);
+    BlockHandler handler = BlockHandler.Factory.get(filename);
+    handler.write(ByteBuffer.wrap(TestUtils.getIncreasingByteArray(fileLen)));
     handler.close();
   }
 

--- a/core/src/test/java/tachyon/worker/WorkerServiceHandlerTest.java
+++ b/core/src/test/java/tachyon/worker/WorkerServiceHandlerTest.java
@@ -114,7 +114,7 @@ public class WorkerServiceHandlerTest {
       throws IOException, InvalidPathException {
     UnderFileSystem.get(filename, mMasterTachyonConf).mkdirs(CommonUtils.getParent(filename), true);
     BlockHandler handler = BlockHandler.Factory.get(filename);
-    handler.write(ByteBuffer.wrap(TestUtils.getIncreasingByteArray(fileLen)));
+    handler.write(0, ByteBuffer.wrap(TestUtils.getIncreasingByteArray(fileLen)));
     handler.close();
   }
 

--- a/core/src/test/java/tachyon/worker/tiered/AllocateStrategyTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/AllocateStrategyTest.java
@@ -132,7 +132,7 @@ public class AllocateStrategyTest {
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
     dir.initialize();
-    UnderFileSystem ufs = dir.getFs();
+    UnderFileSystem ufs = dir.getUfs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));
   }

--- a/core/src/test/java/tachyon/worker/tiered/AllocateStrategyTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/AllocateStrategyTest.java
@@ -54,11 +54,11 @@ public class AllocateStrategyTest {
   private void createBlockFile(StorageDir dir, long blockId, int blockSize) throws IOException {
     byte[] buf = TestUtils.getIncreasingByteArray(blockSize);
     BlockHandler bhSrc =
-        BlockHandler.get(dir.getUserTempFilePath(USER_ID, blockId));
+        BlockHandler.Factory.get(dir.getUserTempFilePath(USER_ID, blockId));
     dir.requestSpace(USER_ID, blockSize);
     dir.updateTempBlockAllocatedBytes(USER_ID, blockId, blockSize);
     try {
-      bhSrc.append(0, ByteBuffer.wrap(buf));
+      bhSrc.write(ByteBuffer.wrap(buf));
     } finally {
       bhSrc.close();
     }
@@ -132,7 +132,7 @@ public class AllocateStrategyTest {
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
     dir.initialize();
-    UnderFileSystem ufs = dir.getUfs();
+    UnderFileSystem ufs = dir.getFs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));
   }

--- a/core/src/test/java/tachyon/worker/tiered/AllocateStrategyTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/AllocateStrategyTest.java
@@ -58,7 +58,7 @@ public class AllocateStrategyTest {
     dir.requestSpace(USER_ID, blockSize);
     dir.updateTempBlockAllocatedBytes(USER_ID, blockId, blockSize);
     try {
-      bhSrc.write(ByteBuffer.wrap(buf));
+      bhSrc.write(0, ByteBuffer.wrap(buf));
     } finally {
       bhSrc.close();
     }

--- a/core/src/test/java/tachyon/worker/tiered/EvictStrategyTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/EvictStrategyTest.java
@@ -143,7 +143,7 @@ public class EvictStrategyTest {
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
     dir.initialize();
-    UnderFileSystem ufs = dir.getFs();
+    UnderFileSystem ufs = dir.getUfs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));
   }

--- a/core/src/test/java/tachyon/worker/tiered/EvictStrategyTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/EvictStrategyTest.java
@@ -59,11 +59,11 @@ public class EvictStrategyTest {
     byte[] buf = TestUtils.getIncreasingByteArray(blockSize);
 
     BlockHandler bhSrc =
-        BlockHandler.get(dir.getUserTempFilePath(USER_ID, blockId));
+        BlockHandler.Factory.get(dir.getUserTempFilePath(USER_ID, blockId));
     dir.requestSpace(USER_ID, blockSize);
     dir.updateTempBlockAllocatedBytes(USER_ID, blockId, blockSize);
     try {
-      bhSrc.append(0, ByteBuffer.wrap(buf));
+      bhSrc.write(ByteBuffer.wrap(buf));
     } finally {
       bhSrc.close();
     }
@@ -143,7 +143,7 @@ public class EvictStrategyTest {
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
     dir.initialize();
-    UnderFileSystem ufs = dir.getUfs();
+    UnderFileSystem ufs = dir.getFs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));
   }

--- a/core/src/test/java/tachyon/worker/tiered/EvictStrategyTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/EvictStrategyTest.java
@@ -63,7 +63,7 @@ public class EvictStrategyTest {
     dir.requestSpace(USER_ID, blockSize);
     dir.updateTempBlockAllocatedBytes(USER_ID, blockId, blockSize);
     try {
-      bhSrc.write(ByteBuffer.wrap(buf));
+      bhSrc.write(0, ByteBuffer.wrap(buf));
     } finally {
       bhSrc.close();
     }

--- a/core/src/test/java/tachyon/worker/tiered/StorageDirTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/StorageDirTest.java
@@ -136,7 +136,7 @@ public class StorageDirTest {
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
     dir.initialize();
-    UnderFileSystem ufs = dir.getFs();
+    UnderFileSystem ufs = dir.getUfs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));
   }

--- a/core/src/test/java/tachyon/worker/tiered/StorageDirTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/StorageDirTest.java
@@ -98,7 +98,7 @@ public class StorageDirTest {
     dir.requestSpace(USER_ID, blockSize);
     dir.updateTempBlockAllocatedBytes(USER_ID, blockId, blockSize);
     try {
-      bhSrc.write(ByteBuffer.wrap(buf));
+      bhSrc.write(0, ByteBuffer.wrap(buf));
     } finally {
       bhSrc.close();
     }

--- a/core/src/test/java/tachyon/worker/tiered/StorageDirTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/StorageDirTest.java
@@ -94,11 +94,11 @@ public class StorageDirTest {
   private void createBlockFile(StorageDir dir, long blockId, int blockSize) throws IOException {
     byte[] buf = TestUtils.getIncreasingByteArray(blockSize);
     BlockHandler bhSrc =
-        BlockHandler.get(CommonUtils.concatPath(dir.getUserTempFilePath(USER_ID, blockId)));
+        BlockHandler.Factory.get(CommonUtils.concatPath(dir.getUserTempFilePath(USER_ID, blockId)));
     dir.requestSpace(USER_ID, blockSize);
     dir.updateTempBlockAllocatedBytes(USER_ID, blockId, blockSize);
     try {
-      bhSrc.append(0, ByteBuffer.wrap(buf));
+      bhSrc.write(ByteBuffer.wrap(buf));
     } finally {
       bhSrc.close();
     }
@@ -136,7 +136,7 @@ public class StorageDirTest {
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
     dir.initialize();
-    UnderFileSystem ufs = dir.getUfs();
+    UnderFileSystem ufs = dir.getFs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));
   }

--- a/core/src/test/java/tachyon/worker/tiered/StorageTierTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/StorageTierTest.java
@@ -127,7 +127,7 @@ public class StorageTierTest {
   }
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
-    UnderFileSystem ufs = dir.getFs();
+    UnderFileSystem ufs = dir.getUfs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));
   }

--- a/core/src/test/java/tachyon/worker/tiered/StorageTierTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/StorageTierTest.java
@@ -98,11 +98,11 @@ public class StorageTierTest {
   private void createBlockFile(StorageDir dir, long blockId, int blockSize) throws IOException {
     byte[] buf = TestUtils.getIncreasingByteArray(blockSize);
     BlockHandler bhSrc =
-        BlockHandler.get(dir.getUserTempFilePath(USER_ID, blockId));
+        BlockHandler.Factory.get(dir.getUserTempFilePath(USER_ID, blockId));
     dir.requestSpace(USER_ID, blockSize);
     dir.updateTempBlockAllocatedBytes(USER_ID, blockId, blockSize);
     try {
-      bhSrc.append(0, ByteBuffer.wrap(buf));
+      bhSrc.write(ByteBuffer.wrap(buf));
     } finally {
       bhSrc.close();
     }
@@ -127,7 +127,7 @@ public class StorageTierTest {
   }
 
   private void initializeStorageDir(StorageDir dir, long userId) throws IOException {
-    UnderFileSystem ufs = dir.getUfs();
+    UnderFileSystem ufs = dir.getFs();
     ufs.mkdirs(dir.getUserTempPath(userId), true);
     CommonUtils.changeLocalFileToFullPermission(dir.getUserTempPath(userId));
   }

--- a/core/src/test/java/tachyon/worker/tiered/StorageTierTest.java
+++ b/core/src/test/java/tachyon/worker/tiered/StorageTierTest.java
@@ -102,7 +102,7 @@ public class StorageTierTest {
     dir.requestSpace(USER_ID, blockSize);
     dir.updateTempBlockAllocatedBytes(USER_ID, blockId, blockSize);
     try {
-      bhSrc.write(ByteBuffer.wrap(buf));
+      bhSrc.write(0, ByteBuffer.wrap(buf));
     } finally {
       bhSrc.close();
     }


### PR DESCRIPTION
BlockHandler was designed to be used on both client side and worker side, and it only offers some very 
general API like append and read. But currently, BlockHandler is only used on worker side, and it serves
for three scenarios:
1. Migrate block files between different storage layers
2. Get data for remote read in data server with both NIO and NETTY mode
3. Read block files in checkpoint thread
API like append and read are too general, it can be refined to make better integration.
