### PR TITLE
[TACHYON-403] Fix exception in TFsShell

### DIFF
--- a/core/src/main/java/tachyon/command/TFsShell.java
+++ b/core/src/main/java/tachyon/command/TFsShell.java
@@ -748,7 +748,9 @@ public class TFsShell implements Closeable {
         }
         is.skip(tFile.length() - bytesToRead);
         int read = is.read(buf);
-        System.out.write(buf, 0, read);
+        if (read != -1) {
+          System.out.write(buf, 0, read);
+        }
         return 0;
       } finally {
         is.close();

--- a/core/src/main/java/tachyon/command/TFsShell.java
+++ b/core/src/main/java/tachyon/command/TFsShell.java
@@ -426,11 +426,11 @@ public class TFsShell implements Closeable {
    * @throws IOException
    */
   public int getUsedBytes(String[] argv) throws IOException {
-    if (argv.length != 2) {
-      System.out.println("Usage: tfs getUsedBytes <path>");
+    if (argv.length != 1) {
+      System.out.println("Usage: tfs getUsedBytes");
       return -1;
     }
-    TachyonURI path = new TachyonURI(argv[1]);
+    TachyonURI path = new TachyonURI(TachyonURI.SEPARATOR);
     TachyonFS tachyonClient = createFS(path);
     long usedBytes = tachyonClient.getUsedBytes();
     if (usedBytes == -1) {
@@ -448,11 +448,11 @@ public class TFsShell implements Closeable {
    * @throws IOException
    */
   public int getCapacityBytes(String[] argv) throws IOException {
-    if (argv.length != 2) {
-      System.out.println("Usage: tfs getCapacityBytes <path>");
+    if (argv.length != 1) {
+      System.out.println("Usage: tfs getCapacityBytes");
       return -1;
     }
-    TachyonURI path = new TachyonURI(argv[1]);
+    TachyonURI path = new TachyonURI(TachyonURI.SEPARATOR);
     TachyonFS tachyonClient = createFS(path);
     long capacityBytes = tachyonClient.getCapacityBytes();
     if (capacityBytes == -1) {
@@ -514,8 +514,8 @@ public class TFsShell implements Closeable {
     System.out.println("       [pin <path>]");
     System.out.println("       [unpin <path>]");
     System.out.println("       [free <file path|folder path>]");
-    System.out.println("       [getUsedBytes <tachyon root path>]");
-    System.out.println("       [getCapacityBytes <tachyon root path>]");
+    System.out.println("       [getUsedBytes]");
+    System.out.println("       [getCapacityBytes]");
     System.out.println("       [du <path>]");
   }
 
@@ -538,6 +538,7 @@ public class TFsShell implements Closeable {
       System.out.println("Renamed " + srcPath + " to " + dstPath);
       return 0;
     } else {
+      System.out.println("mv: Failed to rename " + srcPath + " to " + dstPath);
       return -1;
     }
   }

--- a/core/src/test/java/tachyon/command/TFsShellTest.java
+++ b/core/src/test/java/tachyon/command/TFsShellTest.java
@@ -544,6 +544,13 @@ public class TFsShellTest {
   }
 
   @Test
+  public void tailEmptyFileTest() throws IOException {
+    TestUtils.createByteFile(mTfs, "/emptyFile", WriteType.MUST_CACHE, 0);
+    int ret = mFsShell.tail(new String[] {"tail", "/emptyFile"});
+    Assert.assertEquals(0, ret);
+  }
+
+  @Test
   public void tailLargeFileTest() throws IOException {
     TestUtils.createByteFile(mTfs, "/testFile", WriteType.MUST_CACHE, 2048);
     mFsShell.tail(new String[] {"tail", "/testFile"});


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-403

Fix exception when tail an empty file.
Remove the <path> parameter in getUsedBytes, getCapacityBytes.
Add error message when operation mv is failed.