### PR TITLE
Revert "Remove deprecated API method delete from AbstractTFS"

### DIFF
--- a/core/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/core/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -235,6 +235,12 @@ abstract class AbstractTFS extends FileSystem {
     return this.create(cPath, permission, overwrite, bufferSize, replication, blockSize, progress);
   }
 
+  @Override
+  @Deprecated
+  public boolean delete(Path path) throws IOException {
+    return delete(path, true);
+  }
+
   /**
    * Attempts to delete the file or directory with the specified path. Will return true if one or
    * more files/directories were deleted. Will return false if no files or directories were


### PR DESCRIPTION
This reverts commit ddfabdb07b3bf7a62975e5a9cb9c8b0a3232f114.

Method delete is deprecated but should not be removed for now as this is required to be overriden if we want to extend AbstractTFS from org.apache.hadoop.fs.FileSystem.