### PR TITLE
[TACHYON-499] Make FileInStream throw EOFException when read position is past EOF

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/FileInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/FileInStream.java
@@ -15,6 +15,7 @@
 
 package tachyon.client;
 
+import java.io.EOFException;
 import java.io.IOException;
 
 import tachyon.conf.TachyonConf;
@@ -97,7 +98,8 @@ public class FileInStream extends InStream {
   @Override
   public int read() throws IOException {
     if (mCurrentPosition >= mFileLength) {
-      return -1;
+      throw new EOFException(String.format("Read position %s is past file length %s.",
+          mCurrentPosition, mFileLength));
     }
 
     checkAndAdvanceBlockInStream();
@@ -121,7 +123,8 @@ public class FileInStream extends InStream {
     } else if (len == 0) {
       return 0;
     } else if (mCurrentPosition >= mFileLength) {
-      return -1;
+      throw new EOFException(String.format("Read position %s is past file length %s.",
+          mCurrentPosition, mFileLength));
     }
 
     int tOff = off;
@@ -153,7 +156,7 @@ public class FileInStream extends InStream {
     if (pos < 0) {
       throw new IOException("Seek position is negative: " + pos);
     } else if (pos > mFileLength) {
-      throw new IOException("Seek position is past EOF: " + pos + ", fileSize = " + mFileLength);
+      throw new EOFException("Seek position is past EOF: " + pos + ", fileSize = " + mFileLength);
     }
 
     if ((int) (pos / mBlockCapacity) != mCurrentBlockIndex) {

--- a/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package tachyon.client;
 
+import java.io.EOFException;
 import java.io.IOException;
 
 import org.junit.AfterClass;
@@ -77,7 +78,11 @@ public class FileInStreamIntegrationTest {
           Assert.assertTrue(value >= 0);
           Assert.assertTrue(value < 256);
           ret[cnt ++] = (byte) value;
-          value = is.read();
+          try {
+            value = is.read();
+          } catch (EOFException e) {
+            value = -1;
+          }
         }
         Assert.assertEquals(cnt, k);
         Assert.assertTrue(TestUtils.equalIncreasingByteArray(k, ret));
@@ -92,7 +97,11 @@ public class FileInStreamIntegrationTest {
           Assert.assertTrue(value >= 0);
           Assert.assertTrue(value < 256);
           ret[cnt ++] = (byte) value;
-          value = is.read();
+          try {
+            value = is.read();
+          } catch (EOFException e) {
+            value = -1;
+          }
         }
         Assert.assertEquals(cnt, k);
         Assert.assertTrue(TestUtils.equalIncreasingByteArray(k, ret));
@@ -180,8 +189,12 @@ public class FileInStreamIntegrationTest {
           byte[] ret = new byte[k / 2];
           int readBytes = is.read(ret, 0, k / 2);
           while (readBytes != -1) {
-            readBytes = is.read(ret);
-            Assert.assertTrue(0 != readBytes);
+            try {
+              readBytes = is.read(ret);
+              Assert.assertTrue(0 != readBytes);
+            } catch (EOFException e) {
+              readBytes = -1;
+            }
           }
           Assert.assertEquals(-1, readBytes);
         } finally {


### PR DESCRIPTION
Make FileInStream throw EOFException when read position is past EOF.
It is used for Spark integration, In spark, FileInStream will be transformed to be a iterator, when getting to the end of the file, the iterator will catch the EOFException, and automatically close the stream.
current implementation doesn't throw EOFException which causes the FileInStream not closed after reading.