### PR TITLE
[TACHYON-421] Filter signature files in shade execution for client module.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -121,6 +121,16 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:* </artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>org.apache.thrift</pattern>


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-421

If signature files are included in the client jar, they will not be filtered out because it does not match the *:* artifact pattern. Therefore, we should filter out the signature files when we create the client jar to ensure there are no signature files included in the uber jar.