### PR TITLE
[TACHYON-380] Resolved path in web UI

### DIFF
--- a/libexec/tachyon-config.sh
+++ b/libexec/tachyon-config.sh
@@ -22,7 +22,7 @@ this="$config_bin/$script"
 # their own tachyon-layout.sh file to set system installation locations.
 if [ -z "$TACHYON_SYSTEM_INSTALLATION" ]; then
   VERSION=0.7.0-SNAPSHOT
-  export TACHYON_PREFIX=`dirname "$this"`/..
+  export TACHYON_PREFIX=`dirname $(dirname "$this")`
   export TACHYON_HOME=${TACHYON_PREFIX}
   export TACHYON_CONF_DIR="$TACHYON_HOME/conf"
   export TACHYON_LOGS_DIR="$TACHYON_HOME/logs"


### PR DESCRIPTION
Now, path related to tachyon.home in system configuration in web UI is displayed as:
tachyon.home	/tachyon/libexec/..
tachyon.master.journal.folder	/tachyon/libexec/../journal/

the root cause is not in codes of web ui, but in libexec/tachyon-config.sh. 