### PR TITLE
[TACHYON-380] Resolve Values in ConfUI

### DIFF
--- a/core/src/main/java/tachyon/web/WebInterfaceConfigurationServlet.java
+++ b/core/src/main/java/tachyon/web/WebInterfaceConfigurationServlet.java
@@ -74,7 +74,7 @@ public final class WebInterfaceConfigurationServlet extends HttpServlet {
     for (Map.Entry<Object, Object> entry : mTachyonConf.getInternalProperties().entrySet()) {
       String key = entry.getKey().toString();
       if (key.startsWith(TACHYON_CONF_PREFIX) && !TACHYON_CONF_EXCLUDES.contains(key)) {
-        rtn.add(new ImmutablePair<String, String>(key, mTachyonConf.get(key, null)));
+        rtn.add(new ImmutablePair<String, String>(key, mTachyonConf.get(key, "")));
       }
     }
     return rtn;

--- a/core/src/main/java/tachyon/web/WebInterfaceConfigurationServlet.java
+++ b/core/src/main/java/tachyon/web/WebInterfaceConfigurationServlet.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -54,7 +54,7 @@ public final class WebInterfaceConfigurationServlet extends HttpServlet {
 
   /**
    * Populates attributes before redirecting to a jsp.
-   * 
+   *
    * @param request The HttpServletRequest object
    * @param response The HttpServletReponse object
    * @throws ServletException
@@ -74,7 +74,7 @@ public final class WebInterfaceConfigurationServlet extends HttpServlet {
     for (Map.Entry<Object, Object> entry : mTachyonConf.getInternalProperties().entrySet()) {
       String key = entry.getKey().toString();
       if (key.startsWith(TACHYON_CONF_PREFIX) && !TACHYON_CONF_EXCLUDES.contains(key)) {
-        rtn.add(new ImmutablePair<String, String>(key, entry.getValue().toString()));
+        rtn.add(new ImmutablePair<String, String>(key, mTachyonConf.get(key, null)));
       }
     }
     return rtn;


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-380

This just makes the `${value}` parts of the conf resolved to the correct conf values. 

For example: `${tachyon.home}/core/src/main/webapp` will now be `/tachyon/core/src/main/webapp` if `tachyon.home` is set to `/tachyon`

Path resolution is more complicated because there is no indicator of whether or not a config value is a path.