### PR TITLE
[TACHYON-424] Calculate MD5 in S3OutputStream

### DIFF
--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -107,9 +107,10 @@ public class S3OutputStream extends OutputStream {
     mClosed = true;
     mLocalOutputStream.close();
     try {
-      S3Object obj = new S3Object(mFile);
+      S3Object obj = new S3Object(mKey);
       obj.setBucketName(mBucketName);
-      obj.setKey(mKey);
+      obj.setDataInputFile(mFile);
+      obj.setContentLength(mFile.length());
       obj.setContentEncoding(Mimetypes.MIMETYPE_BINARY_OCTET_STREAM);
       obj.setMd5Hash(mHash.digest());
       mClient.putObject(mBucketName, obj);
@@ -117,8 +118,6 @@ public class S3OutputStream extends OutputStream {
     } catch (ServiceException se) {
       LOG.error("Failed to upload " + mKey + ". Temporary file @ " + mFile.getPath());
       throw new IOException(se);
-    } catch (NoSuchAlgorithmException nsae) {
-      throw new IOException(nsae);
     }
   }
 }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -71,8 +71,8 @@ public class S3OutputStream extends OutputStream {
     mFile = new File(CommonUtils.concatPath("/tmp", UUID.randomUUID()));
     try {
       mHash = MessageDigest.getInstance("MD5");
-      mLocalOutputStream = new BufferedOutputStream(new DigestOutputStream(new FileOutputStream
-          (mFile), mHash));
+      mLocalOutputStream =
+          new BufferedOutputStream(new DigestOutputStream(new FileOutputStream(mFile), mHash));
     } catch (NoSuchAlgorithmException nsae) {
       LOG.warn("Algorithm not available for MD5 hash.", nsae);
       mHash = null;

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 
 import com.google.common.base.Preconditions;

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -20,6 +20,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 
@@ -47,12 +49,15 @@ public class S3OutputStream extends OutputStream {
   private final String mBucketName;
   /** Key of the file when it is uploaded to S3 */
   private final String mKey;
-  /** The outputstream to a local file where the file will be buffered until closed */
-  private final OutputStream mLocalOutputStream;
   /** The local file that will be uploaded when the stream is closed */
   private final File mFile;
   /** The JetS3t client for S3 operations */
   private final S3Service mClient;
+
+  /** The outputstream to a local file where the file will be buffered until closed */
+  private OutputStream mLocalOutputStream;
+  /** The MD5 hash of the file */
+  private MessageDigest mHash;
 
   /** Flag to indicate this stream has been closed, to ensure close is only done once */
   private boolean mClosed;
@@ -64,7 +69,13 @@ public class S3OutputStream extends OutputStream {
     mKey = key;
     mClient = client;
     mFile = new File(CommonUtils.concatPath("/tmp", UUID.randomUUID()));
-    mLocalOutputStream = new BufferedOutputStream(new FileOutputStream(mFile));
+    try {
+      mHash = MessageDigest.getInstance("MD5");
+      mLocalOutputStream = new BufferedOutputStream(new DigestOutputStream(new FileOutputStream
+          (mFile), mHash));
+    } catch (Exception e) {
+      //
+    }
     mClosed = false;
   }
 
@@ -100,6 +111,7 @@ public class S3OutputStream extends OutputStream {
       obj.setBucketName(mBucketName);
       obj.setKey(mKey);
       obj.setContentEncoding(Mimetypes.MIMETYPE_BINARY_OCTET_STREAM);
+      obj.setMd5Hash(mHash.digest());
       mClient.putObject(mBucketName, obj);
       mFile.delete();
     } catch (ServiceException se) {


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-424

Instead of using the jets3t convenience method to calculate MD5, we calculate it in the stream. This will give a large performance boost for large files due to the MD5 calculation being the bottleneck in machines with less CPU resource.

On a 5 node cluster of r3.large machines, there is a write performance increase of ~60%.