### PR TITLE
[TACHYON-476] Improve eviction strategy by adding evicting block list

### DIFF
--- a/servers/src/main/java/tachyon/worker/eviction/EvictLRU.java
+++ b/servers/src/main/java/tachyon/worker/eviction/EvictLRU.java
@@ -47,6 +47,7 @@ public final class EvictLRU extends EvictLRUBase {
     // return null; and if eviction size plus free space of some StorageDir is larger than request
     // size, return the Pair of StorageDir and blockInfoList.
     // TODO Remove while(true). It is in general bad to have the while-loop on true.
+    cleanEvictingBlockIds();
     while (true) {
       // Get oldest block in StorageDir candidates
       Pair<StorageDir, Long> candidate =
@@ -66,8 +67,8 @@ public final class EvictLRU extends EvictLRUBase {
         dir2SizeToEvict.put(dir, evictBytes);
       }
       dir2LRUBlocks.remove(dir);
-
       if (evictBytes + dir.getAvailableBytes() >= requestBytes) {
+        updateEvictingBlockIds(blockInfoList);
         return new Pair<StorageDir, List<BlockInfo>>(dir, blockInfoList);
       }
     }

--- a/servers/src/main/java/tachyon/worker/eviction/EvictLRUBase.java
+++ b/servers/src/main/java/tachyon/worker/eviction/EvictLRUBase.java
@@ -19,8 +19,12 @@ import java.util.Collection;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
+
 import tachyon.Pair;
-import tachyon.master.BlockInfo;
+import tachyon.worker.tiered.BlockInfo;
 import tachyon.worker.tiered.StorageDir;
 
 /**
@@ -28,9 +32,12 @@ import tachyon.worker.tiered.StorageDir;
  */
 public abstract class EvictLRUBase implements EvictStrategy {
   private final boolean mLastTier;
+  protected final Multimap<StorageDir, Long> mEvictingBlockIds;
 
   protected EvictLRUBase(boolean lastTier) {
     mLastTier = lastTier;
+    mEvictingBlockIds = Multimaps
+        .synchronizedMultimap(HashMultimap.<StorageDir, Long>create());
   }
 
   /**
@@ -41,7 +48,34 @@ public abstract class EvictLRUBase implements EvictStrategy {
    * @return true if the block can be evicted, false otherwise
    */
   protected boolean blockEvictable(long blockId, Set<Integer> pinList) {
-    return !mLastTier || !pinList.contains(BlockInfo.computeInodeId(blockId));
+    return !mLastTier || !pinList.contains(tachyon.master.BlockInfo.computeInodeId(blockId));
+  }
+
+  /**
+   * Clean the Id of blocks that have been evicted from evicting list in each StorageDir
+   */
+  protected void cleanEvictingBlockIds() {
+    for (Entry<StorageDir, Long> block : mEvictingBlockIds.entries()) {
+      StorageDir dir = block.getKey();
+      long blockId = block.getValue();
+      // If the block has been evicted, remove it from list
+      if (!dir.containsBlock(blockId)) {
+        mEvictingBlockIds.remove(dir, blockId);
+      }
+    }
+  }
+
+  /**
+   * Update the Id of blocks that are being evicted in each StorageDir
+   * 
+   * @param blockList The list of blocks that will be added in to evicting list
+   */
+  protected void updateEvictingBlockIds(Collection<BlockInfo> blockList) {
+    for (BlockInfo block : blockList) {
+      StorageDir dir = block.getStorageDir();
+      long blockId = block.getBlockId();
+      mEvictingBlockIds.put(dir, blockId);
+    }
   }
 
   /**
@@ -54,21 +88,23 @@ public abstract class EvictLRUBase implements EvictStrategy {
    */
   protected Pair<Long, Long> getLRUBlock(StorageDir curDir, Collection<Long> toEvictBlockIds,
       Set<Integer> pinList) {
-    long blockId = -1;
+    long lruBlockId = -1;
     long oldestTime = Long.MAX_VALUE;
-    Set<Entry<Long, Long>> accessTimes = curDir.getLastBlockAccessTimeMs();
+    Set<Long> evictingBlockIds = (Set<Long>) mEvictingBlockIds.get(curDir);
 
-    for (Entry<Long, Long> accessTime : accessTimes) {
-      if (toEvictBlockIds.contains(accessTime.getKey())) {
+    for (Entry<Long, Long> accessInfo : curDir.getLastBlockAccessTimeMs()) {
+      long blockId = accessInfo.getKey();
+      long accessTime = accessInfo.getValue();
+      if (toEvictBlockIds.contains(blockId) || evictingBlockIds.contains(blockId)) {
         continue;
       }
-      if (accessTime.getValue() < oldestTime && !curDir.isBlockLocked(accessTime.getKey())
-          && blockEvictable(accessTime.getKey(), pinList)) {
-        oldestTime = accessTime.getValue();
-        blockId = accessTime.getKey();
+      if (accessTime < oldestTime && !curDir.isBlockLocked(blockId)
+          && blockEvictable(blockId, pinList)) {
+        lruBlockId = blockId;
+        oldestTime = accessTime;
       }
     }
 
-    return new Pair<Long, Long>(blockId, oldestTime);
+    return new Pair<Long, Long>(lruBlockId, oldestTime);
   }
 }

--- a/servers/src/main/java/tachyon/worker/eviction/EvictLRUBase.java
+++ b/servers/src/main/java/tachyon/worker/eviction/EvictLRUBase.java
@@ -17,6 +17,7 @@ package tachyon.worker.eviction;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -56,17 +57,14 @@ public abstract class EvictLRUBase implements EvictStrategy {
    * Clean the blocks that have been evicted from evicting list in each StorageDir
    */
   protected void cleanEvictingBlockIds() {
-    List<Pair<StorageDir, Long>> outdatedBlocks = new ArrayList<Pair<StorageDir, Long>>();
-    for (Entry<StorageDir, Long> block : mEvictingBlockIds.entries()) {
+    Iterator<Entry<StorageDir, Long>> iterator = mEvictingBlockIds.entries().iterator();
+    while (iterator.hasNext()) {
+      Entry<StorageDir, Long> block = iterator.next();
       StorageDir dir = block.getKey();
       long blockId = block.getValue();
-      // If the block has been evicted, mark it outdated
       if (!dir.containsBlock(blockId)) {
-        outdatedBlocks.add(new Pair<StorageDir, Long>(dir, blockId));
+        iterator.remove();
       }
-    }
-    for (Pair<StorageDir, Long> block : outdatedBlocks) {
-      mEvictingBlockIds.remove(block.getFirst(), block.getSecond());
     }
   }
 

--- a/servers/src/main/java/tachyon/worker/eviction/EvictPartialLRU.java
+++ b/servers/src/main/java/tachyon/worker/eviction/EvictPartialLRU.java
@@ -39,6 +39,8 @@ public final class EvictPartialLRU extends EvictLRUBase {
     List<BlockInfo> blockInfoList = new ArrayList<BlockInfo>();
     Set<StorageDir> ignoredDirs = new HashSet<StorageDir>();
     StorageDir dirSelected = getDirWithMaxFreeSpace(requestBytes, storageDirs, ignoredDirs);
+
+    cleanEvictingBlockIds();
     while (dirSelected != null) {
       Set<Long> blockIdSet = new HashSet<Long>();
       long sizeToEvict = 0;
@@ -55,6 +57,7 @@ public final class EvictPartialLRU extends EvictLRUBase {
         }
       }
       if (sizeToEvict + dirSelected.getAvailableBytes() >= requestBytes) {
+        updateEvictingBlockIds(blockInfoList);
         return new Pair<StorageDir, List<BlockInfo>>(dirSelected, blockInfoList);
       }
       ignoredDirs.add(dirSelected);


### PR DESCRIPTION
Add evicting block list to record the blocks that is being evicted, so that blocks that are evicting by another thread will not be chosen by current thread again