### PR TITLE
[TACHYON-358] [Tachyon-Perf] Add a utility to support collecting worker logs from master

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -27,8 +27,9 @@ The following steps show how to run a Tachyon-Perf test.
  * The test's configurations are in `conf/testSuite/<TestCase>.xml`, and you can modify it as your wish.
 4. When TachyonPerf is running, the status of the testing job will be collected and printed on the console. For some reasons, if you want to abort the tests, you can just press `Ctrl + C` to terminate it and then type the command `perf/bin/tachyon-perf-abort` on the master node to abort test processes on each slave node.
 5. After all the tests finished successfully, each slave node will generate a result report, locates at `result/` by default. You can also generate a total report by the command `./bin/tachyon-perf-collect <TestCase>`.
-6. In addition, command `./bin/tachyon-perf-clean` is used to clean the workspace directory on Tachyon.
-7. A batch script `bin/tachyon-perf-batch` is also provided to run test with different xml configurations.
+6. If any slaves failed, you can use `bin/tachyon-perf-log-collect all` to collect logs from all the slave nodes, or just the failed nodes, e.g. `bin/tachyon-perf-log-collect node1 node2`
+7. In addition, command `./bin/tachyon-perf-clean` is used to clean the workspace directory on Tachyon.
+8. A batch script `bin/tachyon-perf-batch` is also provided to run test with different xml configurations.
 
 ##Acknowledgement
 Tachyon-Perf is a project started in the Nanjing University [PASA Lab](http://pasa-bigdata.nju.edu.cn/English/index.html) and contributed to Tachyon. Any suggestions and furthure contributions are appreciated.

--- a/perf/bin/tachyon-perf-log-collect
+++ b/perf/bin/tachyon-perf-log-collect
@@ -22,7 +22,7 @@ TACHYON_PERF_LOG_DIR=$TACHYON_PERF_HOME/logs
 TACHYON_PERF_COLLECT_LOG_DIR=$TACHYON_PERF_LOG_DIR/collected-logs
 
 # collect logs from all the slave nodes
-if [ "$1"x = "all"x ]; then
+if [ "$1" = "all" ]; then
   if [ -e $TACHYON_PERF_COLLECT_LOG_DIR ]; then
     rm -rf $TACHYON_PERF_COLLECT_LOG_DIR
   fi
@@ -30,9 +30,8 @@ if [ "$1"x = "all"x ]; then
 
   NODELIST=$TACHYON_PERF_CONF_DIR/slaves
   for slave in `sort "$NODELIST" | uniq | sed  "s/#.*$//;/^$/d"`; do
-    mkdir -p $TACHYON_PERF_COLLECT_LOG_DIR/$slave
     echo -n "Collect logs from $slave ... "
-    scp $slave:$TACHYON_PERF_LOG_DIR/*.log $TACHYON_PERF_COLLECT_LOG_DIR/$slave/
+    scp $slave:$TACHYON_PERF_LOG_DIR/*.log $TACHYON_PERF_COLLECT_LOG_DIR/
     sleep 0.02
   done
   echo "all logs collected at $TACHYON_PERF_COLLECT_LOG_DIR"
@@ -40,17 +39,14 @@ if [ "$1"x = "all"x ]; then
 fi
 
 # collect logs from the specified nodes
+mkdir -p $TACHYON_PERF_COLLECT_LOG_DIR
 while [ $# -gt 0 ]
 do
   slave=$1
   shift
 
-  if [ -e $TACHYON_PERF_COLLECT_LOG_DIR/$slave ]; then
-    rm -rf $TACHYON_PERF_COLLECT_LOG_DIR/$slave
-  fi
-  mkdir -p $TACHYON_PERF_COLLECT_LOG_DIR/$slave
   echo -n "Collect logs from $slave ... "
-  scp $slave:$TACHYON_PERF_LOG_DIR/*.log $TACHYON_PERF_COLLECT_LOG_DIR/$slave/
+  scp $slave:$TACHYON_PERF_LOG_DIR/*.log $TACHYON_PERF_COLLECT_LOG_DIR/
   sleep 0.02
 done
 echo "all logs collected at $TACHYON_PERF_COLLECT_LOG_DIR"

--- a/perf/bin/tachyon-perf-log-collect
+++ b/perf/bin/tachyon-perf-log-collect
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+function printUsage {
+  echo "Usage: tachyon-perf-log-collect <all|[Nodes ...]>"
+  echo "  'all' means collect the logs from all the slave nodes"
+  echo "  or you can specify the nodes such as 'node1 node2 ...'"
+}
+
+# if less than 1 args specified, show usage
+if [ $# -le 0 ]; then
+  printUsage
+  exit 1
+fi
+
+bin=`cd "$( dirname "$0" )"; pwd`
+
+DEFAULT_PERF_LIBEXEC_DIR="$bin"/../libexec
+TACHYON_PERF_LIBEXEC_DIR=${TACHYON_PERF_LIBEXEC_DIR:-$DEFAULT_PERF_LIBEXEC_DIR}
+. $TACHYON_PERF_LIBEXEC_DIR/tachyon-perf-config.sh
+
+TACHYON_PERF_LOG_DIR=$TACHYON_PERF_HOME/logs
+TACHYON_PERF_COLLECT_LOG_DIR=$TACHYON_PERF_LOG_DIR/collected-logs
+
+# collect logs from all the slave nodes
+if [ "$1"x = "all"x ]; then
+  if [ -e $TACHYON_PERF_COLLECT_LOG_DIR ]; then
+    rm -rf $TACHYON_PERF_COLLECT_LOG_DIR
+  fi
+  mkdir -p $TACHYON_PERF_COLLECT_LOG_DIR
+
+  NODELIST=$TACHYON_PERF_CONF_DIR/slaves
+  for slave in `sort "$NODELIST" | uniq | sed  "s/#.*$//;/^$/d"`; do
+    mkdir -p $TACHYON_PERF_COLLECT_LOG_DIR/$slave
+    echo -n "Collect logs from $slave ... "
+    scp $slave:$TACHYON_PERF_LOG_DIR/*.log $TACHYON_PERF_COLLECT_LOG_DIR/$slave/
+    sleep 0.02
+  done
+  echo "all logs collected at $TACHYON_PERF_COLLECT_LOG_DIR"
+  exit 0
+fi
+
+# collect logs from the specified nodes
+while [ $# -gt 0 ]
+do
+  slave=$1
+  shift
+
+  if [ -e $TACHYON_PERF_COLLECT_LOG_DIR/$slave ]; then
+    rm -rf $TACHYON_PERF_COLLECT_LOG_DIR/$slave
+  fi
+  mkdir -p $TACHYON_PERF_COLLECT_LOG_DIR/$slave
+  echo -n "Collect logs from $slave ... "
+  scp $slave:$TACHYON_PERF_LOG_DIR/*.log $TACHYON_PERF_COLLECT_LOG_DIR/$slave/
+  sleep 0.02
+done
+echo "all logs collected at $TACHYON_PERF_COLLECT_LOG_DIR"
+
+


### PR DESCRIPTION
This script supports user to get the worker logs from a failed worker to the master instead of ssh to the workers. https://tachyon.atlassian.net/browse/TACHYON-358
The usage is `bin/tachyon-perf-log-collect all` or `bin/tachyon-perf-log-collect node1 node2 ...`
The collected logs will be under ${tachyon.perf.home}/logs/collected-logs, in different node-named directories.