### PR TITLE
[TACHYON-368] master listening address configuration option

### DIFF
--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -121,6 +121,8 @@ public class Constants {
 
   public static final String MASTER_FORMAT_FILE_PREFIX = "tachyon.master.format.file_prefix";
   public static final String MASTER_HOSTNAME = "tachyon.master.hostname";
+  public static final String MASTER_HOSTNAME_LISTENING = "tachyon.master.hostname.listening";
+  public static final String MASTER_HOSTNAME_LISTENING_WILDCARD = "*";
   public static final String MASTER_JOURNAL_FOLDER = "tachyon.master.journal.folder";
   public static final String MASTER_PORT = "tachyon.master.port";
   public static final String MASTER_ADDRESS = "tachyon.master.address";

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -378,15 +378,15 @@ tachyon-site.properties file is not available in nodes where the MR is running.
 
 To support this, the MR application client needs to do these steps:
 
-1. Get the TachyonConf instance from call to TachyonConf.get().
+1. Get the TachyonConf instance by calling `TachyonConf.get()`.
 2. Store the encoded TachyonConf object into Hadoop MR job’s Configuration using `ConfUtils.storeToHadoopConfiguration` call.
 3. During initialization of the TFS, it will check if the key exists from the job’s Configuration
 and if it does it will merge the override properties to the current TachyonConf instance via `ConfUtil.loadFromHadoopConfiguration`.
 
 # System environment properties
 
-The system environment variables is configured using the configuration file, which responsible for
-setting system properties, is located under `conf/tachyon-env.sh`.
+The system environment variables are configured using the configuration file
+(located under `conf/tachyon-env.sh`), which is responsible for setting system properties.
 
 The location of the `tachyon-env.sh` can be set by environment variable `TACHYON_CONF_DIR`.
 
@@ -394,11 +394,11 @@ These variables should be set as variables under the `TACHYON_JAVA_OPTS` definit
 
 A template is provided with the zip: `conf/tachyon-env.sh.template`.
 
-Additional Java VM options can be added to `TACHYON_MASTER_JAVA_OPTS` for Master and
+Additional Java VM options can be added to `TACHYON_MASTER_JAVA_OPTS` for Master, and
 `TACHYON_WORKER_JAVA_OPTS` for Worker configuration. In the template file, `TACHYON_JAVA_OPTS` is
 included in both `TACHYON_MASTER_JAVA_OPTS` and `TACHYON_WORKER_JAVA_OPTS`.
 
-For example if you would like to enable Java remote debugging at port 7001 in the Master you can modify
+For example, if you would like to enable Java remote debugging at port 7001 in the Master, you can modify
 `TACHYON_MASTER_JAVA_OPTS` like this:
 
 `export TACHYON_MASTER_JAVA_OPTS="$TACHYON_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=7001"`

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -5,8 +5,8 @@ title: Configuration Settings
 
 There are two types of configuration parameters for Tachyon:
 
-1. Configuration properties, which is used to configure the runtime setting of Tachyon
-2. System environment properties, which controls the Tachyon Java VM options
+1. Configuration properties, which are used to configure the runtime settings of Tachyon
+2. System environment properties, which control the Tachyon Java VM options
 
 # Configuration properties
 
@@ -15,7 +15,7 @@ Tachyon introduces default and site specific configuration properties files to s
 Each site deployment and application client can override the default via tachyon.site.properties file.
 This file has to be located in the classpath of the Java VM where Tachyon is running.
 
-The easiest way is to put the site properties file in a directory specified by `$TACHYON_CONF_DIR`, which is by default is
+The easiest way is to put the site properties file in a directory specified by `$TACHYON_CONF_DIR`, which by default is
 set to `$TACHYON_HOME/conf`.
 
 The Tachyon configuration properties fall into four categories: Master, Worker, Common (Master and
@@ -60,7 +60,7 @@ The common configuration contains constants which specify paths and the log appe
 <tr>
   <td>tachyon.usezookeeper</td>
   <td>false</td>
-  <td>If setup master fault tolerant mode using ZooKeeper.</td>
+  <td>If true, setup master fault tolerant mode using ZooKeeper.</td>
 </tr>
 <tr>
   <td>tachyon.zookeeper.address</td>
@@ -90,7 +90,7 @@ The common configuration contains constants which specify paths and the log appe
 <tr>
   <td>tachyon.table.metadata.byte</td>
   <td>5242880</td>
-  <td>Maximum amount of bytes allowed to be store as RawTable metadata, must be set on the server side</td>
+  <td>Maximum allowable size (in bytes) of RawTable metadata, must be set on the server side</td>
 </tr>
 <tr>
   <td>fs.s3n.awsAccessKeyId</td>
@@ -115,7 +115,7 @@ The common configuration contains constants which specify paths and the log appe
 <tr>
   <td>tachyon.underfs.glusterfs.mapred.system.dir</td>
   <td>glusterfs:///mapred/system</td>
-  <td>Optionally specify subdirectory under GLusterfs for intermediary MapReduce data.</td>
+  <td>Optionally specify subdirectory under Glusterfs for intermediary MapReduce data.</td>
 </tr>
 <tr>
   <td>tachyon.underfs.hadoop.prefixes</td>

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -157,6 +157,11 @@ number.
   <td>The externally visible hostname of Tachyon's master address.</td>
 </tr>
 <tr>
+  <td>tachyon.master.hostname.listening</td>
+  <td></td>
+  <td>(optional) The address the master will listen on. If set to the wildcard address, "*", the master will listen on all addresses. If unspecified, the master will listen on the address specified for `tachyon.master.hostname`.</td>
+</tr>
+<tr>
   <td>tachyon.master.port</td>
   <td>19998</td>
   <td>The port Tachyon's master node runs on.</td>

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -102,14 +102,14 @@ public class TachyonMaster {
     TachyonConf.assertValidPort(port, mTachyonConf);
     TachyonConf.assertValidPort(webPort, mTachyonConf);
 
-    String hostName = mTachyonConf.get(Constants.MASTER_HOSTNAME, "localhost");
+    String hostnameExternal = mTachyonConf.get(Constants.MASTER_HOSTNAME, "localhost");
     // The master listens to the MASTER_HOSTNAME_LISTENING configuration option.
     // MASTER_HOSTNAME_LISTENING defaults to MASTER_HOSTNAME if unspecified. If set to
     // MASTER_HOSTNAME_LISTENING_WILDCARD, server listens to all addresses.
     String hostnameListening =
-        mTachyonConf.get(Constants.MASTER_HOSTNAME_LISTENING, hostName);
+        mTachyonConf.get(Constants.MASTER_HOSTNAME_LISTENING, hostnameExternal);
 
-    InetSocketAddress address = new InetSocketAddress(hostName, port);
+    InetSocketAddress address = new InetSocketAddress(hostnameExternal, port);
     InetSocketAddress addressListening;
     if (hostnameListening.equals(Constants.MASTER_HOSTNAME_LISTENING_WILDCARD)) {
       addressListening = new InetSocketAddress(port);


### PR DESCRIPTION
A config option to set the address the master listens to.
- if unspecified, master just listens on hostname (current behavior)
- if specified to "*", master listens on all addresses
- otherwise, the master listens on the specified hostname