### PR TITLE
[TACHYON-478] Enable spark eventlog in deploy/vagrant

### DIFF
--- a/deploy/vagrant/provision/roles/spark/files/spark-defaults.sh
+++ b/deploy/vagrant/provision/roles/spark/files/spark-defaults.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+cp /spark/conf/spark-defaults.conf.template /spark/conf/spark-defaults.conf
+mkdir -p /tmp/spark-eventlog
+cat > /spark/conf/spark-defaults.conf <<EOF
+  spark.master spark://TachyonMaster.local:7077
+  spark.eventLog.enabled true
+  spark.eventLog.dir /tmp/spark-eventlog
+  spark.serializer org.apache.spark.serializer.KryoSerializer
+EOF

--- a/deploy/vagrant/provision/roles/spark/tasks/config.yml
+++ b/deploy/vagrant/provision/roles/spark/tasks/config.yml
@@ -8,4 +8,7 @@
 - name: set spark/conf/core-site.xml
   script: config_core_site.sh
 
+- name: set spark/conf/spark-defaults.conf
+  script: spark-defaults.sh
+
 # vim :set filetype=ansible.yaml:

--- a/deploy/vagrant/provision/roles/spark/tasks/start.yml
+++ b/deploy/vagrant/provision/roles/spark/tasks/start.yml
@@ -1,4 +1,7 @@
 - name: start spark
   shell: /spark/sbin/start-all.sh
 
+- name: start spark history server
+  shell: /spark/sbin/start-history-server.sh
+
 # vim :set filetype=ansible.yaml:


### PR DESCRIPTION
since deploy/vagrant is mainly used for testing, enabling spark eventlog and history server is needed for monitoring and debugging, this PR enables these two features by default. Did not make them optional because they are common use cases.