### PR TITLE
[TACHYON-390] Add auto-refresh functionality to Web UI

### DIFF
--- a/core/src/main/webapp/browse-body.jsp
+++ b/core/src/main/webapp/browse-body.jsp
@@ -3,8 +3,7 @@
 <%@ page import="static org.apache.commons.lang.StringEscapeUtils.escapeHtml" %>
 <%@ page import="static java.net.URLEncoder.encode" %>
 
-<script src="js/jquery-1.9.1.min.js" type="text/javascript"></script>
-<script src="js/bootstrap.min.js"></script>
+<jsp:include page="header-scripts.jsp" />
 <div class="container-fluid">
   <jsp:include page="header.jsp" />
 

--- a/core/src/main/webapp/browse-pagination-header.jsp
+++ b/core/src/main/webapp/browse-pagination-header.jsp
@@ -1,4 +1,3 @@
-<script src="js/cookies.min.js" type="text/javascript"></script>
 <script type="text/javascript">
   var nTotalFile = <%= request.getAttribute("nTotalFile") %>;
 

--- a/core/src/main/webapp/configuration.jsp
+++ b/core/src/main/webapp/configuration.jsp
@@ -8,8 +8,7 @@
 </head>
 <title>Tachyon</title>
 <body>
-<script src="js/jquery-1.9.1.min.js" type="text/javascript"></script>
-<script src="js/bootstrap.min.js"></script>
+<jsp:include page="header-scripts.jsp" />
 <div class="container-fluid">
   <jsp:include page="header.jsp" />
   <div class="row-fluid">

--- a/core/src/main/webapp/dependency.jsp
+++ b/core/src/main/webapp/dependency.jsp
@@ -8,8 +8,7 @@
 </head>
 <title>Tachyon</title>
 <body>
-<script src="js/jquery-1.9.1.min.js" type="text/javascript"></script>
-<script src="js/bootstrap.min.js"></script>
+<jsp:include page="header-scripts.jsp" />
 <div class="container-fluid">
   <jsp:include page="header.jsp" />
   <div class="row-fluid">

--- a/core/src/main/webapp/footer-scripts.jsp
+++ b/core/src/main/webapp/footer-scripts.jsp
@@ -1,0 +1,1 @@
+<script src="js/autorefresh.js" type="text/javascript"></script>

--- a/core/src/main/webapp/footer.jsp
+++ b/core/src/main/webapp/footer.jsp
@@ -1,4 +1,5 @@
 <footer>
+  <jsp:include page="footer-scripts.jsp" />
   <p style="text-align: center;">
     <a href="http://tachyon-project.org/" target="_blank">Tachyon</a> is an <a href="https://github.com/amplab/tachyon" target="_blank">open source</a> project developed at the UC Berkeley <a href="https://amplab.cs.berkeley.edu" target="_blank">AMPLab</a>.
   </p>

--- a/core/src/main/webapp/general.jsp
+++ b/core/src/main/webapp/general.jsp
@@ -9,8 +9,7 @@
 </head>
 <title>Tachyon</title>
 <body>
-<script src="js/jquery-1.9.1.min.js" type="text/javascript"></script>
-<script src="js/bootstrap.min.js"></script>
+<jsp:include page="header-scripts.jsp" />
 <div class="container-fluid">
   <jsp:include page="header.jsp" />
   <div class="row-fluid">

--- a/core/src/main/webapp/header-scripts.jsp
+++ b/core/src/main/webapp/header-scripts.jsp
@@ -1,0 +1,3 @@
+<script src="js/jquery-1.9.1.min.js" type="text/javascript"></script>
+<script src="js/bootstrap.min.js" type="text/javascript"></script>
+<script src="js/cookies.min.js" type="text/javascript"></script>

--- a/core/src/main/webapp/header.jsp
+++ b/core/src/main/webapp/header.jsp
@@ -12,6 +12,7 @@
         <li id="blockInfo-li"><a href="./blockInfo">BlockInfo</a></li>
       <% } %>
       <li id="browseLogs-li"><a href="./browseLogs">Browse Log Files</a></li>
+      <li id="autorefresh-li"><a href="javascript:toggleAutoRefresh();" id="autorefresh-link">Enable Auto-Refresh</a></li>
     </ul>
   </div>
 </div>

