### PR TITLE
[TACHYON-408] add option to vagrant deployment to deploy public releases

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -46,14 +46,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           spark_repo, spark_version = SparkV.repo_version
           is_vb = Provider == "vb"
           ans.extra_vars = {
+              tachyon_is_release: TachyonV.type == "Release",
               tachyon_is_git: TachyonV.type == "Github",
               tachyon_is_local: TachyonV.type == "Local",
               tachyon_repo: tachyon_repo, 
               tachyon_version: tachyon_version,
+              compile_tachyon: TachyonV.type != "Release",
+              tachyon_dist: TachyonV.dist,
+
               use_spark: SparkV.use_spark,
+              spark_is_release: SparkV.type == "Release",
+              spark_is_git: SparkV.type == "Github",
               spark_repo: spark_repo,
               spark_version: spark_version,
               spark_version_lessthan_1: SparkV.v_lt_1,
+              compile_spark: SparkV.use_spark && SparkV.type != "Release",
+              spark_dist: SparkV.dist,
+
               is_os: Provider == "openstack",
               is_aws: Provider == "aws",
               is_vb: is_vb,

--- a/deploy/vagrant/core/EnvSetup.rb
+++ b/deploy/vagrant/core/EnvSetup.rb
@@ -74,19 +74,27 @@ class TachyonVersion
     @yml = YAML.load_file(yaml_path)
 
     @type = @yml['Type']
+    @repo = ''
+    @version = ''
+    @dist = ''
     case @type
     when "Local"
       puts 'using local tachyon dir'
-      @repo = ''
-      @version = ''
     when "Github"
       @repo = @yml['Github']['Repo']
       @version = @yml['Github']['Version']
       puts "using github #{@repo}, version #{@version}"
+    when "Release"
+      @dist = @yml['Release']['Dist']
+      puts "using tachyon dist #{@dist}"
     else
-      puts "Unknown VersionType, Only {Github | Local} supported"
+      puts "Unknown VersionType"
       exit(1)
     end
+  end
+
+  def dist
+    return @dist
   end
 
   def type
@@ -104,20 +112,36 @@ class SparkVersion
     puts 'parsing spark_version.yml'
     @yml = YAML.load_file(yaml_path)
 
-    if @yml['Type'] == 'None'
+    @use_spark = true
+    @repo = ''
+    @version = ''
+    @dist = ''
+    @v_lt_1 = false
+    case @yml['Type']
+    when "None"
       puts 'No Spark will be set up'
-      @repo = ''
-      @version = ''
-      @v_lt_1 = true
       @use_spark = false
-    else
-      @use_spark = true
+    when "Github"
       @git = @yml['Github']
       @repo = @git['Repo']
       @version = @git['Version']
       @v_lt_1 = @git['Version_LessThan_1.0.0']
       puts "using github #{@repo}, version #{@version}"
+    when "Release"
+      @dist = @yml['Release']['Dist']
+      puts "using spark dist #{@dist}"
+    else
+      puts "Unknown VersionType"
+      exit(1)
     end
+  end
+
+  def type
+    return @yml['Type']
+  end
+
+  def dist
+    return @dist
   end
 
   def use_spark

--- a/deploy/vagrant/provision/playbook.yaml
+++ b/deploy/vagrant/provision/playbook.yaml
@@ -11,6 +11,9 @@
       shell: sudo mkdir -p /vagrant && user=`whoami` && sudo chown -R $user /vagrant
       when: not is_vb # vb sync the whole /vagrant directory
 
+    - name: prepare /vagrant/shared
+      shell: sudo mkdir -p /vagrant/shared && user=`whoami` && sudo chown -R $user /vagrant
+
     - name: sync files
       synchronize: src=../files dest=/vagrant
       when: not is_vb # vb sync the whole /vagrant directory
@@ -25,7 +28,7 @@
     - name: configure hosts
       script: host.sh
     - name: rename hostname from TachyonXXX to TachyonXXX.local in virtualbox
-      shell: sudo hostname `hostname`.local
+      shell: sudo hostname `hostname | cut -d'.' -f1`.local # if provision multiple times, won't become TachyonXXX.local.local.local
       when: is_vb
 
     - name: install java
@@ -33,6 +36,9 @@
 
     - name: install rsync
       shell: sudo yum install -y -q rsync
+
+    - name: install wget
+      command: sudo yum install -y -q wget
 
     - name: mkdir /tachyon
       shell: sudo mkdir -p /tachyon && user=`whoami` && sudo chown -R $user /tachyon
@@ -45,10 +51,11 @@
   tasks:
     - name: install maven
       script: maven.sh
+      when: compile_tachyon or compile_spark
 
     - name: install git
       command: sudo yum install -y -q git
-      when: tachyon_is_git or use_spark
+      when: tachyon_is_git or spark_is_git
 
     - name: clone tachyon repo
       git: repo={{ tachyon_repo }} dest=/tachyon version={{ tachyon_version }}
@@ -69,13 +76,24 @@
           --exclude=journal,
           --exclude=logs,
           --exclude=underFSStorage
-      when: (not is_vb) and (not tachyon_is_git)
+      when: (not is_vb) and tachyon_is_local
 
     - copy: src=../ufs/{{ ufs }}/compile_tachyon.sh dest=/tmp/compile_tachyon.sh
+      when: compile_tachyon
     - name: compile tachyon
       command: bash /tmp/compile_tachyon.sh
       async: 1200
       poll: 60
+      when: compile_tachyon
+
+    - name: prepare tachyon release
+      shell: if [ ! -f /vagrant/shared/{{ tachyon_dist }} ]; then \
+               version=`echo {{ tachyon_dist }} | cut -d'-' -f2`; \
+               wget -q https://github.com/amplab/tachyon/releases/download/v${version}/{{ tachyon_dist }} -P /vagrant/shared; \
+             fi && \
+             tar xzf /vagrant/shared/{{ tachyon_dist }} -C /tachyon --strip-components 1
+      ignore_errors: yes # tachyon dist is tared by bsdtar, when untar using gnutar, return code will be 1
+      when: tachyon_is_release
 
     - name: set tachyon/conf/workers tachyon/conf/slaves
       shell: cp /vagrant/files/workers /tachyon/conf/workers && cp /vagrant/files/workers /tachyon/conf/slaves
@@ -93,14 +111,22 @@
 
     - name: clone spark repo
       git: repo={{ spark_repo }} dest=/spark version={{ spark_version }}
-      when: use_spark
+      when: spark_is_git
+
+    - name: prepare spark release
+      shell: version=`echo {{ spark_dist }} | cut -d'-' -f2` && \
+             if [ ! -f /vagrant/shared/{{ spark_dist }} ]; then \
+               wget -q http://archive.apache.org/dist/spark/spark-${version}/{{ spark_dist }} -P /vagrant/shared; \
+             fi && \
+             tar xzf /vagrant/shared/{{ spark_dist }} -C /spark --strip-components 1
+      when: spark_is_release
 
     - name: set current tachyon version in spark/core/pom.xml
       shell: tachyon_version=`/tachyon/bin/tachyon version | cut -d':' -f2 | tr -d ' '` && \
              perl -0777 -i -pe \
              "s/(<artifactId>tachyon-client<\/artifactId>\n\s*)<version>.*/\1<version>${tachyon_version}<\/version>/g" \
              /spark/core/pom.xml
-      when: use_spark
+      when: compile_spark
 
     - name: set spark/conf/slaves
       command: cp /vagrant/files/workers /spark/conf/slaves
@@ -117,14 +143,14 @@
       when: use_spark
 
     - copy: src=../ufs/{{ ufs }}/compile_spark.sh dest=/tmp/compile_spark.sh
-      when: use_spark
+      when: compile_spark
     - name: compile spark and make-distribution
       command: bash /tmp/compile_spark.sh
       async: 18000
       poll: 60
-      when: use_spark
+      when: compile_spark
     - shell: cp -r /spark/conf /spark/dist/
-      when: use_spark
+      when: compile_spark
 
 - hosts: TachyonWorker*
   tasks:
@@ -135,17 +161,14 @@
           && rsync -avz TachyonMaster.local:'/tachyon/bin /tachyon/conf /tachyon/libexec' /tachyon
       when: not (is_vb and tachyon_is_local)
 
-    - name: rsync spark bin distribution from TachyonMaster
+    - name: rsync /spark/dist from TachyonMaster
       shell: rsync -avz TachyonMaster.local:/spark/dist/* /spark
-      when: use_spark
+      when: compile_spark
 
-- hosts: all
-  tasks:
-    - name: prepare /vagrant/shared
-      shell: sudo mkdir -p /vagrant/shared && user=`whoami` && sudo chown -R $user /vagrant
+    - name: rsync /spark from TachyonMaster
+      shell: rsync -avz TachyonMaster.local:/spark/* /spark
+      when: use_spark and (not compile_spark)
 
-    - name: install wget
-      command: sudo yum install -y -q wget
 
 # when is_vb, only master downloads ufs, others share throught /vagrant/shared
 - hosts: TachyonMaster

--- a/deploy/vagrant/provision/playbook.yaml
+++ b/deploy/vagrant/provision/playbook.yaml
@@ -27,9 +27,6 @@
 
     - name: configure hosts
       script: host.sh
-    - name: rename hostname from TachyonXXX to TachyonXXX.local in virtualbox
-      shell: sudo hostname `hostname | cut -d'.' -f1`.local # if provision multiple times, won't become TachyonXXX.local.local.local
-      when: is_vb
 
     - name: install java
       script: java.sh
@@ -135,7 +132,8 @@
     - name: set spark-env.sh
       shell: echo export SPARK_CLASSPATH=/tachyon/client/target/tachyon-client-*-jar-with-dependencies.jar:$SPARK_CLASSPATH >> /spark/conf/spark-env.sh
       when: use_spark and spark_version_lessthan_1
-    - shell: echo export HADOOP_CONF_DIR=/hadoop/etc/hadoop >> /spark/conf/spark-env.sh
+    - shell: echo export HADOOP_CONF_DIR=/hadoop/etc/hadoop >> /spark/conf/spark-env.sh && \
+             echo export SPARK_MASTER_IP="`tail -n1 /spark/conf/slaves`" >> /spark/conf/spark-env.sh
       when: use_spark
 
     - name: set spark/conf/core-site.xml

--- a/deploy/vagrant/spark_version.yml
+++ b/deploy/vagrant/spark_version.yml
@@ -1,6 +1,13 @@
-# Type can be {None|Github}, None means don't set up spark
-Type: None
+# Type can be {None|Github|Release}
+# None means don't set up spark
+# Release means using binary distribution
+Type: Release
+
 Github:
   Repo: https://github.com/apache/spark
   Version: branch-1.3 # repo of this version must contain make-distribution.sh, that is branch-0.8 afterwards
   Version_LessThan_1.0.0: false
+
+Release: 
+  Dist: spark-1.3.1-bin-hadoop1.tgz
+  

--- a/deploy/vagrant/spark_version.yml
+++ b/deploy/vagrant/spark_version.yml
@@ -1,7 +1,7 @@
 # Type can be {None|Github|Release}
 # None means don't set up spark
 # Release means using binary distribution
-Type: Release
+Type: None
 
 Github:
   Repo: https://github.com/apache/spark

--- a/deploy/vagrant/tachyon_version.yml
+++ b/deploy/vagrant/tachyon_version.yml
@@ -1,7 +1,10 @@
 # {Github | Local}
-Type: Local
+Type: Release
 
 # github repo and version(can be branch, commit hash)
 Github: 
   Repo: https://github.com/amplab/tachyon
   Version: branch-0.5
+
+Release:
+  Dist: tachyon-0.5.0-bin.tar.gz

--- a/deploy/vagrant/tachyon_version.yml
+++ b/deploy/vagrant/tachyon_version.yml
@@ -1,5 +1,5 @@
 # {Github | Local}
-Type: Release
+Type: Local
 
 # github repo and version(can be branch, commit hash)
 Github: 

--- a/deploy/vagrant/tachyon_version.yml
+++ b/deploy/vagrant/tachyon_version.yml
@@ -1,4 +1,4 @@
-# {Github | Local}
+# {Github | Local | Release}
 Type: Local
 
 # github repo and version(can be branch, commit hash)

--- a/deploy/vagrant/ufs/hadoop1/init.sh
+++ b/deploy/vagrant/ufs/hadoop1/init.sh
@@ -6,9 +6,6 @@ NODES=`cat /tachyon/conf/workers`
 
 cd /vagrant/shared
 
-mkdir -p /tmp/hdfs-datanode
-mkdir -p /tmp/hadoop-tmpstore
-
 if [ ! -f hadoop-${HADOOP_VERSION}-bin.tar.gz ]
 then
     # download hadoop

--- a/docs/Running-Specific-Version-Of-Tachyon-Or-Spark-Via-Vagrant.md
+++ b/docs/Running-Specific-Version-Of-Tachyon-Or-Spark-Via-Vagrant.md
@@ -5,26 +5,51 @@ title: Deploy Specific Version Of Either Tachyon Or Spark Via Vagrant
 
 In deploy/vagrant/tachyon_version.yml:
 
-    # {Github | Local}
-    Type: Github
+    # {Github | Local | Release}
+    Type: Local
 
-    # github repo and commit hash 
+    # github repo and version(can be branch, commit hash)
     Github: 
       Repo: https://github.com/amplab/tachyon
-      Version: eaeaccd19832494c5f0b2a792888a5eaacd7bcf8
+      Version: branch-0.5
 
-You can set `Type` to `Local` to deploy the Tachyon built locally in your Tachyon project's root directory
+    Release:
+      Dist: tachyon-0.5.0-bin.tar.gz
 
-Set `Type` to `Github`, `Repo` to the git repo url, `Version` to commit hash or remote branch name, then deploy this specific version of Tachyon!
+Parameters explained: 
+
+<table class="table">
+<tr>
+    <th>Parameter</th><th>Description</th><th>Values</th>
+</tr>
+<tr>
+    <td>Type</td><td>where to get tachyon</td><td>Local|Github|Release. Local means deploy the tachyon on your host that is deploy/vagrant/../.. relative to where you start vagrant. Github means deploy tachyon from repo and version specified in Github section. Release means deploy binary distribution from https://github.com/amplab/tachyon/releases, Dist specifies which tar you want to download. </td>
+</tr>
+<tr>
+    <td>Github:Repo</td><td>url of github repo for tachyon</td><td>official repo is https://github.com/amplab/tachyon</td>
+</tr>
+<tr>
+    <td>Github:Version</td><td>branch or commit hash of the repo</td><td>e.x. branch-0.5 or 88116afd140306ce9755eabe3d6fd305ddaf9267</td>
+</tr>
+<tr>
+    <td>Release:Dist</td><td>the name of tarball you want to deploy</td><td>e.x. tachyon-0.5.0-bin.tar.gz</td>
+</tr>
+</table>
 
 Similarly, configure deploy/vagrant/spark_version.yml to deploy spark or not:
 
-    # Type can be {None|Github}, None means don't set up spark
+    # Type can be {None|Github|Release}
+    # None means don't set up spark
+    # Release means using binary distribution
     Type: None
+
     Github:
       Repo: https://github.com/apache/spark
       Version: branch-1.3 # repo of this version must contain make-distribution.sh, that is branch-0.8 afterwards
       Version_LessThan_1.0.0: false
+
+    Release: 
+      Dist: spark-1.3.1-bin-hadoop1.tgz
 
 The deployed Spark will use Tachyon as Cache layer and Hadoop as underlayer filesystem. 
 


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-408

currently, use deploy module forces you to compile tachyon/spark, it's too time consuming

with this PR, you can choose to deploy tachyon/spark releases, the process should be in 10min with ./run_vb.sh