### PR TITLE
[TACHYON-438] Clean up poms

### DIFF
--- a/underfs/glusterfs/pom.xml
+++ b/underfs/glusterfs/pom.xml
@@ -29,12 +29,5 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon</artifactId>
-      <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/underfs/hdfs/pom.xml
+++ b/underfs/hdfs/pom.xml
@@ -18,20 +18,12 @@
 
   <dependencies>
     <dependency>
-      <!-- NOTE: dependency of hadoop-minicluster needs to be put before
-           hadoop-client to bring up a transitive dependency of
-           org.mortbay.jetty via hadoop-core. Otherwise hadoop-core brought up
-           by hadoop-client excludes it. -->
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-minicluster</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon</artifactId>
+      <artifactId>tachyon-common</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -39,28 +31,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon</artifactId>
-      <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/underfs/hdfs/src/test/resources/test_metrics.properties
+++ b/underfs/hdfs/src/test/resources/test_metrics.properties
@@ -1,6 +1,0 @@
-*.sink.console.class=tachyon.metrics.sink.ConsoleSink
-*.sink.console.period=15
-*.source.jvm.class=tachyon.metrics.source.JvmSource
-master.sink.console.period=20
-master.sink.console.unit=minutes
-master.sink.jmx.class=tachyon.metrics.sink.JmxSink

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -19,7 +19,7 @@
   <dependencies>
     <dependency>
       <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon</artifactId>
+      <artifactId>tachyon-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -30,25 +30,8 @@
 
     <!-- Test Dependencies -->
     <dependency>
-      <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon</artifactId>
-      <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.curator</groupId>
-      <artifactId>curator-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://tachyon.atlassian.net/projects/TACHYON/issues/TACHYON-438

Cleans up poms for the underfs modules since they should no longer need to pull in test classes from the core (these are in integration-tests now).