### PR TITLE
[TACHYON-490] Fix the Javadoc

### DIFF
--- a/docs/_plugins/copy_javadoc_to_docs.rb
+++ b/docs/_plugins/copy_javadoc_to_docs.rb
@@ -4,7 +4,7 @@ include FileUtils
 
 puts "Copy over the JavaDoc for all projects to api/java"
 
-source = "../common/target/site/apidocs"
+source = "../target/site/apidocs"
 dest = "api/java"
 
 puts "Making directory " + dest

--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,12 @@
         <version>2.9</version>
         <executions>
           <execution>
+            <id>aggregate</id>
+            <goals>
+              <goal>aggregate</goal>
+            </goals>
+          </execution>
+          <execution>
             <id>attach-javadoc</id>
             <goals>
               <goal>jar</goal>


### PR DESCRIPTION
Fix TACHYON-490, it requires to run `mvn javadoc:javadoc` and `mvn site:site` first.

https://tachyon.atlassian.net/browse/TACHYON-490