### PR TITLE
[TACHYON-424] S3 input stream in S3 client

### DIFF
--- a/servers/src/test/java/tachyon/underfs/UnderFileSystemCluster.java
+++ b/servers/src/test/java/tachyon/underfs/UnderFileSystemCluster.java
@@ -99,7 +99,7 @@ public abstract class UnderFileSystemCluster {
   protected final TachyonConf mTachyonConf;
 
   /**
-   * This method is only for unit-test {@link tachyon.client.FileOutStreamTest} temporarily
+   * This method is only used by the {@link tachyon.client.FileOutStreamIntegrationTest} unit-test
    *
    * @return true if reads on end of file return negative otherwise false
    */

--- a/servers/src/test/java/tachyon/underfs/UnderFileSystemCluster.java
+++ b/servers/src/test/java/tachyon/underfs/UnderFileSystemCluster.java
@@ -105,7 +105,7 @@ public abstract class UnderFileSystemCluster {
    */
   public static boolean readEOFReturnsNegative() {
     // TODO Should be dynamically determined - may need additional method on UnderFileSystem
-    return (null != sUfsClz) && !(sUfsClz.equals("tachyon.LocalUnderFileSystem"));
+    return null != sUfsClz && sUfsClz.equals("tachyon.underfs.hdfs.LocalMiniDFSCluster");
   }
 
   public UnderFileSystemCluster(String baseDir, TachyonConf tachyonConf) {

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>net.java.dev.jets3t</groupId>
       <artifactId>jets3t</artifactId>
-      <version>0.9.3</version>
+      <version>0.8.1</version>
     </dependency>
 
     <!-- Test Dependencies -->

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3InputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3InputStream.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.underfs.s3;
+
+import org.jets3t.service.ServiceException;
+import org.jets3t.service.model.S3Object;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class S3InputStream extends InputStream {
+  private S3Object mObject;
+  private BufferedInputStream mInputStream;
+
+  S3InputStream(S3Object object) throws ServiceException {
+    mObject = object;
+    mInputStream = new BufferedInputStream(mObject.getDataInputStream());
+  }
+
+  public int read() throws IOException {
+    return mInputStream.read();
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    if (mInputStream.available() >= n) {
+      return mInputStream.skip(n);
+    }
+    mInputStream.close();
+    try {
+      mInputStream = new BufferedInputStream(mObject.getDataInputStream());
+    } catch (ServiceException se) {
+      return 0;
+    }
+    return n;
+  }
+
+}

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3InputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3InputStream.java
@@ -19,10 +19,8 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.jets3t.service.S3Service;
 import org.jets3t.service.ServiceException;
-import org.jets3t.service.impl.rest.httpclient.HttpMethodReleaseInputStream;
 import org.jets3t.service.model.S3Object;
 
 public class S3InputStream extends InputStream {
@@ -33,7 +31,6 @@ public class S3InputStream extends InputStream {
 
   private S3Object mObject;
   private BufferedInputStream mInputStream;
-  private HttpMethodReleaseInputStream mHttpStream;
   private long mPos;
 
   S3InputStream(String bucketName, String key, S3Service client) throws ServiceException {
@@ -41,13 +38,12 @@ public class S3InputStream extends InputStream {
     mKey = key;
     mClient = client;
     mObject = mClient.getObject(mBucketName, mKey);
-    mHttpStream = (HttpMethodReleaseInputStream) mObject.getDataInputStream();
     mInputStream = new BufferedInputStream(mObject.getDataInputStream());
   }
 
   @Override
   public void close() throws IOException {
-    closeInnerStream();
+    mInputStream.close();
   }
 
   public int read() throws IOException {
@@ -71,7 +67,7 @@ public class S3InputStream extends InputStream {
     if (mInputStream.available() >= n) {
       return mInputStream.skip(n);
     }
-    closeInnerStream();
+    mInputStream.close();
     mPos += n;
     try {
       mObject = mClient.getObject(mBucketName, mKey, null, null, null, null, mPos, null);
@@ -80,10 +76,5 @@ public class S3InputStream extends InputStream {
       throw new IOException(se);
     }
     return n;
-  }
-
-  private void closeInnerStream() throws IOException {
-    ((CloseableHttpResponse) mHttpStream.getHttpResponse()).close();
-    mInputStream.close();
   }
 }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3InputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3InputStream.java
@@ -15,13 +15,13 @@
 
 package tachyon.underfs.s3;
 
-import org.jets3t.service.S3Service;
-import org.jets3t.service.ServiceException;
-import org.jets3t.service.model.S3Object;
-
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+
+import org.jets3t.service.S3Service;
+import org.jets3t.service.ServiceException;
+import org.jets3t.service.model.S3Object;
 
 public class S3InputStream extends InputStream {
 
@@ -31,7 +31,7 @@ public class S3InputStream extends InputStream {
 
   private S3Object mObject;
   private BufferedInputStream mInputStream;
-  private long pos;
+  private long mPos;
 
   S3InputStream(String bucketName, String key, S3Service client) throws ServiceException {
     mBucketName = bucketName;
@@ -44,7 +44,7 @@ public class S3InputStream extends InputStream {
   public int read() throws IOException {
     int ret = mInputStream.read();
     if (ret != -1) {
-      pos ++;
+      mPos++;
     }
     return ret;
   }
@@ -52,7 +52,7 @@ public class S3InputStream extends InputStream {
   public int read(byte[] b, int off, int len) throws IOException {
     int ret = mInputStream.read(b, off, len);
     if (ret != -1) {
-      pos += ret;
+      mPos += ret;
     }
     return ret;
   }
@@ -62,9 +62,9 @@ public class S3InputStream extends InputStream {
     if (mInputStream.available() >= n) {
       return mInputStream.skip(n);
     }
-    pos += n;
+    mPos += n;
     try {
-      mObject = mClient.getObject(mBucketName, mKey, null, null, null, null, pos, null);
+      mObject = mClient.getObject(mBucketName, mKey, null, null, null, null, mPos, null);
       mInputStream = new BufferedInputStream(mObject.getDataInputStream());
     } catch (ServiceException se) {
       throw new IOException(se);

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -57,7 +57,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
   /** Prefix of the bucket, for example s3n://my-bucket-name/ */
   private final String mBucketPrefix;
 
-  public S3UnderFileSystem(String bucketName, TachyonConf tachyonConf) {
+  public S3UnderFileSystem(String bucketName, TachyonConf tachyonConf) throws ServiceException {
     super(tachyonConf);
     AWSCredentials awsCredentials =
         new AWSCredentials(tachyonConf.get(Constants.S3_ACCESS_KEY, null), tachyonConf.get(

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -241,7 +241,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
   public InputStream open(String path) throws IOException {
     try {
       path = stripPrefixIfPresent(path);
-      return mClient.getObject(mBucketName, path).getDataInputStream();
+      return new S3InputStream(mBucketName, path, mClient);
     } catch (ServiceException se) {
       LOG.error("Failed to open file: " + path, se);
       return null;

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -47,7 +47,8 @@ public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
       try {
         return new S3UnderFileSystem(uri.getHost(), tachyonConf);
       } catch (ServiceException se) {
-        // Do nothing, will fail after.
+        LOG.error("Failed to create S3UnderFileSystem.", se);
+        throw Throwables.propagate(se);
       }
     }
 

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 
+import org.jets3t.service.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,12 +44,16 @@ public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
 
     if (addAndCheckAWSCredentials(tachyonConf)) {
       TachyonURI uri = new TachyonURI(path);
-      return new S3UnderFileSystem(uri.getHost(), tachyonConf);
-    } else {
-      String err = "AWS Credentials not available, cannot create S3 Under File System.";
-      LOG.error(err);
-      throw Throwables.propagate(new IOException(err));
+      try {
+        return new S3UnderFileSystem(uri.getHost(), tachyonConf);
+      } catch (ServiceException se) {
+        // Do nothing, will fail after.
+      }
     }
+
+    String err = "AWS Credentials not available, cannot create S3 Under File System.";
+    LOG.error(err);
+    throw Throwables.propagate(new IOException(err));
   }
 
   @Override


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-424

This patch fixes a few issues with S3 client's read performance related to multiblock reads. The performance gain is linear in the number of blocks of the file, ie 10x for a file with 10 blocks.

1. A faster skip is implemented to avoid reading and discarding bytes. This becomes very costly when skipping a large number of bytes.
2. The jets3t version is changed to 0.8.1. This is because the implementation of the inputstream from s3 does not efficiently close (reads the entire file before closing).