### PR TITLE
[TACHYON-415] Make metrics system tests stable

### DIFF
--- a/core/src/main/java/tachyon/metrics/MetricsConfig.java
+++ b/core/src/main/java/tachyon/metrics/MetricsConfig.java
@@ -45,7 +45,16 @@ public final class MetricsConfig {
   public MetricsConfig(String configFile) {
     mConfigFile = configFile;
     mProperties = new Properties();
-    initialize();
+    setDefaultProperties();
+    loadConfigFile();
+    parseConfiguration();
+  }
+
+  public MetricsConfig(Properties properties) {
+    mProperties = new Properties();
+    setDefaultProperties();
+    mProperties.putAll(properties);
+    parseConfiguration();
   }
 
   private void addDefaultProperties(Properties prop, Properties defaultProp) {
@@ -84,14 +93,9 @@ public final class MetricsConfig {
   }
 
   /**
-   * Loads and parses the metrics configuration file.
+   * Loads the metrics configuration file.
    */
-  private void initialize() {
-    // Set the default properties. The MetricsServlet is enabled and the path is /metrics/json
-    // by default.
-    mProperties.setProperty("*.sink.servlet.class", "tachyon.metrics.sink.MetricsServlet");
-    mProperties.setProperty("*.sink.servlet.path", "/metrics/json");
-
+  private void loadConfigFile() {
     InputStream is = null;
     try {
       if (mConfigFile != null) {
@@ -113,8 +117,12 @@ public final class MetricsConfig {
         }
       }
     }
+  }
 
-    // Parses the configuration and maps the instance name to its properties.
+  /**
+   * Parses the configuration and maps the instance name to its properties.
+   */
+  private void parseConfiguration() {
     mPropertyCategories = subProperties(mProperties, INSTANCE_REGEX);
     if (mPropertyCategories.containsKey(DEFAULT_PREFIX)) {
       Properties defaultProperties = mPropertyCategories.get(DEFAULT_PREFIX);
@@ -124,6 +132,15 @@ public final class MetricsConfig {
         }
       }
     }
+  }
+
+  /**
+   * Set the default properties. The MetricsServlet is enabled and the path is /metrics/json
+   * by default.
+   */
+  private void setDefaultProperties() {
+    mProperties.setProperty("*.sink.servlet.class", "tachyon.metrics.sink.MetricsServlet");
+    mProperties.setProperty("*.sink.servlet.path", "/metrics/json");
   }
 
   /**

--- a/core/src/main/java/tachyon/metrics/MetricsSystem.java
+++ b/core/src/main/java/tachyon/metrics/MetricsSystem.java
@@ -85,6 +85,19 @@ public class MetricsSystem {
     mMetricsConfig = new MetricsConfig(mTachyonConf.get(Constants.METRICS_CONF_FILE, null));
   }
 
+  /**
+   * Creates a MetricsSystem.
+   *
+   * @param instance the instance name.
+   * @param metricsConfig the MetricsConfig object.
+   * @param tachyonConf the {@link TachyonConf} instance for configuration properties.
+   */
+  public MetricsSystem(String instance, MetricsConfig metricsConfig, TachyonConf tachyonConf) {
+    mInstance = instance;
+    mMetricsConfig = metricsConfig;
+    mTachyonConf = tachyonConf;
+  }
+
   /***
    * Get the ServletContextHandler of the metrics servlet.
    *

--- a/core/src/test/java/tachyon/metrics/MetricsConfigTest.java
+++ b/core/src/test/java/tachyon/metrics/MetricsConfigTest.java
@@ -23,16 +23,22 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class MetricsConfigTest {
-  private String mFilePath;
+  private Properties mMetricsProps;
 
   @Before
   public final void Before() {
-    mFilePath = getClass().getClassLoader().getResource("test_metrics.properties").getFile();
+    mMetricsProps = new Properties();
+    mMetricsProps.setProperty("*.sink.console.class", "tachyon.metrics.sink.ConsoleSink");
+    mMetricsProps.setProperty("*.sink.console.period", "15");
+    mMetricsProps.setProperty("*.source.jvm.class", "tachyon.metrics.source.JvmSource");
+    mMetricsProps.setProperty("master.sink.console.period", "20");
+    mMetricsProps.setProperty("master.sink.console.unit", "minutes");
+    mMetricsProps.setProperty("master.sink.jmx.class", "tachyon.metrics.sink.JmxSink");
   }
 
   @Test
   public void setPropertiesTest() {
-    MetricsConfig config = new MetricsConfig(mFilePath);
+    MetricsConfig config = new MetricsConfig(mMetricsProps);
 
     Properties masterProp = config.getInstanceProperties("master");
     Assert.assertEquals(7, masterProp.size());
@@ -61,7 +67,7 @@ public class MetricsConfigTest {
 
   @Test
   public void subPropertiesTest() {
-    MetricsConfig config = new MetricsConfig(mFilePath);
+    MetricsConfig config = new MetricsConfig(mMetricsProps);
 
     Map<String, Properties> propertyCategories = config.getPropertyCategories();
     Assert.assertEquals(2, propertyCategories.size());

--- a/core/src/test/java/tachyon/metrics/MetricsSystemTest.java
+++ b/core/src/test/java/tachyon/metrics/MetricsSystemTest.java
@@ -15,29 +15,36 @@
 
 package tachyon.metrics;
 
+import java.util.Properties;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.master.MasterSource;
 import tachyon.worker.WorkerSource;
 
 public class MetricsSystemTest {
-  private String mFilePath;
+  private MetricsConfig mMetricsConfig;
   private TachyonConf mTachyonConf;
 
   @Before
   public final void Before() {
-    mFilePath = getClass().getClassLoader().getResource("test_metrics.properties").getFile();
     mTachyonConf = new TachyonConf();
-    mTachyonConf.set(Constants.METRICS_CONF_FILE, mFilePath);
+    Properties metricsProps = new Properties();
+    metricsProps.setProperty("*.sink.console.class", "tachyon.metrics.sink.ConsoleSink");
+    metricsProps.setProperty("*.sink.console.period", "15");
+    metricsProps.setProperty("*.source.jvm.class", "tachyon.metrics.source.JvmSource");
+    metricsProps.setProperty("master.sink.console.period", "20");
+    metricsProps.setProperty("master.sink.console.unit", "minutes");
+    metricsProps.setProperty("master.sink.jmx.class", "tachyon.metrics.sink.JmxSink");
+    mMetricsConfig = new MetricsConfig(metricsProps);
   }
 
   @Test
   public void metricsSystemTest() {
-    MetricsSystem masterMetricsSystem = new MetricsSystem("master", mTachyonConf);
+    MetricsSystem masterMetricsSystem = new MetricsSystem("master", mMetricsConfig, mTachyonConf);
     masterMetricsSystem.start();
 
     Assert.assertNotNull(masterMetricsSystem.getServletHandler());
@@ -47,7 +54,7 @@ public class MetricsSystemTest {
     Assert.assertEquals(2, masterMetricsSystem.getSources().size());
     masterMetricsSystem.stop();
 
-    MetricsSystem workerMetricsSystem = new MetricsSystem("worker", mTachyonConf);
+    MetricsSystem workerMetricsSystem = new MetricsSystem("worker", mMetricsConfig, mTachyonConf);
     workerMetricsSystem.start();
 
     Assert.assertNotNull(workerMetricsSystem.getServletHandler());

--- a/core/src/test/resources/test_metrics.properties
+++ b/core/src/test/resources/test_metrics.properties
@@ -1,6 +1,0 @@
-*.sink.console.class=tachyon.metrics.sink.ConsoleSink
-*.sink.console.period=15
-*.source.jvm.class=tachyon.metrics.source.JvmSource
-master.sink.console.period=20
-master.sink.console.unit=minutes
-master.sink.jmx.class=tachyon.metrics.sink.JmxSink


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-415
The metrics system tests are not stable because the test_metrics.properties file fails to be loaded randomly. 
This PR removes the file and set the properites in code. 