### PR TITLE
[TACHYON-335] Automatically mount all block device mappings

### DIFF
--- a/deploy/vagrant/provision/device.sh
+++ b/deploy/vagrant/provision/device.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+# To make sure all external storages specified in block device mapping are mounted with ext4
+
+# DeviceName specified in block device mapping can not be trusted
+# they may be changed by kernel driver
+# e.x. /dev/sdb may be changed into /dev/xvdb, or /dev/sdh, even /dev/hdh
+# the behavior depends on what type of virtualization you use(PV/HVM), your AMI, your instance type
+# And some AMI may mount devices defined in block device mapping by default, others won't
+# for more info, visit http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
+# So, it's not as trivial as just iterating over DeviceNames, format the disks and mount them
+# Also, We can not just check whether devicenames can be found in `df` to determine whether they have been mounted
+# because devicenames may be changed silently by kernel
+
+# But user specified devicenames should be defined according to 
+#  http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
+# they should start with /dev/sd* or /dev/xvd* or /dev/hd*, so this script will view items matching one of these 
+# three patterns and not ending in "da"(this is revserved by default) as devices specified in block device mapping
+# Next, determine those of them that are not mounted yet
+
+# Solution to determine the devices that haven't been mounted is:
+# find those in the set of the user specified devices but not in the results of `df` yet
+dev=`ls /dev | egrep '^sd|^hd|^xvd' | grep -v da`
+echo "possible devices defined in block device mapping: "
+printf "%s\n" $dev
+
+mounted=`df | cut -d' ' -f1 | grep ^/dev | grep -v da | sed -r 's/^.{5}//'`
+echo "devices in /dev that are already mounted: "
+printf "%s\n" $mounted
+
+# trick to implement set complement, will output items in $dev but not in $mounted
+to_mount=`printf "%s\n" $mounted $mounted $dev | sort | uniq -u`
+echo "devices known by kernel but not mounted yet: "
+printf "%s\n" $to_mount
+
+# format disk, sequentially mount to /disk0, /disk1, ...
+n=0
+for disk in $to_mount
+do
+	sudo mkfs.ext4 "/dev/$disk"
+	sudo mkdir "/disk$n"
+	sudo mount "/dev/$disk" "/disk$n"
+	n=$(( $n + 1 ))
+done
+echo "$n devices mounted as /disk#"

--- a/deploy/vagrant/provision/playbook.yaml
+++ b/deploy/vagrant/provision/playbook.yaml
@@ -1,5 +1,8 @@
 - hosts: all
   tasks:
+    - name: mount devices defined in block device mapping
+      script: device.sh
+
     - name: prepare /vagrant
       shell: sudo mkdir -p /vagrant && user=`whoami` && sudo chown -R $user /vagrant
       when: not is_vb # vb sync the whole /vagrant directory

--- a/deploy/vagrant/provision/playbook.yaml
+++ b/deploy/vagrant/provision/playbook.yaml
@@ -2,6 +2,7 @@
   tasks:
     - name: mount devices defined in block device mapping
       script: device.sh
+      when: is_aws
 
     - name: prepare /vagrant
       shell: sudo mkdir -p /vagrant && user=`whoami` && sudo chown -R $user /vagrant

--- a/docs/Running-Tachyon-on-AWS.md
+++ b/docs/Running-Tachyon-on-AWS.md
@@ -5,7 +5,7 @@ title: Running Tachyon on Amazon EC2
 
 ## Deploy Tachyon Cluster on Amazon EC2 via Vagrant
 
-[Vagrant](https://www.vagrantup.com/downloads.html) can spawn Tachyon cluster in the cloud at [AWS EC2 VPC](http://aws.amazon.com/vpc/).
+[Vagrant](https://www.vagrantup.com/downloads.html) can spawn Tachyon cluster in the cloud at [AWS EC2 VPC](http://aws.amazon.com/vpc/), and provision all nodes in parallel with [Ansible](http://www.ansible.com/home).
 
 A set of pre-configured Vagrant recipe and shell scripts can be found at `tachyon/deploy/vagrant`
 directory:
@@ -76,6 +76,13 @@ For Docker provider, containers use DHCP, these addresses are not used.
 </td><td>IPv4 address string</td>
 </tr>
 </table>
+
+## Block Device Mapping
+
+To mount extra disks, you can define them through block device mapping in conf/ec2-config.yml. 
+
+After launching the cluster, all block devices will either be mounted to /mnt, or /disk0, /disk1, ... in sequence. Each of
+these directories maps to a unique block device with ext4 as filesystem.
 
 ## Launch Cluster
 

--- a/docs/Running-Tachyon-on-Container.md
+++ b/docs/Running-Tachyon-on-Container.md
@@ -5,7 +5,7 @@ title: Running Tachyon on Linux Container
 
 ## Deploy Tachyon Cluster on Linux Container via Vagrant
 
-[Vagrant](https://www.vagrantup.com/downloads.html) can spawn Tachyon cluster locally inside [Linux container](http://www.docker.com/).
+[Vagrant](https://www.vagrantup.com/downloads.html) can spawn Tachyon cluster locally inside [Linux container](http://www.docker.com/), and provision all nodes in parallel with [Ansible](http://www.ansible.com/home).
 
 A set of pre-configured Vagrant recipe and shell scripts can be found at `tachyon/deploy/vagrant`
 directory:

--- a/docs/Running-Tachyon-on-OpenStack.md
+++ b/docs/Running-Tachyon-on-OpenStack.md
@@ -5,7 +5,7 @@ title: Running Tachyon on OpenStack Compute
 
 ## Deploy Tachyon Cluster on OpenStack Compute via Vagrant
 
-[Vagrant](https://www.vagrantup.com/downloads.html) can spawn Tachyon cluster in the cloud at [OpenStack Compute](http://www.openstack.org/software/openstack-compute/).
+[Vagrant](https://www.vagrantup.com/downloads.html) can spawn Tachyon cluster in the cloud at [OpenStack Compute](http://www.openstack.org/software/openstack-compute/), and provision all nodes in parallel with [Ansible](http://www.ansible.com/home).
 
 A set of pre-configured Vagrant recipe and shell scripts can be found at `tachyon/deploy/vagrant`
 directory:

--- a/docs/Running-Tachyon-on-VirtualBox.md
+++ b/docs/Running-Tachyon-on-VirtualBox.md
@@ -5,7 +5,7 @@ title: Running Tachyon on Oracle VirtualBox
 
 ## Deploy Tachyon Cluster on VirtualBox via Vagrant
 
-[Vagrant](https://www.vagrantup.com/downloads.html) can spawn Tachyon cluster in the on [VirtualBox](https://www.virtualbox.org/).
+[Vagrant](https://www.vagrantup.com/downloads.html) can spawn Tachyon cluster in the on [VirtualBox](https://www.virtualbox.org/), and provision all nodes in parallel with [Ansible](http://www.ansible.com/home).
 
 A set of pre-configured Vagrant recipe and shell scripts can be found at `tachyon/deploy/vagrant`
 directory:


### PR DESCRIPTION
The purpose and design considerations are explained in vagrant/provision/device.sh in the first commit.