### PR TITLE
[TACHYON-467] Client may still use a small remote read buffer size

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -375,7 +375,7 @@ public class RemoteBlockInStream extends BlockInStream {
    */
   private boolean updateCurrentBuffer() throws IOException {
     long bufferSize =
-        mTachyonConf.getBytes(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE, Constants.MB);
+        mTachyonConf.getBytes(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE, 8 * Constants.MB);
     if (mCurrentBuffer != null && mBufferStartPos <= mBlockPos
         && mBlockPos < Math.min(mBufferStartPos + bufferSize, mBlockInfo.length)) {
       // We move the buffer to read at mBlockPos


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-467
tachyon.user.remote.read.buffer.size.byte is set to 8MB as a default value. This is set in the tachyon-default.properties. But in RemoteBlockInStream.java, it still uses 1MB as a default value if this property is not set. A client process without the tachyon-default.properties on the class path may still use 1MB as the remote read buffer size.