### PR TITLE
[TACHYON-445] Faster Data Server shutdown in unit tests

### DIFF
--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -164,6 +164,10 @@ public class Constants {
   public static final String WORKER_NETTY_SEND_BUFFER = "tachyon.worker.network.netty.buffer.send";
   public static final String WORKER_NETTY_RECEIVE_BUFFER =
       "tachyon.worker.network.netty.buffer.receive";
+  public static final String WORKER_NETTY_SHUTDOWN_QUIET_PERIOD =
+      "tachyon.worker.network.netty.shutdown.quiet.period";
+  public static final String WORKER_NETTY_SHUTDOWN_TIMEOUT =
+      "tachyon.worker.network.netty.shutdown.timeout";
   public static final String WORKER_EVICT_STRATEGY_TYPE = "tachyon.worker.evict.strategy";
   public static final String WORKER_ALLOCATE_STRATEGY_TYPE = "tachyon.worker.allocate.strategy";
   public static final String WORKER_MAX_TIERED_STORAGE_LEVEL =

--- a/core/src/main/java/tachyon/worker/netty/NettyDataServer.java
+++ b/core/src/main/java/tachyon/worker/netty/NettyDataServer.java
@@ -55,8 +55,8 @@ public final class NettyDataServer implements DataServer {
 
   @Override
   public void close() throws IOException {
-    int quietPeriodSecs = mTachyonConf.getInt("tachyon.worker.netty.quiet.period", 2);
-    int timeoutSecs = mTachyonConf.getInt("tachyon.worker.netty.timeout", 15);
+    int quietPeriodSecs = mTachyonConf.getInt(Constants.WORKER_NETTY_SHUTDOWN_QUIET_PERIOD, 2);
+    int timeoutSecs = mTachyonConf.getInt(Constants.WORKER_NETTY_SHUTDOWN_TIMEOUT, 15);
     mChannelFuture.channel().close().awaitUninterruptibly();
     mBootstrap.group().shutdownGracefully(quietPeriodSecs, timeoutSecs, TimeUnit.SECONDS);
     mBootstrap.childGroup().shutdownGracefully(quietPeriodSecs, timeoutSecs, TimeUnit.SECONDS);

--- a/core/src/main/java/tachyon/worker/netty/NettyDataServer.java
+++ b/core/src/main/java/tachyon/worker/netty/NettyDataServer.java
@@ -17,6 +17,7 @@ package tachyon.worker.netty;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -54,9 +55,11 @@ public final class NettyDataServer implements DataServer {
 
   @Override
   public void close() throws IOException {
+    int quietPeriodSecs = mTachyonConf.getInt("tachyon.netty.quiet.period", 2);
+    int timeoutSecs = mTachyonConf.getInt("tachyon.netty.timeout", 15);
     mChannelFuture.channel().close().awaitUninterruptibly();
-    mBootstrap.group().shutdownGracefully();
-    mBootstrap.childGroup().shutdownGracefully();
+    mBootstrap.group().shutdownGracefully(quietPeriodSecs, timeoutSecs, TimeUnit.SECONDS);
+    mBootstrap.childGroup().shutdownGracefully(quietPeriodSecs, timeoutSecs, TimeUnit.SECONDS);
   }
 
   private ServerBootstrap createBootstrap() {

--- a/core/src/main/java/tachyon/worker/netty/NettyDataServer.java
+++ b/core/src/main/java/tachyon/worker/netty/NettyDataServer.java
@@ -55,8 +55,8 @@ public final class NettyDataServer implements DataServer {
 
   @Override
   public void close() throws IOException {
-    int quietPeriodSecs = mTachyonConf.getInt("tachyon.netty.quiet.period", 2);
-    int timeoutSecs = mTachyonConf.getInt("tachyon.netty.timeout", 15);
+    int quietPeriodSecs = mTachyonConf.getInt("tachyon.worker.netty.quiet.period", 2);
+    int timeoutSecs = mTachyonConf.getInt("tachyon.worker.netty.timeout", 15);
     mChannelFuture.channel().close().awaitUninterruptibly();
     mBootstrap.group().shutdownGracefully(quietPeriodSecs, timeoutSecs, TimeUnit.SECONDS);
     mBootstrap.childGroup().shutdownGracefully(quietPeriodSecs, timeoutSecs, TimeUnit.SECONDS);

--- a/integration-tests/src/test/java/tachyon/master/LocalTachyonCluster.java
+++ b/integration-tests/src/test/java/tachyon/master/LocalTachyonCluster.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -171,7 +171,7 @@ public final class LocalTachyonCluster {
     mMasterConf.set(Constants.USER_QUOTA_UNIT_BYTES, Integer.toString(mQuotaUnitBytes));
     mMasterConf.set(Constants.USER_DEFAULT_BLOCK_SIZE_BYTE, Integer.toString(mUserBlockSize));
     mMasterConf.set(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE, "64");
-    
+
     // Since tests are always running on a single host keep the resolution timeout low as otherwise people
     // running with strange network configurations will see very slow tests
     mMasterConf.set(Constants.HOST_RESOLUTION_TIMEOUT_MS, "250");
@@ -207,7 +207,9 @@ public final class LocalTachyonCluster {
     mWorkerConf.set(Constants.WORKER_MIN_WORKER_THREADS, Integer.toString(1));
     mWorkerConf.set(Constants.WORKER_MAX_WORKER_THREADS, Integer.toString(100));
     mWorkerConf.set(Constants.WORKER_NETTY_WORKER_THREADS, Integer.toString(2));
-    
+    mWorkerConf.set("tachyon.worker.netty.quiet.period", "0");
+    mWorkerConf.set("tachyon.worker.netty.timeout", "0");
+
     // Since tests are always running on a single host keep the resolution timeout low as otherwise people
     // running with strange network configurations will see very slow tests
     mWorkerConf.set(Constants.HOST_RESOLUTION_TIMEOUT_MS, "250");

--- a/integration-tests/src/test/java/tachyon/master/LocalTachyonCluster.java
+++ b/integration-tests/src/test/java/tachyon/master/LocalTachyonCluster.java
@@ -207,8 +207,10 @@ public final class LocalTachyonCluster {
     mWorkerConf.set(Constants.WORKER_MIN_WORKER_THREADS, Integer.toString(1));
     mWorkerConf.set(Constants.WORKER_MAX_WORKER_THREADS, Integer.toString(100));
     mWorkerConf.set(Constants.WORKER_NETTY_WORKER_THREADS, Integer.toString(2));
-    mWorkerConf.set("tachyon.worker.netty.quiet.period", "0");
-    mWorkerConf.set("tachyon.worker.netty.timeout", "0");
+
+    // Perform immediate shutdown of data server. Graceful shutdown is unnecessary and slow
+    mWorkerConf.set(Constants.WORKER_NETTY_SHUTDOWN_QUIET_PERIOD, Integer.toString(0));
+    mWorkerConf.set(Constants.WORKER_NETTY_SHUTDOWN_TIMEOUT, Integer.toString(0));
 
     // Since tests are always running on a single host keep the resolution timeout low as otherwise people
     // running with strange network configurations will see very slow tests


### PR DESCRIPTION
https://tachyon.atlassian.net/projects/TACHYON/issues/TACHYON-445

Total test run time goes down by ~50% on my local machine with this change. Two new internal (not documented to users) settings are added which control the nature of the netty data server shutdown. The default values are the same as if `shutdownGracefully` is called without parameters.