### PR TITLE
[TACHYON-424] S3 client v2

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -105,6 +105,17 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.tachyonproject</groupId>
+      <artifactId>tachyon-underfs-s3</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.tachyonproject</groupId>
+          <artifactId>tachyon</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -46,6 +46,8 @@ public class Constants {
   public static final String SCHEME_FT = "tachyon-ft";
   public static final String HEADER_FT = SCHEME_FT + "://";
 
+  public static final String HEADER_S3N = "s3n://";
+
   public static final int DEFAULT_MASTER_PORT = 19998;
   public static final int DEFAULT_MASTER_WEB_PORT = DEFAULT_MASTER_PORT + 1;
   public static final int DEFAULT_WORKER_PORT = 29998;

--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -204,4 +204,6 @@ public class Constants {
   public static final String USER_ENABLE_LOCAL_READ = "tachyon.user.localread.enable";
   public static final String USER_ENABLE_LOCAL_WRITE = "tachyon.user.localwrite.enable";
 
+  public static final String S3_ACCESS_KEY = "fs.s3n.awsAccessKeyId";
+  public static final String S3_SECRET_KEY = "fs.s3n.awsSecretAccessKey";
 }

--- a/common/src/main/java/tachyon/underfs/UnderFileSystem.java
+++ b/common/src/main/java/tachyon/underfs/UnderFileSystem.java
@@ -130,7 +130,7 @@ public abstract class UnderFileSystem {
       String header = path.getScheme() + "://";
       String authority = (path.hasAuthority()) ? path.getAuthority() : "";
       if (header.equals(Constants.HEADER) || header.equals(Constants.HEADER_FT)
-          || isHadoopUnderFS(header, tachyonConf)) {
+          || isHadoopUnderFS(header, tachyonConf) || header.equals("s3n://")) {
         if (path.getPath().isEmpty()) {
           return new Pair<String, String>(header + authority, TachyonURI.SEPARATOR);
         } else {

--- a/common/src/main/java/tachyon/underfs/UnderFileSystem.java
+++ b/common/src/main/java/tachyon/underfs/UnderFileSystem.java
@@ -124,13 +124,13 @@ public abstract class UnderFileSystem {
    *         address is "/" and the path starts with "/".
    */
   public static Pair<String, String> parse(TachyonURI path, TachyonConf tachyonConf) {
-    Preconditions.checkArgument(path != null, "path may not be null");
+    Preconditions.checkNotNull(path);
 
     if (path.hasScheme()) {
       String header = path.getScheme() + "://";
       String authority = (path.hasAuthority()) ? path.getAuthority() : "";
       if (header.equals(Constants.HEADER) || header.equals(Constants.HEADER_FT)
-          || isHadoopUnderFS(header, tachyonConf) || header.equals("s3n://")) {
+          || isHadoopUnderFS(header, tachyonConf) || header.equals(Constants.HEADER_S3N)) {
         if (path.getPath().isEmpty()) {
           return new Pair<String, String>(header + authority, TachyonURI.SEPARATOR);
         } else {

--- a/core/src/main/java/tachyon/hadoop/Utils.java
+++ b/core/src/main/java/tachyon/hadoop/Utils.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -36,11 +36,11 @@ public final class Utils {
    * System properties, and they're not already set.
    */
   public static void addS3Credentials(Configuration conf) {
-    String accessKeyConf = "fs.s3n.awsAccessKeyId";
+    String accessKeyConf = Constants.S3_ACCESS_KEY;
     if (System.getProperty(accessKeyConf) != null && conf.get(accessKeyConf) == null) {
       conf.set(accessKeyConf, System.getProperty(accessKeyConf));
     }
-    String secretKeyConf = "fs.s3n.awsSecretAccessKey";
+    String secretKeyConf = Constants.S3_SECRET_KEY;
     if (System.getProperty(secretKeyConf) != null && conf.get(secretKeyConf) == null) {
       conf.set(secretKeyConf, System.getProperty(secretKeyConf));
     }

--- a/core/src/test/java/tachyon/client/BlockInStreamTest.java
+++ b/core/src/test/java/tachyon/client/BlockInStreamTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/core/src/test/java/tachyon/underfs/UnderFileSystemCluster.java
+++ b/core/src/test/java/tachyon/underfs/UnderFileSystemCluster.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -52,7 +52,7 @@ public abstract class UnderFileSystemCluster {
 
   /**
    * To start the underfs test bed and register the shutdown hook
-   * 
+   *
    * @throws IOException
    * @throws InterruptedException
    */
@@ -100,12 +100,12 @@ public abstract class UnderFileSystemCluster {
 
   /**
    * This method is only for unit-test {@link tachyon.client.FileOutStreamTest} temporarily
-   * 
+   *
    * @return true if reads on end of file return negative otherwise false
    */
   public static boolean readEOFReturnsNegative() {
     // TODO Should be dynamically determined - may need additional method on UnderFileSystem
-    return (null != mUfsClz) && (mUfsClz.equals("tachyon.underfs.hdfs.LocalMiniDFSCluster"));
+    return (null != mUfsClz) && !(mUfsClz.equals("tachyon.LocalUnderFileSystem"));
   }
 
   public UnderFileSystemCluster(String baseDir, TachyonConf tachyonConf) {
@@ -118,7 +118,7 @@ public abstract class UnderFileSystemCluster {
    * system for the next test round instead of turning on/off it from time to time. This function is
    * expected to be called either before or after each test case which avoids certain overhead from
    * the bootstrap.
-   * 
+   *
    * @throws IOException
    */
   public void cleanup() throws IOException {
@@ -135,7 +135,7 @@ public abstract class UnderFileSystemCluster {
 
   /**
    * Check if the cluster started.
-   * 
+   *
    * @return
    */
   public abstract boolean isStarted();
@@ -143,7 +143,7 @@ public abstract class UnderFileSystemCluster {
   /**
    * Add a shutdown hook. The {@link #shutdown} phase will be automatically called while the process
    * exists.
-   * 
+   *
    * @throws InterruptedException
    */
   public void registerJVMOnExistHook() throws IOException {
@@ -152,14 +152,14 @@ public abstract class UnderFileSystemCluster {
 
   /**
    * To stop the underfs cluster system
-   * 
+   *
    * @throws IOException
    */
   public abstract void shutdown() throws IOException;
 
   /**
    * To start the underfs cluster system
-   * 
+   *
    * @throws IOException
    */
   public abstract void start() throws IOException;

--- a/core/src/test/java/tachyon/underfs/UnderStorageSystemInterfaceTest.java
+++ b/core/src/test/java/tachyon/underfs/UnderStorageSystemInterfaceTest.java
@@ -250,7 +250,7 @@ public class UnderStorageSystemInterfaceTest {
     String testDirSrcChild = CommonUtils.concatPath(testDirSrc, "testFile");
     String testDirDst = CommonUtils.concatPath(mUnderfsAddress, "testDirDst");
     String testDirDstChild = CommonUtils.concatPath(testDirDst, "testFile");
-    String testDirFinalDst = CommonUtils.concatPath(testDirDst, "TestDirSrc");
+    String testDirFinalDst = CommonUtils.concatPath(testDirDst, "testDirSrc");
     String testDirChildFinalDst = CommonUtils.concatPath(testDirFinalDst, "testFile");
     mUfs.mkdirs(testDirSrc, false);
     mUfs.mkdirs(testDirDst, false);

--- a/docs/Setup-UFS.md
+++ b/docs/Setup-UFS.md
@@ -31,6 +31,11 @@ necessary credentials such as `fs.s3n.awsAccessKeyId` and `fs.s3n.awsSecretAcces
 the underfs address to a directory and bucket that already exist (you can create new buckets and
 directories from the S3 web interface).
 
+Tachyon comes with a native S3 client and the option to use the S3 client provided by hadoop. To
+enable the native S3 client, include the `underfs-s3` module and exclude the `underfs-hdfs` module.
+Alternatively, modify `tachyon.underfs.hadoop.prefixes` to exclude `s3n://`. To use the hadoop
+provided client, include the `underfs-hdfs` module and exclude the `underfs-s3` module.
+
 Some users have run into additional issues getting Tachyon working with S3. The `hadoop-client`
 package requires the `jets3t` package to use S3, but for some reason doesn't pull it in as a
 depedency. One way to fix this is to repackage Tachyon, adding jets3t as a dependency. For example,

--- a/libexec/tachyon-config.sh
+++ b/libexec/tachyon-config.sh
@@ -26,7 +26,7 @@ if [ -z "$TACHYON_SYSTEM_INSTALLATION" ]; then
   export TACHYON_HOME=${TACHYON_PREFIX}
   export TACHYON_CONF_DIR="$TACHYON_HOME/conf"
   export TACHYON_LOGS_DIR="$TACHYON_HOME/logs"
-  export TACHYON_JARS="$TACHYON_HOME/core/target/tachyon-${VERSION}-jar-with-dependencies.jar:$TACHYON_HOME/underfs/hdfs/target/tachyon-underfs-hdfs-${VERSION}.jar:$TACHYON_HOME/underfs/glusterfs/target/tachyon-underfs-glusterfs-${VERSION}.jar:$TACHYON_HOME/examples/target/tachyon-examples-${VERSION}.jar:$TACHYON_HOME/shell/target/tachyon-shell-${VERSION}.jar"
+  export TACHYON_JARS="$TACHYON_HOME/core/target/tachyon-${VERSION}-jar-with-dependencies.jar:$TACHYON_HOME/underfs/hdfs/target/tachyon-underfs-hdfs-${VERSION}.jar:$TACHYON_HOME/underfs/glusterfs/target/tachyon-underfs-glusterfs-${VERSION}.jar:$TACHYON_HOME/underfs/s3/target/tachyon-underfs-s3-${VERSION}.jar:$TACHYON_HOME/examples/target/tachyon-examples-${VERSION}.jar:$TACHYON_HOME/shell/target/tachyon-shell-${VERSION}.jar"
   export JAVA="$JAVA_HOME/bin/java"
 fi
 

--- a/underfs/hdfs/pom.xml
+++ b/underfs/hdfs/pom.xml
@@ -34,11 +34,6 @@
       <artifactId>tachyon</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.9.30</version>
-    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/underfs/hdfs/pom.xml
+++ b/underfs/hdfs/pom.xml
@@ -34,6 +34,11 @@
       <artifactId>tachyon</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>1.9.30</version>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/underfs/pom.xml
+++ b/underfs/pom.xml
@@ -14,6 +14,7 @@
   <modules>
     <module>hdfs</module>
     <module>glusterfs</module>
+    <module>s3</module>
   </modules>
 
   <properties>

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -37,11 +37,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.thrift</groupId>
-      <artifactId>libthrift</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -1,0 +1,121 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.tachyonproject</groupId>
+    <artifactId>tachyon-underfs</artifactId>
+    <version>0.7.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>tachyon-underfs-s3</artifactId>
+  <name>Tachyon Under File System - S3</name>
+  <description>S3 Under File System implementation</description>
+
+  <properties>
+    <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
+    <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
+    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.tachyonproject</groupId>
+      <artifactId>tachyon</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.tachyonproject</groupId>
+      <artifactId>tachyon</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${libthrift.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>${apache.curator.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.javassist</groupId>
+          <artifactId>javassist</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-minicluster</artifactId>
+      <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.18.1</version>
+        <configuration>
+          <argLine>-Djava.security.krb5.realm= -Djava.security.krb5.kdc=</argLine>
+          <!-- Pull in integration tests from core module -->
+          <dependenciesToScan>
+            <dependency>org.tachyonproject:tachyon</dependency>
+          </dependenciesToScan>
+          <systemPropertyVariables>
+            <ufs>tachyon.underfs.hdfs.LocalMiniDFSCluster</ufs>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -89,12 +89,14 @@
         <configuration>
           <argLine>-Djava.security.krb5.realm= -Djava.security.krb5.kdc=</argLine>
           <!-- Pull in integration tests from core module -->
+          <!-- Uncomment this section to actually run tests against S3.
           <dependenciesToScan>
             <dependency>org.tachyonproject:tachyon</dependency>
           </dependenciesToScan>
           <systemPropertyVariables>
             <ufs>tachyon.underfs.s3.S3UnderStorageCluster</ufs>
           </systemPropertyVariables>
+          !-->
         </configuration>
         <executions>
           <execution>

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -108,7 +108,7 @@
             <dependency>org.tachyonproject:tachyon</dependency>
           </dependenciesToScan>
           <systemPropertyVariables>
-            <ufs>tachyon.underfs.hdfs.LocalMiniDFSCluster</ufs>
+            <ufs>tachyon.underfs.s3.S3UnderStorageCluster</ufs>
           </systemPropertyVariables>
         </configuration>
         <executions>

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -39,43 +39,26 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-      <version>${libthrift.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
-      <version>${apache.curator.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.javassist</groupId>
-          <artifactId>javassist</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
-      <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -78,21 +78,6 @@
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-minicluster</artifactId>
-      <version>${hadoop.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>asm</groupId>
-          <artifactId>asm</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.netty</groupId>
-          <artifactId>netty</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <build>

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -23,9 +23,9 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.9.30</version>
+      <groupId>net.java.dev.jets3t</groupId>
+      <artifactId>jets3t</artifactId>
+      <version>0.9.3</version>
     </dependency>
 
     <!-- Test Dependencies -->

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -67,11 +67,14 @@
         <configuration>
           <argLine>-Djava.security.krb5.realm= -Djava.security.krb5.kdc=</argLine>
           <!-- Pull in integration tests from core module -->
-          <!-- Uncomment this section to actually run tests against S3.
+          <!-- Uncomment this section and fill out the necessary variables to run S3 integration tests
           <dependenciesToScan>
             <dependency>org.tachyonproject:tachyon</dependency>
           </dependenciesToScan>
           <systemPropertyVariables>
+            <accessKey>myAccessKey</accessKey>
+            <secretKey>mySecretKey</secretKey>
+            <s3Bucket>s3n://my-bucket/tachyon-test</s3Bucket>
             <ufs>tachyon.underfs.s3.S3UnderStorageCluster</ufs>
           </systemPropertyVariables>
           !-->

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -22,6 +22,11 @@
       <artifactId>tachyon</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>1.9.30</version>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -31,6 +31,11 @@ import org.jets3t.service.utils.Mimetypes;
 
 import tachyon.util.CommonUtils;
 
+/**
+ * This class creates a streaming interface for writing a file in s3. The data will be persisted
+ * to a temporary directory on local disk and copied as a complete file when the close() method is
+ * called.
+ */
 public class S3OutputStream extends OutputStream {
   private final String mBucketName;
   private final String mKey;

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.underfs.s3;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class S3OutputStream extends OutputStream {
+  private final String mKey;
+  private final OutputStream mOut;
+
+  public S3OutputStream(String key) throws IOException {
+    mKey = key;
+    File tmpFile = new File("/tmp/" + key);
+    mOut = new FileOutputStream(tmpFile);
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+
+  }
+}

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -27,6 +27,8 @@ import org.jets3t.service.ServiceException;
 import org.jets3t.service.model.S3Object;
 import org.jets3t.service.utils.Mimetypes;
 
+import tachyon.util.CommonUtils;
+
 public class S3OutputStream extends OutputStream {
   private final String mBucketName;
   private final String mKey;
@@ -38,7 +40,7 @@ public class S3OutputStream extends OutputStream {
     mBucketName = bucketName;
     mKey = key;
     mClient = client;
-    mFile = new File("/tmp/" + UUID.randomUUID());
+    mFile = new File(CommonUtils.concatPath("/tmp", UUID.randomUUID()));
     mLocalOutputStream = new BufferedOutputStream(new FileOutputStream(mFile));
   }
 

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.UUID;
 
+import com.google.common.base.Preconditions;
+
 import org.jets3t.service.S3Service;
 import org.jets3t.service.ServiceException;
 import org.jets3t.service.model.S3Object;
@@ -37,6 +39,8 @@ public class S3OutputStream extends OutputStream {
   private final S3Service mClient;
 
   public S3OutputStream(String bucketName, String key, S3Service client) throws IOException {
+    Preconditions.checkArgument(bucketName != null && !bucketName.isEmpty(), "Bucket name must "
+        + "not be null or empty.");
     mBucketName = bucketName;
     mKey = key;
     mClient = client;

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -34,9 +34,9 @@ public class S3OutputStream extends OutputStream {
 
   public S3OutputStream(String bucketName, String key, S3Service client) throws IOException {
     mBucketName = bucketName;
-    mKey = key;
+    mKey = key.substring(6 + mBucketName.length() + 1);
     mClient = client;
-    mFile = new File("/tmp/" + key);
+    mFile = new File("/tmp/" + Math.random() * 100);
     mOut = new FileOutputStream(mFile);
   }
 

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -35,7 +35,7 @@ public class S3OutputStream extends OutputStream {
 
   public S3OutputStream(String bucketName, String key, S3Service client) throws IOException {
     mBucketName = bucketName;
-    mKey = key.substring(6 + mBucketName.length() + 1);
+    mKey = key;
     mClient = client;
     mFile = new File("/tmp/" + Math.random() * 100);
     mLocalOutputStream = new BufferedOutputStream(new FileOutputStream(mFile));

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -15,11 +15,15 @@
 
 package tachyon.underfs.s3;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
 import org.jets3t.service.S3Service;
 import org.jets3t.service.ServiceException;
 import org.jets3t.service.model.S3Object;
-
-import java.io.*;
+import org.jets3t.service.utils.Mimetypes;
 
 public class S3OutputStream extends OutputStream {
   private final String mBucketName;
@@ -49,8 +53,10 @@ public class S3OutputStream extends OutputStream {
   @Override
   public void close() throws IOException {
     mOut.close();
-    BufferedInputStream in = new BufferedInputStream(new FileInputStream(mFile));
     S3Object obj = new S3Object(mKey);
+    obj.setDataInputFile(mFile);
+    obj.setContentLength(mFile.length());
+    obj.setContentEncoding(Mimetypes.MIMETYPE_BINARY_OCTET_STREAM);
     try {
       mClient.putObject(mBucketName, obj);
     } catch (ServiceException se) {

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.UUID;
 
 import org.jets3t.service.S3Service;
 import org.jets3t.service.ServiceException;
@@ -37,7 +38,7 @@ public class S3OutputStream extends OutputStream {
     mBucketName = bucketName;
     mKey = key;
     mClient = client;
-    mFile = new File("/tmp/" + Math.random() * 100);
+    mFile = new File("/tmp/" + UUID.randomUUID());
     mLocalOutputStream = new BufferedOutputStream(new FileOutputStream(mFile));
   }
 

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -102,6 +102,8 @@ public class S3UnderFileSystem extends UnderFileSystem {
   public boolean delete(String path, boolean recursive) throws IOException {
     if (!recursive) {
       if (isFolder(path) && listInternal(path, false).length != 0) {
+        LOG.error("Unable to delete " + path + " because it is a non empty directory. Specify "
+            + "recursive as true in order to delete non empty directories.");
         return false;
       }
       return deleteInternal(path);

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -20,6 +20,13 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 
+import org.jets3t.service.S3Service;
+import org.jets3t.service.S3ServiceException;
+import org.jets3t.service.ServiceException;
+import org.jets3t.service.impl.rest.httpclient.RestS3Service;
+import org.jets3t.service.model.S3Bucket;
+import org.jets3t.service.model.S3Object;
+import org.jets3t.service.security.AWSCredentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,11 +34,22 @@ import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 
+/**
+ * Under file system implementation for S3 using the Jets3t library.
+ */
 public class S3UnderFileSystem extends UnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
+  private final S3Service mClient;
+  private final S3Bucket mBucket;
+
   public S3UnderFileSystem(String bucketName, TachyonConf tachyonConf) {
     super(tachyonConf);
+    AWSCredentials awsCredentials =
+        new AWSCredentials(tachyonConf.get("fs.s3n.awsAccessKeyId", null), tachyonConf.get(
+            "fs.s3n.awsSecretAccessKey", null));
+    mClient = new RestS3Service(awsCredentials);
+    mBucket = new S3Bucket(bucketName);
   }
 
   @Override
@@ -53,42 +71,65 @@ public class S3UnderFileSystem extends UnderFileSystem {
     return null;
   }
 
+  // Not supported
   @Override
   public OutputStream create(String path, int blockSizeByte) throws IOException {
-    return null;
+    return create(path);
   }
 
+  // Not supported
   @Override
   public OutputStream create(String path, short replication, int blockSizeByte)
       throws IOException {
-    return null;
+    return create(path);
   }
 
   @Override
   public boolean delete(String path, boolean recursive) throws IOException {
+    if (!recursive) {
+      return delete(path);
+    }
+
+    // Get all relevant files
+    String[] pathsToDelete = list(path);
+    for (String pathToDelete : pathsToDelete) {
+      // If we fail to delete one file, stop
+      if (!delete(pathToDelete)) {
+        return false;
+      }
+    }
     return true;
   }
 
   @Override
   public boolean exists(String path) throws IOException {
-    return false;
+    try {
+      mClient.getObjectDetails(mBucket, path);
+      return true;
+    } catch (ServiceException s) {
+      return false;
+    }
   }
 
+  // Largest size of one file is 5 TB
   @Override
   public long getBlockSizeByte(String path) throws IOException {
-    return -1L;
+    return Constants.TB * 5;
   }
 
+  // Not supported
   @Override
   public Object getConf() {
     return null;
   }
 
+  // Not supported
   @Override
   public List<String> getFileLocations(String path) throws IOException {
     return null;
   }
 
+  // Not supported
   @Override
   public List<String> getFileLocations(String path, long offset) throws IOException {
     return null;
@@ -96,17 +137,33 @@ public class S3UnderFileSystem extends UnderFileSystem {
 
   @Override
   public long getFileSize(String path) throws IOException {
-    return -1L;
+    return getObjectDetails(path).getContentLength();
   }
 
   @Override
   public long getModificationTimeMs(String path) throws IOException {
-    return -1L;
+    return getObjectDetails(path).getLastModifiedDate().getTime();
   }
 
+  // S3 is not really bounded
   @Override
   public long getSpace(String path, SpaceType type) throws IOException {
-    return -1L;
+    switch (type) {
+      // TODO: This might be really slow
+      case SPACE_USED:
+        long ret = 0L;
+        String[] keys = list(path);
+        for (String key : keys) {
+          ret += getObjectDetails(key).getContentLength();
+        }
+        return ret;
+      case SPACE_FREE:
+        return Long.MAX_VALUE;
+      case SPACE_TOTAL:
+        return Long.MAX_VALUE;
+      default:
+        throw new IOException("Unknown getSpace parameter: " + type);
+    }
   }
 
   @Override
@@ -143,4 +200,41 @@ public class S3UnderFileSystem extends UnderFileSystem {
 
   }
 
+  /**
+   * Internal function to delete a key in S3
+   * @param key the key to delete
+   * @return true if successful, false if an exception is thrown
+   * @throws IOException
+   */
+  private boolean delete(String key) throws IOException {
+    try {
+      mClient.deleteObject(mBucket, key);
+    } catch (ServiceException se) {
+      LOG.error("Failed to delete " + key, se);
+      return false;
+    }
+    return true;
+  }
+
+  private S3Object getObjectDetails(String key) throws IOException {
+    try {
+      return mClient.getObjectDetails(mBucket, key);
+    } catch (ServiceException se) {
+      LOG.error("File does not exist");
+      handleException(se);
+      return null;
+    }
+  }
+
+  /**
+   * Transforms JetS3t's Service Exceptions to IOExceptions
+   * @throws IOException
+   */
+  private void handleException(ServiceException se) throws IOException {
+    if (se.getCause() instanceof IOException) {
+      throw (IOException) se.getCause();
+    } else {
+      // Unexpected Service Exception
+    }
+  }
 }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -183,9 +183,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
     if (!isFolder(path)) {
       return null;
     }
-    System.out.println("List with : " + path);
     path = path.endsWith(PATH_SEPARATOR) ? path : path + PATH_SEPARATOR;
-    System.out.println("List after : " + path);
     return listInternal(path, false);
   }
 

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -20,23 +20,18 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 
 public class S3UnderFileSystem extends UnderFileSystem {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
-  private final AmazonS3 mS3Client;
-
-  public S3UnderFileSystem(TachyonConf tachyonConf) {
+  public S3UnderFileSystem(String bucketName, TachyonConf tachyonConf) {
     super(tachyonConf);
-    BasicAWSCredentials credentials =
-        new BasicAWSCredentials(tachyonConf.get("fs.s3n.awsAccessKeyId", null),
-        tachyonConf.get("fs.s3n.awsSecretAccessKey", null));
-    mS3Client = new AmazonS3Client(credentials);
   }
 
   @Override
@@ -71,7 +66,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
 
   @Override
   public boolean delete(String path, boolean recursive) throws IOException {
-    return false;
+    return true;
   }
 
   @Override

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -46,7 +46,6 @@ public class S3UnderFileSystem extends UnderFileSystem {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   private static final String FOLDER_SUFFIX = "_$folder$";
   private static final String PATH_SEPARATOR = "/";
-  private static final String SCHEME = "s3n://";
 
   private final S3Service mClient;
   private final String mBucketName;
@@ -429,8 +428,8 @@ public class S3UnderFileSystem extends UnderFileSystem {
    * @return true if the key is the root, false otherwise
    */
   private boolean isRoot(String key) {
-    return
-        key.equals(SCHEME + mBucketName) || key.equals(SCHEME + mBucketName + PATH_SEPARATOR);
+    return key.equals(Constants.HEADER_S3N + mBucketName)
+        || key.equals(Constants.HEADER_S3N + mBucketName + PATH_SEPARATOR);
   }
 
   /**
@@ -510,7 +509,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
    * @return the key without the s3 bucket prefix
    */
   private String stripPrefix(String key) {
-    String prefix = SCHEME + mBucketName + PATH_SEPARATOR;
+    String prefix = Constants.HEADER_S3N + mBucketName + PATH_SEPARATOR;
     if (key.startsWith(prefix)) {
       return key.substring(prefix.length());
     } else {

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -220,13 +220,14 @@ public class S3UnderFileSystem extends UnderFileSystem {
     if (exists(dst)) {
       if (!isFolder(dst)) {
         LOG.error("Unable to rename " + src + " to " + dst + " because destination already "
-            + "exists as a file");
+            + "exists as a file.");
         return false;
       }
       // Destination is a folder, move source into dst
       if (!isFolder(src)) {
         // Source is a file
-        S3Object obj = new S3Object(src);
+        String srcName = getKeyName(src);
+        renameInternal(src, dst);
       }
     }
     if (isFolder(src)) {
@@ -373,6 +374,17 @@ public class S3UnderFileSystem extends UnderFileSystem {
       return true;
     } catch (ServiceException se) {
       LOG.error("Failed to create directory: " + key, se);
+      return false;
+    }
+  }
+
+  private boolean renameInternal(String src, String dst) {
+    try {
+      S3Object obj = new S3Object(dst);
+      mClient.copyObject(mBucketName, src, mBucketName, obj, false);
+      return true;
+    } catch (ServiceException se) {
+      LOG.error("Failed to rename file " + src + " to " + dst);
       return false;
     }
   }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -53,8 +53,8 @@ public class S3UnderFileSystem extends UnderFileSystem {
   public S3UnderFileSystem(String bucketName, TachyonConf tachyonConf) {
     super(tachyonConf);
     AWSCredentials awsCredentials =
-        new AWSCredentials(tachyonConf.get("fs.s3n.awsAccessKeyId", null), tachyonConf.get(
-            "fs.s3n.awsSecretAccessKey", null));
+        new AWSCredentials(tachyonConf.get(Constants.S3_ACCESS_KEY, null), tachyonConf.get(
+            Constants.S3_SECRET_KEY, null));
     mBucketName = bucketName;
     mClient = new RestS3Service(awsCredentials);
   }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -76,7 +76,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
 
   @Override
   public OutputStream create(String path) throws IOException {
-    return new S3OutputStream(path);
+    return new S3OutputStream(mBucketName, path, mClient);
   }
 
   // Same as create(path)

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -107,7 +107,6 @@ public class S3UnderFileSystem extends UnderFileSystem {
       String toDelete = path + pathToDelete;
       // If we fail to deleteInternal one file, stop
       if (!deleteInternal(path + pathToDelete)) {
-        System.out.println("Failed to delete: " + toDelete);
         return false;
       }
     }
@@ -251,7 +250,6 @@ public class S3UnderFileSystem extends UnderFileSystem {
       if (!isFolder(src)) {
         // Source is a file
         // Copy to destination
-        System.out.println("SRC is a file");
         if (copy(src, CommonUtils.concatPath(dst, srcName))) {
           // Delete original
           return deleteInternal(src);
@@ -294,7 +292,6 @@ public class S3UnderFileSystem extends UnderFileSystem {
       return delete(src, true);
     }
     // Source is a file and Destination does not exist
-    System.out.println("Dest does not exist and source is a file");
     return copy(src, dst) && deleteInternal(src);
   }
 
@@ -408,7 +405,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
     try {
       String keyAsFolder = convertToFolderName(key).substring(SCHEME.length()
           + mBucketName.length() + 1);
-      StorageObject details = mClient.getObjectDetails(mBucketName, keyAsFolder);
+      mClient.getObjectDetails(mBucketName, keyAsFolder);
       // If no exception is thrown, the key exists as a folder
       return true;
     } catch (ServiceException se) {

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.underfs.s3;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+import tachyon.conf.TachyonConf;
+import tachyon.underfs.UnderFileSystem;
+
+public class S3UnderFileSystem extends UnderFileSystem {
+
+  public S3UnderFileSystem(TachyonConf tachyonConf) {
+    super(tachyonConf);
+  }
+
+  @Override
+  public void close() throws IOException {
+
+  }
+
+  @Override
+  public void connectFromMaster(TachyonConf conf, String hostname) {
+
+  }
+
+  @Override
+  public void connectFromWorker(TachyonConf conf, String hostname) {
+
+  }
+
+  @Override
+  public OutputStream create(String path) throws IOException {
+    return null;
+  }
+
+  @Override
+  public OutputStream create(String path, int blockSizeByte) throws IOException {
+    return null;
+  }
+
+  @Override
+  public OutputStream create(String path, short replication, int blockSizeByte)
+      throws IOException {
+    return null;
+  }
+
+  @Override
+  public boolean delete(String path, boolean recursive) throws IOException {
+    return false;
+  }
+
+  @Override
+  public boolean exists(String path) throws IOException {
+    return false;
+  }
+
+  @Override
+  public long getBlockSizeByte(String path) throws IOException {
+    return -1L;
+  }
+
+  @Override
+  public Object getConf() {
+    return null;
+  }
+
+  @Override
+  public List<String> getFileLocations(String path) throws IOException {
+    return null;
+  }
+
+  @Override
+  public List<String> getFileLocations(String path, long offset) throws IOException {
+    return null;
+  }
+
+  @Override
+  public long getFileSize(String path) throws IOException {
+    return -1L;
+  }
+
+  @Override
+  public long getModificationTimeMs(String path) throws IOException {
+    return -1L;
+  }
+
+  @Override
+  public long getSpace(String path, SpaceType type) throws IOException {
+    return -1L;
+  }
+
+  @Override
+  public boolean isFile(String path) throws IOException {
+    return false;
+  }
+
+  @Override
+  public String[] list(String path) throws IOException {
+    return null;
+  }
+
+  @Override
+  public boolean mkdirs(String path, boolean createParent) throws IOException {
+    return false;
+  }
+
+  @Override
+  public InputStream open(String path) throws IOException {
+    return null;
+  }
+
+  @Override
+  public boolean rename(String src, String dst) throws IOException {
+    return false;
+  }
+
+  @Override
+  public void setConf(Object conf) {
+
+  }
+
+  public void setPermission(String path, String posixPerm) throws IOException {
+
+  }
+
+}

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -180,6 +180,12 @@ public class S3UnderFileSystem extends UnderFileSystem {
   @Override
   public String[] list(String path) throws IOException {
     // Non recursive list
+    if (!isFolder(path)) {
+      return null;
+    }
+    System.out.println("List with : " + path);
+    path = path.endsWith(PATH_SEPARATOR) ? path : path + PATH_SEPARATOR;
+    System.out.println("List after : " + path);
     return listInternal(path, false);
   }
 
@@ -387,6 +393,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
    * @throws IOException
    */
   private boolean isFolder(String key) {
+    key = key.endsWith(PATH_SEPARATOR) ? key.substring(0, key.length() - 1) : key;
     // Root is always a folder
     if (isRoot(key)) {
       return true;

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -20,18 +20,27 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 
 public class S3UnderFileSystem extends UnderFileSystem {
 
+  private final AmazonS3 mS3Client;
+
   public S3UnderFileSystem(TachyonConf tachyonConf) {
     super(tachyonConf);
+    BasicAWSCredentials credentials =
+        new BasicAWSCredentials(tachyonConf.get("fs.s3n.awsAccessKeyId", null),
+        tachyonConf.get("fs.s3n.awsSecretAccessKey", null));
+    mS3Client = new AmazonS3Client(credentials);
   }
 
   @Override
   public void close() throws IOException {
-
   }
 
   @Override

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -84,6 +84,8 @@ public class S3UnderFileSystem extends UnderFileSystem {
   // Same as create(path)
   @Override
   public OutputStream create(String path, int blockSizeByte) throws IOException {
+    LOG.warn("Create with block size is not supported with S3UnderFileSystem. Block size will be "
+        + "ignored.");
     return create(path);
   }
 
@@ -91,6 +93,8 @@ public class S3UnderFileSystem extends UnderFileSystem {
   @Override
   public OutputStream create(String path, short replication, int blockSizeByte)
       throws IOException {
+    LOG.warn("Create with block size and replication is not supported with S3UnderFileSystem."
+        + " Block size and replication will be ignored.");
     return create(path);
   }
 
@@ -107,11 +111,11 @@ public class S3UnderFileSystem extends UnderFileSystem {
     for (String pathToDelete : pathsToDelete) {
       // If we fail to deleteInternal one file, stop
       if (!deleteInternal(CommonUtils.concatPath(path, pathToDelete))) {
+        LOG.error("Failed to delete path " + pathToDelete + ", aborting delete.");
         return false;
       }
     }
-    deleteInternal(path);
-    return true;
+    return deleteInternal(path);
   }
 
   @Override
@@ -129,18 +133,21 @@ public class S3UnderFileSystem extends UnderFileSystem {
   // Not supported
   @Override
   public Object getConf() {
+    LOG.warn("getConf is not supported when using S3UnderFileSystem, returning null.");
     return null;
   }
 
   // Not supported
   @Override
   public List<String> getFileLocations(String path) throws IOException {
+    LOG.warn("getFileLocations is not supported when using S3UnderFileSystem, returning null.");
     return null;
   }
 
   // Not supported
   @Override
   public List<String> getFileLocations(String path, long offset) throws IOException {
+    LOG.warn("getFileLocations is not supported when using S3UnderFileSystem, returning null.");
     return null;
   }
 

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -29,6 +29,10 @@ import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.underfs.UnderFileSystemFactory;
 
+/**
+ * This class is a factory for S3UnderFileSystem clients. It will ensure AWS credentials are
+ * present before returning a client. The validity of the credentials are checked by the client.
+ */
 public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import tachyon.Constants;
+import tachyon.TachyonURI;
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.underfs.UnderFileSystemFactory;
@@ -36,7 +37,8 @@ public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
     Preconditions.checkArgument(path != null, "path may not be null");
 
     if (addAndCheckAWSCredentials(tachyonConf)) {
-      return new S3UnderFileSystem(tachyonConf);
+      TachyonURI uri = new TachyonURI(path);
+      return new S3UnderFileSystem(uri.getHost(), tachyonConf);
     } else {
       String err = "AWS Credentials not available, cannot create S3 Under File System.";
       LOG.error(err);

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -48,7 +48,7 @@ public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
 
   @Override
   public boolean supportsPath(String path, TachyonConf tachyonConf) {
-    return path != null && path.startsWith("s3n://");
+    return path != null && path.startsWith(Constants.HEADER_S3N);
   }
 
   private boolean addAndCheckAWSCredentials(TachyonConf tachyonConf) {

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -33,8 +33,9 @@ public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   @Override
-  public UnderFileSystem create(String path, TachyonConf tachyonConf, Object conf) {
-    Preconditions.checkArgument(path != null, "path may not be null");
+  public UnderFileSystem create(String path, TachyonConf tachyonConf, Object unusedConf) {
+    Preconditions.checkNotNull(path);
+    Preconditions.checkNotNull(tachyonConf);
 
     if (addAndCheckAWSCredentials(tachyonConf)) {
       TachyonURI uri = new TachyonURI(path);

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -1,0 +1,5 @@
+package tachyon.underfs.s3;
+
+public class S3UnderFileSystemFactory {
+  
+}

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -52,11 +52,11 @@ public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
   }
 
   private boolean addAndCheckAWSCredentials(TachyonConf tachyonConf) {
-    String accessKeyConf = "fs.s3n.awsAccessKeyId";
+    String accessKeyConf = Constants.S3_ACCESS_KEY;
     if (System.getProperty(accessKeyConf) != null && tachyonConf.get(accessKeyConf, null) == null) {
       tachyonConf.set(accessKeyConf, System.getProperty(accessKeyConf));
     }
-    String secretKeyConf = "fs.s3n.awsSecretAccessKey";
+    String secretKeyConf = Constants.S3_SECRET_KEY;
     if (System.getProperty(secretKeyConf) != null && tachyonConf.get(secretKeyConf, null) == null) {
       tachyonConf.set(secretKeyConf, System.getProperty(secretKeyConf));
     }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -48,7 +48,7 @@ public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
 
   @Override
   public boolean supportsPath(String path, TachyonConf tachyonConf) {
-    return path != null && (path.startsWith("s3://") || path.startsWith("s3n://"));
+    return path != null && path.startsWith("s3n://");
   }
 
   private boolean addAndCheckAWSCredentials(TachyonConf tachyonConf) {

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -1,5 +1,41 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package tachyon.underfs.s3;
 
-public class S3UnderFileSystemFactory {
-  
+import com.google.common.base.Preconditions;
+
+import tachyon.conf.TachyonConf;
+import tachyon.underfs.UnderFileSystem;
+import tachyon.underfs.UnderFileSystemFactory;
+
+public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
+
+  @Override
+  public UnderFileSystem create(String path, TachyonConf tachyonConf, Object conf) {
+    Preconditions.checkArgument(path != null, "path may not be null");
+
+    return new S3UnderFileSystem(tachyonConf);
+  }
+
+  @Override
+  public boolean supportsPath(String path, TachyonConf conf) {
+    if (path == null) {
+      return false;
+    }
+
+    return path.startsWith("s3://") || path.startsWith("s3n://");
+  }
 }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -15,6 +15,8 @@
 
 package tachyon.underfs.s3;
 
+import java.io.IOException;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 
@@ -25,8 +27,6 @@ import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.underfs.UnderFileSystemFactory;
-
-import java.io.IOException;
 
 public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);

--- a/underfs/s3/src/main/resources/META-INF/services/tachyon.underfs.UnderFileSystemFactory
+++ b/underfs/s3/src/main/resources/META-INF/services/tachyon.underfs.UnderFileSystemFactory
@@ -1,0 +1,1 @@
+tachyon.underfs.s3.S3UnderFileSystemFactory

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderFileSystemTest.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderFileSystemTest.java
@@ -22,6 +22,9 @@ import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystemFactory;
 import tachyon.underfs.UnderFileSystemRegistry;
 
+/**
+ * This test ensures the s3 ufs module correctly accepts paths that begin with s3n://
+ */
 public class S3UnderFileSystemTest {
   @Test
   public void factoryTest() {

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderFileSystemTest.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderFileSystemTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.underfs.s3;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import tachyon.conf.TachyonConf;
+import tachyon.underfs.UnderFileSystemFactory;
+import tachyon.underfs.UnderFileSystemRegistry;
+
+public class S3UnderFileSystemTest {
+  @Test
+  public void factoryTest() {
+    TachyonConf conf = new TachyonConf();
+
+    UnderFileSystemFactory factory =
+        UnderFileSystemRegistry.find("s3n://localhost/test/path", conf);
+    Assert.assertNotNull(
+        "A UnderFileSystemFactory should exist for s3n paths when using this module", factory);
+  }
+}

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -18,6 +18,7 @@ package tachyon.underfs.s3;
 import java.io.IOException;
 import java.util.UUID;
 
+import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.underfs.UnderFileSystemCluster;
@@ -34,8 +35,8 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
 
   public S3UnderStorageCluster(String baseDir, TachyonConf tachyonConf) {
     super(baseDir, tachyonConf);
-    System.setProperty("fs.s3n.awsAccessKeyId", awsAccessKey);
-    System.setProperty("fs.s3n.awsSecretAccessKey", awsSecretKey);
+    System.setProperty(Constants.S3_ACCESS_KEY, awsAccessKey);
+    System.setProperty(Constants.S3_SECRET_KEY, awsSecretKey);
     mBaseDir = baseDirectory + UUID.randomUUID();
   }
 

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -18,6 +18,7 @@ package tachyon.underfs.s3;
 import java.io.IOException;
 
 import tachyon.conf.TachyonConf;
+import tachyon.underfs.UnderFileSystem;
 import tachyon.underfs.UnderFileSystemCluster;
 
 /**
@@ -25,8 +26,13 @@ import tachyon.underfs.UnderFileSystemCluster;
  */
 public class S3UnderStorageCluster extends UnderFileSystemCluster {
 
+  private final String awsAccessKey = "";
+  private final String awsSecretKey = "";
+
   public S3UnderStorageCluster(String baseDir, TachyonConf tachyonConf) {
     super(baseDir, tachyonConf);
+    System.setProperty("fs.s3n.awsAccessKeyId", awsAccessKey);
+    System.setProperty("fs.s3n.awsSecretAccessKey", awsSecretKey);
     mBaseDir = "s3n://calvin-s3-test/testdir";
   }
 
@@ -41,7 +47,10 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
   }
 
   @Override
-  public void shutdown() throws IOException {}
+  public void shutdown() throws IOException {
+    UnderFileSystem ufs = UnderFileSystem.get(mBaseDir, mTachyonConf);
+    ufs.delete(mBaseDir, true);
+  }
 
   @Override
   public void start() throws IOException {}

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -33,7 +33,15 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
     super(baseDir, tachyonConf);
     System.setProperty("fs.s3n.awsAccessKeyId", awsAccessKey);
     System.setProperty("fs.s3n.awsSecretAccessKey", awsSecretKey);
-    mBaseDir = "s3n://calvin-s3-test/testdir";
+    mBaseDir = "s3n://calvin-s3-test/testdir" + Math.random() * 100;
+  }
+
+  @Override
+  public void cleanup() throws IOException {
+    String oldDir = mBaseDir;
+    mBaseDir = "s3n://calvin-s3-test/testdir" + Math.random() * 100;
+    UnderFileSystem ufs = UnderFileSystem.get(mBaseDir, mTachyonConf);
+    ufs.delete(oldDir, true);
   }
 
   @Override
@@ -48,8 +56,6 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
 
   @Override
   public void shutdown() throws IOException {
-    UnderFileSystem ufs = UnderFileSystem.get(mBaseDir, mTachyonConf);
-    ufs.delete(mBaseDir, true);
   }
 
   @Override

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -16,30 +16,33 @@
 package tachyon.underfs.s3;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.underfs.UnderFileSystemCluster;
 
 /**
- * This class will use Amazon S3 as the backing store.
+ * This class will use Amazon S3 as the backing store. Update awsAccessKey, awsSecretKey, and
+ * baseDirectory accordingly to enable this test.
  */
 public class S3UnderStorageCluster extends UnderFileSystemCluster {
 
   private final String awsAccessKey = "";
   private final String awsSecretKey = "";
+  private final String baseDirectory = ""; // s3n://my-test-bucket/tachyon-test
 
   public S3UnderStorageCluster(String baseDir, TachyonConf tachyonConf) {
     super(baseDir, tachyonConf);
     System.setProperty("fs.s3n.awsAccessKeyId", awsAccessKey);
     System.setProperty("fs.s3n.awsSecretAccessKey", awsSecretKey);
-    mBaseDir = "s3n://calvin-s3-test/testdir" + Math.random() * 100;
+    mBaseDir = baseDirectory + UUID.randomUUID();
   }
 
   @Override
   public void cleanup() throws IOException {
     String oldDir = mBaseDir;
-    mBaseDir = "s3n://calvin-s3-test/testdir" + Math.random() * 100;
+    mBaseDir = baseDirectory + UUID.randomUUID();
     UnderFileSystem ufs = UnderFileSystem.get(mBaseDir, mTachyonConf);
     ufs.delete(oldDir, true);
   }

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -24,8 +24,11 @@ import tachyon.underfs.UnderFileSystem;
 import tachyon.underfs.UnderFileSystemCluster;
 
 /**
- * This class will use Amazon S3 as the backing store. Update awsAccessKey, awsSecretKey, and
- * baseDirectory accordingly to enable this test.
+ * This class will use Amazon S3 as the backing store. The integration properties should be
+ * specified in the module's pom file. Each instance of the cluster will run with a separate base
+ * directory (user prefix + uuid). Each test will attempt to clean up their test directories, but
+ * in cases of complete failure (ie. jvm crashed) the directory will need to be cleaned up through
+ * manual means.
  */
 public class S3UnderStorageCluster extends UnderFileSystemCluster {
 

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -29,21 +29,26 @@ import tachyon.underfs.UnderFileSystemCluster;
  */
 public class S3UnderStorageCluster extends UnderFileSystemCluster {
 
-  private final String awsAccessKey = "";
-  private final String awsSecretKey = "";
-  private final String baseDirectory = ""; // s3n://my-test-bucket/tachyon-test
+  private final static String INTEGRATION_S3_ACCESS_KEY = "accessKey";
+  private final static String INTEGRATION_S3_SECRET_KEY = "secretKey";
+  private final static String INTEGRATION_S3_BUCKET = "s3Bucket";
+
+  private String mS3Bucket;
 
   public S3UnderStorageCluster(String baseDir, TachyonConf tachyonConf) {
     super(baseDir, tachyonConf);
+    String awsAccessKey = System.getProperty(INTEGRATION_S3_ACCESS_KEY);
+    String awsSecretKey = System.getProperty(INTEGRATION_S3_SECRET_KEY);
     System.setProperty(Constants.S3_ACCESS_KEY, awsAccessKey);
     System.setProperty(Constants.S3_SECRET_KEY, awsSecretKey);
-    mBaseDir = baseDirectory + UUID.randomUUID();
+    mS3Bucket = System.getProperty(INTEGRATION_S3_BUCKET);
+    mBaseDir = mS3Bucket + UUID.randomUUID();
   }
 
   @Override
   public void cleanup() throws IOException {
     String oldDir = mBaseDir;
-    mBaseDir = baseDirectory + UUID.randomUUID();
+    mBaseDir = mS3Bucket + UUID.randomUUID();
     UnderFileSystem ufs = UnderFileSystem.get(mBaseDir, mTachyonConf);
     ufs.delete(oldDir, true);
   }

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -55,8 +55,7 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
   }
 
   @Override
-  public void shutdown() throws IOException {
-  }
+  public void shutdown() throws IOException {}
 
   @Override
   public void start() throws IOException {}

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.underfs.s3;
+
+import java.io.IOException;
+
+import tachyon.conf.TachyonConf;
+import tachyon.underfs.UnderFileSystemCluster;
+
+/**
+ * This class will use Amazon S3 as the backing store.
+ */
+public class S3UnderStorageCluster extends UnderFileSystemCluster {
+
+  public S3UnderStorageCluster(String baseDir, TachyonConf tachyonConf) {
+    super(baseDir, tachyonConf);
+    mBaseDir = "s3n://calvin-s3-test/testdir";
+  }
+
+  @Override
+  public String getUnderFilesystemAddress() {
+    return mBaseDir;
+  }
+
+  @Override
+  public boolean isStarted() {
+    return true;
+  }
+
+  @Override
+  public void shutdown() throws IOException {}
+
+  @Override
+  public void start() throws IOException {}
+}

--- a/underfs/s3/src/test/resources/log4j.properties
+++ b/underfs/s3/src/test/resources/log4j.properties
@@ -1,0 +1,17 @@
+tachyon.root.logger=INFO, TEST_LOGGER
+tachyon.log.dir=.
+tachyon.log.file=logs/tests.log
+
+log4j.rootLogger=${tachyon.root.logger}
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+
+#Test Logger
+log4j.appender.TEST_LOGGER=org.apache.log4j.RollingFileAppender
+log4j.appender.TEST_LOGGER.File=${tachyon.log.dir}/${tachyon.log.file}
+log4j.appender.TEST_LOGGER.MaxFileSize=10MB
+log4j.appender.TEST_LOGGER.MaxBackupIndex=100
+log4j.appender.TEST_LOGGER.layout=org.apache.log4j.PatternLayout
+log4j.appender.TEST_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n


### PR DESCRIPTION
Rebased version of #891 

https://tachyon.atlassian.net/projects/TACHYON/issues/TACHYON-424

This PR implements an S3 Client using the jets3t library.

A new s3 submodule under /underfs contains the logic for the client. The user may enable this client as their s3 client by removing the s3n:// prefix from the hadoop prefixes in their configuration.

The implementation conforms to our UnderFileSystem interface and unit tests. It also passes all applicable core tests when using the S3UnderFileSystemCluster. Since the S3UnderFileSystem is implemented as a real S3 backend, the tests are disabled by default.