### PR TITLE
[TACHYON-419] Fix loadufs class name.

### DIFF
--- a/bin/tachyon
+++ b/bin/tachyon
@@ -208,7 +208,7 @@ elif [ "$COMMAND" == "formatWorker" ]; then
 elif [ "$COMMAND" == "tfs" ]; then
   CLASS=tachyon.shell.TFsShell
 elif [ "$COMMAND" == "loadufs" ]; then
-  CLASS=tachyon.util.UfsUtils
+  CLASS=tachyon.underfs.UfsUtils
 elif [ "$COMMAND" == "runTest" ]; then
   runTest "$@"
   exit $?


### PR DESCRIPTION
After refactoring, it is now under `tachyon.underfs` instead of `tachyon.util`