### PR TITLE
[TACHYON-397] Add deprecated method for 0.6.x's TachyonFS.get(TachyonURI).

### DIFF
--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -64,7 +64,7 @@ public class TachyonFS extends AbstractTachyonFS {
    *
    * @param tachyonPath a Tachyon path contains master address. e.g., tachyon://localhost:19998,
    *        tachyon://localhost:19998/ab/c.txt
-   * @return the corresponding TachyonFS hanlder
+   * @return the corresponding TachyonFS handler
    * @throws IOException
    * @see #get(tachyon.TachyonURI, tachyon.conf.TachyonConf)
    */
@@ -76,9 +76,9 @@ public class TachyonFS extends AbstractTachyonFS {
   /**
    * Create a TachyonFS handler.
    *
-   * @param tachyonURI a Tachyon path contains master address. e.g., tachyon://localhost:19998,
+   * @param tachyonURI a Tachyon URI to indicate master address. e.g., tachyon://localhost:19998,
    *        tachyon://localhost:19998/ab/c.txt
-   * @return the corresponding TachyonFS hanlder
+   * @return the corresponding TachyonFS handler
    * @throws IOException
    * @see #get(tachyon.TachyonURI, tachyon.conf.TachyonConf)
    */

--- a/core/src/main/java/tachyon/client/TachyonFS.java
+++ b/core/src/main/java/tachyon/client/TachyonFS.java
@@ -76,6 +76,20 @@ public class TachyonFS extends AbstractTachyonFS {
   /**
    * Create a TachyonFS handler.
    *
+   * @param tachyonURI a Tachyon path contains master address. e.g., tachyon://localhost:19998,
+   *        tachyon://localhost:19998/ab/c.txt
+   * @return the corresponding TachyonFS hanlder
+   * @throws IOException
+   * @see #get(tachyon.TachyonURI, tachyon.conf.TachyonConf)
+   */
+  @Deprecated
+  public static synchronized TachyonFS get(final TachyonURI tachyonURI) throws IOException {
+    return get(tachyonURI, new TachyonConf());
+  }
+
+  /**
+   * Create a TachyonFS handler.
+   *
    * @param tachyonURI a Tachyon URI to indicate master address. e.g., tachyon://localhost:19998,
    *        tachyon://localhost:19998/ab/c.txt
    * @param tachyonConf The TachyonConf instance.


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-397

We should support backward compatibility for at least 1 version. For example, spark recently updated to use the TachyonURI API instead of the String API, which makes it incompatible with master branch without this addition.