### PR TITLE
TACHYON-427 : Running Spark on Tachyon Documentation need correction

### DIFF
--- a/docs/Running-Spark-on-Tachyon.md
+++ b/docs/Running-Spark-on-Tachyon.md
@@ -55,7 +55,7 @@ additionally add new entry in previously created `spark/conf/core-site.xml`:
 
     <property>
         <name>fs.tachyon-ft.impl</name>
-        <value>tachyon.hadoop.TFS</value>
+        <value>tachyon.hadoop.TFSFT</value>
     </property>
 
 Add the following line to `spark/conf/spark-env.sh`:


### PR DESCRIPTION
Documentation for configuring Spark with Tachyon FT mode shows wrong value for fs.tachyon-ft.impl

<property>
<name>fs.tachyon-ft.impl</name>
<value>tachyon.hadoop.TFS</value>
</property>


It should be ..

<property>
<name>fs.tachyon-ft.impl</name>
<value>tachyon.hadoop.TFSFT</value>
</property>