### PR TITLE
[TACHYON-100] Let user disable local read/writes

### DIFF
--- a/core/src/main/java/tachyon/Constants.java
+++ b/core/src/main/java/tachyon/Constants.java
@@ -59,7 +59,7 @@ public class Constants {
   public static final int DEFAULT_WORKER_MAX_WORKER_THREADS = 2048;
 
   public static final int DEFAULT_USER_FAILED_SPACE_REQUEST_LIMITS = 3;
-  
+
   public static final boolean DEFAULT_USER_ENABLE_LOCAL_READ = true;
   public static final boolean DEFAULT_USER_ENABLE_LOCAL_WRITE = true;
 

--- a/core/src/main/java/tachyon/Constants.java
+++ b/core/src/main/java/tachyon/Constants.java
@@ -59,6 +59,9 @@ public class Constants {
   public static final int DEFAULT_WORKER_MAX_WORKER_THREADS = 2048;
 
   public static final int DEFAULT_USER_FAILED_SPACE_REQUEST_LIMITS = 3;
+  
+  public static final boolean DEFAULT_USER_DISABLE_LOCAL_READ = false;
+  public static final boolean DEFAULT_USER_DISABLE_LOCAL_WRITE = false;
 
   public static final int DEFAULT_BLOCK_SIZE_BYTE = 512 * MB;
 
@@ -202,5 +205,7 @@ public class Constants {
   public static final String USER_REMOTE_BLOCK_READER = "tachyon.user.remote.block.reader.class";
   public static final Class<? extends RemoteBlockReader> USER_REMOTE_BLOCK_READER_CLASS =
       tachyon.client.tcp.TCPRemoteBlockReader.class;
+  public static final String USER_DISABLE_LOCAL_READ = "tachyon.user.localread.disable";
+  public static final String USER_DISABLE_LOCAL_WRITE = "tachyon.user.localwrite.disable";
 
 }

--- a/core/src/main/java/tachyon/Constants.java
+++ b/core/src/main/java/tachyon/Constants.java
@@ -60,8 +60,8 @@ public class Constants {
 
   public static final int DEFAULT_USER_FAILED_SPACE_REQUEST_LIMITS = 3;
   
-  public static final boolean DEFAULT_USER_DISABLE_LOCAL_READ = false;
-  public static final boolean DEFAULT_USER_DISABLE_LOCAL_WRITE = false;
+  public static final boolean DEFAULT_USER_ENABLE_LOCAL_READ = true;
+  public static final boolean DEFAULT_USER_ENABLE_LOCAL_WRITE = true;
 
   public static final int DEFAULT_BLOCK_SIZE_BYTE = 512 * MB;
 
@@ -205,7 +205,7 @@ public class Constants {
   public static final String USER_REMOTE_BLOCK_READER = "tachyon.user.remote.block.reader.class";
   public static final Class<? extends RemoteBlockReader> USER_REMOTE_BLOCK_READER_CLASS =
       tachyon.client.tcp.TCPRemoteBlockReader.class;
-  public static final String USER_DISABLE_LOCAL_READ = "tachyon.user.localread.disable";
-  public static final String USER_DISABLE_LOCAL_WRITE = "tachyon.user.localwrite.disable";
+  public static final String USER_ENABLE_LOCAL_READ = "tachyon.user.localread.enable";
+  public static final String USER_ENABLE_LOCAL_WRITE = "tachyon.user.localwrite.enable";
 
 }

--- a/core/src/main/java/tachyon/client/BlockInStream.java
+++ b/core/src/main/java/tachyon/client/BlockInStream.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -17,6 +17,10 @@ package tachyon.client;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 
 /**
@@ -26,10 +30,12 @@ import tachyon.conf.TachyonConf;
  * client code.
  */
 public abstract class BlockInStream extends InStream {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+  
   /**
    * Get a new BlockInStream of the given block without under file system configuration. The block
    * is decided by the tachyonFile and blockIndex
-   *
+   * 
    * @param tachyonFile the file the block belongs to
    * @param readType the InStream's read type
    * @param blockIndex the index of the block in the tachyonFile
@@ -45,7 +51,7 @@ public abstract class BlockInStream extends InStream {
   /**
    * Get a new BlockInStream of the given block with the under file system configuration. The block
    * is decided by the tachyonFile and blockIndex
-   *
+   * 
    * @param tachyonFile the file the block belongs to
    * @param readType the InStream's read type
    * @param blockIndex the index of the block in the tachyonFile
@@ -55,14 +61,19 @@ public abstract class BlockInStream extends InStream {
    */
   public static BlockInStream get(TachyonFile tachyonFile, ReadType readType, int blockIndex,
       Object ufsConf, TachyonConf tachyonConf) throws IOException {
-    TachyonByteBuffer buf = tachyonFile.readLocalByteBuffer(blockIndex);
-    if (buf != null) {
-      if (readType.isPromote()) {
-        tachyonFile.promoteBlock(blockIndex);
+    if (!tachyonConf.getBoolean(Constants.USER_DISABLE_LOCAL_READ,
+        Constants.DEFAULT_USER_DISABLE_LOCAL_READ)) {
+      LOG.info("Reading with local stream.");
+      TachyonByteBuffer buf = tachyonFile.readLocalByteBuffer(blockIndex);
+      if (buf != null) {
+        if (readType.isPromote()) {
+          tachyonFile.promoteBlock(blockIndex);
+        }
+        return new LocalBlockInStream(tachyonFile, readType, blockIndex, buf, tachyonConf);
       }
-      return new LocalBlockInStream(tachyonFile, readType, blockIndex, buf, tachyonConf);
     }
-
+    
+    LOG.info("Reading with remote stream.");
     return new RemoteBlockInStream(tachyonFile, readType, blockIndex, ufsConf, tachyonConf);
   }
 

--- a/core/src/main/java/tachyon/client/BlockInStream.java
+++ b/core/src/main/java/tachyon/client/BlockInStream.java
@@ -61,8 +61,8 @@ public abstract class BlockInStream extends InStream {
    */
   public static BlockInStream get(TachyonFile tachyonFile, ReadType readType, int blockIndex,
       Object ufsConf, TachyonConf tachyonConf) throws IOException {
-    if (!tachyonConf.getBoolean(Constants.USER_DISABLE_LOCAL_READ,
-        Constants.DEFAULT_USER_DISABLE_LOCAL_READ)) {
+    if (tachyonConf.getBoolean(Constants.USER_ENABLE_LOCAL_READ,
+        Constants.DEFAULT_USER_ENABLE_LOCAL_READ)) {
       LOG.info("Reading with local stream.");
       TachyonByteBuffer buf = tachyonFile.readLocalByteBuffer(blockIndex);
       if (buf != null) {

--- a/core/src/main/java/tachyon/client/BlockInStream.java
+++ b/core/src/main/java/tachyon/client/BlockInStream.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -31,11 +31,11 @@ import tachyon.conf.TachyonConf;
  */
 public abstract class BlockInStream extends InStream {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-  
+
   /**
    * Get a new BlockInStream of the given block without under file system configuration. The block
    * is decided by the tachyonFile and blockIndex
-   * 
+   *
    * @param tachyonFile the file the block belongs to
    * @param readType the InStream's read type
    * @param blockIndex the index of the block in the tachyonFile
@@ -51,7 +51,7 @@ public abstract class BlockInStream extends InStream {
   /**
    * Get a new BlockInStream of the given block with the under file system configuration. The block
    * is decided by the tachyonFile and blockIndex
-   * 
+   *
    * @param tachyonFile the file the block belongs to
    * @param readType the InStream's read type
    * @param blockIndex the index of the block in the tachyonFile
@@ -72,7 +72,7 @@ public abstract class BlockInStream extends InStream {
         return new LocalBlockInStream(tachyonFile, readType, blockIndex, buf, tachyonConf);
       }
     }
-    
+
     LOG.info("Reading with remote stream.");
     return new RemoteBlockInStream(tachyonFile, readType, blockIndex, ufsConf, tachyonConf);
   }

--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -134,7 +134,7 @@ public class RemoteBlockInStream extends BlockInStream {
 
   /**
    * Cancels the re-caching attempt
-   * 
+   *
    * @throws IOException
    */
   private void cancelRecache() throws IOException {
@@ -319,7 +319,7 @@ public class RemoteBlockInStream extends BlockInStream {
 
   /**
    * Sets up the underfs stream to read at mBlockPos
-   * 
+   *
    * @return true if the input stream is set to read at mBlockPos, false otherwise
    **/
   private boolean setupStreamFromUnderFs() throws IOException {
@@ -368,7 +368,7 @@ public class RemoteBlockInStream extends BlockInStream {
    * Makes sure mCurrentBuffer is set to read at mBlockPos. If it is already, we do nothing.
    * Otherwise, we set mBufferStartPos accordingly and try to read the correct range of bytes
    * remotely. If we fail to read remotely, mCurrentBuffer will be null at the end of the function
-   * 
+   *
    * @return true if mCurrentBuffer was successfully set to read at mBlockPos, or false if the
    *         remote read failed.
    * @throws IOException

--- a/core/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/core/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -55,8 +55,8 @@ public class RemoteBlockInStream extends BlockInStream {
   private long mCheckpointPos = -1;
 
   /**
-   * The position in the block we are currently at, relative to the block. The
-   * position relative to the file would be mBlockInfo.offset + mBlockPos.
+   * The position in the block we are currently at, relative to the block. The position relative to
+   * the file would be mBlockInfo.offset + mBlockPos.
    */
   private long mBlockPos = 0;
 
@@ -134,7 +134,7 @@ public class RemoteBlockInStream extends BlockInStream {
 
   /**
    * Cancels the re-caching attempt
-   *
+   * 
    * @throws IOException
    */
   private void cancelRecache() throws IOException {
@@ -265,12 +265,11 @@ public class RemoteBlockInStream extends BlockInStream {
         if (port == -1) {
           continue;
         }
-        
+
         if (host.equals(InetAddress.getLocalHost().getHostName())
-            || host.equals(InetAddress.getLocalHost().getHostAddress())
-            || host.equals(localhost)) {
-          LOG.warn("Master thinks the local machine has data, But not! blockId:{}",
-              blockInfo.blockId);
+            || host.equals(InetAddress.getLocalHost().getHostAddress()) || host.equals(localhost)) {
+          LOG.warn("Master thinks the local machine has data, but not!"
+              + "(or local read is disabled) blockId:{}", blockInfo.blockId);
         }
         LOG.info(host + ":" + port + " current host is " + localhost + " "
             + NetworkUtils.getLocalIpAddress(conf));
@@ -320,7 +319,7 @@ public class RemoteBlockInStream extends BlockInStream {
 
   /**
    * Sets up the underfs stream to read at mBlockPos
-   *
+   * 
    * @return true if the input stream is set to read at mBlockPos, false otherwise
    **/
   private boolean setupStreamFromUnderFs() throws IOException {
@@ -366,11 +365,10 @@ public class RemoteBlockInStream extends BlockInStream {
   }
 
   /**
-   * Makes sure mCurrentBuffer is set to read at mBlockPos. If it is already, we do
-   * nothing. Otherwise, we set mBufferStartPos accordingly and try to read the correct range of
-   * bytes remotely. If we fail to read remotely, mCurrentBuffer will be null at the end of the
-   * function
-   *
+   * Makes sure mCurrentBuffer is set to read at mBlockPos. If it is already, we do nothing.
+   * Otherwise, we set mBufferStartPos accordingly and try to read the correct range of bytes
+   * remotely. If we fail to read remotely, mCurrentBuffer will be null at the end of the function
+   * 
    * @return true if mCurrentBuffer was successfully set to read at mBlockPos, or false if the
    *         remote read failed.
    * @throws IOException

--- a/core/src/main/java/tachyon/client/TachyonFile.java
+++ b/core/src/main/java/tachyon/client/TachyonFile.java
@@ -359,7 +359,7 @@ public class TachyonFile implements Comparable<TachyonFile> {
     if (!isComplete()) {
       return null;
     }
-    
+
     // TODO allow user to disable local read for this advanced API
     TachyonByteBuffer ret = readLocalByteBuffer(blockIndex);
     if (ret == null) {

--- a/core/src/main/java/tachyon/client/TachyonFile.java
+++ b/core/src/main/java/tachyon/client/TachyonFile.java
@@ -359,7 +359,8 @@ public class TachyonFile implements Comparable<TachyonFile> {
     if (!isComplete()) {
       return null;
     }
-
+    
+    // TODO allow user to disable local read for this advanced API
     TachyonByteBuffer ret = readLocalByteBuffer(blockIndex);
     if (ret == null) {
       // TODO Make it local cache if the OpType is try cache.

--- a/core/src/test/java/tachyon/client/BlockInStreamTest.java
+++ b/core/src/test/java/tachyon/client/BlockInStreamTest.java
@@ -60,13 +60,13 @@ public class BlockInStreamTest {
     int fileId = TestUtils.createByteFile(sTfs, "/file_no_local_read", WriteType.TRY_CACHE, 10);
     
     TachyonConf conf = sLocalTachyonCluster.getWorkerTachyonConf();
-    conf.set(Constants.USER_DISABLE_LOCAL_READ, "true");
+    conf.set(Constants.USER_ENABLE_LOCAL_READ, "false");
     TachyonFS sTfs1 = TachyonFS.get(conf);
     TachyonFile file1 = sTfs1.getFile(fileId);
     InStream is1 = file1.getInStream(ReadType.NO_CACHE);
     Assert.assertTrue(is1 instanceof RemoteBlockInStream); //local read is disabled
     
-    conf.set(Constants.USER_DISABLE_LOCAL_READ, "false");
+    conf.set(Constants.USER_ENABLE_LOCAL_READ, "true");
     TachyonFS sTfs2 = TachyonFS.get(conf);
     TachyonFile file2 = sTfs2.getFile(fileId);
     InStream is2 = file2.getInStream(ReadType.NO_CACHE);

--- a/core/src/test/java/tachyon/client/BlockInStreamTest.java
+++ b/core/src/test/java/tachyon/client/BlockInStreamTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import tachyon.Constants;
 import tachyon.TestUtils;
+import tachyon.conf.TachyonConf;
 import tachyon.master.LocalTachyonCluster;
 
 /**
@@ -48,6 +49,28 @@ public class BlockInStreamTest {
     sLocalTachyonCluster = new LocalTachyonCluster(10000, 1000, Constants.GB);
     sLocalTachyonCluster.start();
     sTfs = sLocalTachyonCluster.getClient();
+  }
+  
+  /** 
+   * Test disable local read
+   * @throws IOException 
+   */
+  @Test
+  public void disableLocalReadTest() throws IOException {
+    int fileId = TestUtils.createByteFile(sTfs, "/file_no_local_read", WriteType.TRY_CACHE, 10);
+    
+    TachyonConf conf = sLocalTachyonCluster.getWorkerTachyonConf();
+    conf.set(Constants.USER_DISABLE_LOCAL_READ, "true");
+    TachyonFS sTfs1 = TachyonFS.get(conf);
+    TachyonFile file1 = sTfs1.getFile(fileId);
+    InStream is1 = file1.getInStream(ReadType.NO_CACHE);
+    Assert.assertTrue(is1 instanceof RemoteBlockInStream); //local read is disabled
+    
+    conf.set(Constants.USER_DISABLE_LOCAL_READ, "false");
+    TachyonFS sTfs2 = TachyonFS.get(conf);
+    TachyonFile file2 = sTfs2.getFile(fileId);
+    InStream is2 = file2.getInStream(ReadType.NO_CACHE);
+    Assert.assertTrue(is2 instanceof LocalBlockInStream); //local read is enabled
   }
 
   /**


### PR DESCRIPTION
allow user to disable local read through tachyon.user.localread.disable, default to false.
tachyon.user.localwrite.disable is also added but not used.
test case added.
JIRA: https://tachyon.atlassian.net/browse/TACHYON-53
see comments in the JIRA for more details.