### PR TITLE
[TACHYON-468] Tachyon worker fails to start when under file system is secured HDFS

### DIFF
--- a/servers/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/servers/src/main/java/tachyon/worker/TachyonWorker.java
@@ -208,6 +208,15 @@ public class TachyonWorker implements Runnable {
     }
     mWorkerAddress =
         new NetAddress(workerAddress.getAddress().getCanonicalHostName(), mPort, mDataPort);
+
+    // Connect to UFS before initializing the workerStorage.
+    try {
+      connectToUFS();
+    } catch (IOException ioe) {
+      LOG.error(ioe.getMessage(), ioe);
+      throw Throwables.propagate(ioe);
+    }
+
     mWorkerStorage.initialize(mWorkerAddress);
 
     mWebServer =
@@ -321,8 +330,6 @@ public class TachyonWorker implements Runnable {
    * Start the data server thread and heartbeat thread of this TachyonWorker.
    */
   public void start() throws IOException {
-    connectToUFS();
-
     mHeartbeatThread.start();
     mWorkerMetricsSystem.start();
     mWebServer.addHandler(mWorkerMetricsSystem.getServletHandler());

--- a/servers/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/servers/src/main/java/tachyon/worker/TachyonWorker.java
@@ -213,7 +213,7 @@ public class TachyonWorker implements Runnable {
     try {
       connectToUFS();
     } catch (IOException ioe) {
-      LOG.error(ioe.getMessage(), ioe);
+      LOG.error("Worker @ " + workerAddress + " failed to connect to the under file system", ioe);
       throw Throwables.propagate(ioe);
     }
 


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-468

The worker will access the under file system when initializing the WorkerStorage. If the under file system is secured HDFS, it will fail as it has not yet logined. 