--- a/core/src/main/webapp/js/autorefresh.js
+++ b/core/src/main/webapp/js/autorefresh.js
@@ -1,0 +1,33 @@
+var requestUrl = window.location.href;
+var autoRefresh = requestUrl.indexOf("autoRefresh=") != -1 ? true : false;
+
+function doAutoRefresh() {
+  var refreshUrl = window.location.href;
+  refreshUrl = refreshUrl.replace(window.location.hash, "");
+  if (refreshUrl.indexOf("?") == -1) {
+    refreshUrl = refreshUrl + "?";
+  }
+  refreshUrl = refreshUrl.replace(/(.+)&?autoRefresh=([^&]+)(.+)?/, "$1$3");
+  refreshUrl = refreshUrl + "&autoRefresh=1";
+  refreshUrl = refreshUrl.replace("?&", "?");
+  window.location.replace(refreshUrl);
+}
+
+var autoRefreshTimer;
+function toggleAutoRefresh() {
+  if (autoRefresh) {
+      autoRefresh = false;
+      window.clearTimeout(autoRefreshTimer);
+      $("#autorefresh-link").text("Enable Auto-Refresh");
+  } else {
+      autoRefresh = true;
+      autoRefreshTimer = window.setTimeout(doAutoRefresh, 15000);
+      $("#autorefresh-link").text("Disable Auto-Refresh");
+  }
+}
+if (autoRefresh == "1") {
+  $("#autorefresh-link").text("Disable Auto-Refresh");
+  autoRefreshTimer = window.setTimeout(doAutoRefresh, 15000);
+} else {
+  $("#autorefresh-link").text("Enable Auto-Refresh");
+}

--- a/core/src/main/webapp/js/autorefresh.js
+++ b/core/src/main/webapp/js/autorefresh.js
@@ -1,5 +1,5 @@
 var requestUrl = window.location.href;
-var autoRefresh = requestUrl.indexOf("autoRefresh=") != -1 ? true : false;
+var autoRefresh = requestUrl.indexOf("autoRefresh=") != -1;
 
 function doAutoRefresh() {
   var refreshUrl = window.location.href;
@@ -25,7 +25,7 @@ function toggleAutoRefresh() {
       $("#autorefresh-link").text("Disable Auto-Refresh");
   }
 }
-if (autoRefresh == "1") {
+if (autoRefresh) {
   $("#autorefresh-link").text("Disable Auto-Refresh");
   autoRefreshTimer = window.setTimeout(doAutoRefresh, 15000);
 } else {

--- a/core/src/main/webapp/memory-pagination-header.jsp
+++ b/core/src/main/webapp/memory-pagination-header.jsp
@@ -1,4 +1,3 @@
-<script src="js/cookies.min.js" type="text/javascript"></script>
 <script type="text/javascript">
   var nTotalFile = <%= request.getAttribute("inMemoryFileNum") %>;
 

--- a/core/src/main/webapp/memory.jsp
+++ b/core/src/main/webapp/memory.jsp
@@ -8,8 +8,7 @@
 </head>
 <title>Tachyon</title>
 <body>
-<script src="js/jquery-1.9.1.min.js" type="text/javascript"></script>
-<script src="js/bootstrap.min.js"></script>
+<jsp:include page="header-scripts.jsp" />
 <div class="container-fluid">
   <jsp:include page="header.jsp" />
 

--- a/core/src/main/webapp/viewFile-body.jsp
+++ b/core/src/main/webapp/viewFile-body.jsp
@@ -3,8 +3,7 @@
 <%@ page import="static org.apache.commons.lang.StringEscapeUtils.escapeHtml" %>
 <%@ page import="static java.net.URLEncoder.encode" %>
 
-<script src="js/jquery-1.9.1.min.js" type="text/javascript"></script>
-<script src="js/bootstrap.min.js"></script>
+<jsp:include page="header-scripts.jsp" />
 <script>
   function displayContent() {
     var tmp = document.getElementById("offset").value;

--- a/core/src/main/webapp/workers.jsp
+++ b/core/src/main/webapp/workers.jsp
@@ -8,8 +8,7 @@
 </head>
 <title>Workers</title>
 <body>
-<script src="js/jquery-1.9.1.min.js" type="text/javascript"></script>
-<script src="js/bootstrap.min.js"></script>
+<jsp:include page="header-scripts.jsp" />
 <div class="container-fluid">
   <jsp:include page="header.jsp" />
   <div class="row-fluid">


### PR DESCRIPTION
This commits adds auto-refresh functionality to the Web UI which is
useful if you are keeping an eye on Tachyon's state and don't want to
have to hit Refresh manually.

Auto-Refresh is off by default and is toggled on via a link in the top
navigation.  Once enabled the page will refresh after 15 seconds and
auto-refresh remains enabled on page reload.

Refresh uses `window.location.replace()` so it does not fill the users
history and the back button will work normally

As part of this commit the JSPs were refactored slightly to pull the
script definitions out into includeable JSPs.  One for scripts that need
to appear at the start of a page and one for scripts that must appear at
the end of the page.