### PR TITLE
[TACHYON-502] [TACHYON-506] Add 'Massive' workload to the perf module and update perf's README

### DIFF
--- a/perf/README.md
+++ b/perf/README.md
@@ -23,13 +23,30 @@ The following steps show how to run a Tachyon-Perf test.
 1. Copy `perf/conf/tachyon-perf-env.sh.template` to `perf/conf/tachyon-perf-env.sh` and configure it as prompted.
 2. Edit `perf/conf/slaves` to add testing slave nodes. It's recommended to be the same as `{tachyon.home}/conf/workers`. By the way, duplicate slave name is allowed which implies start multi-processes tests on one slave node.
 3. The running test command is `perf/bin/tachyon-perf <TestCase>`
- * The parameter is the name of test case, and now it should be `Metadata`, `SimpleWrite`, `SimpleRead`, `SkipRead`, `Mixture`, `Iterate` or `Massive`.
+ * The parameter is the name of test case, and now it should be `Metadata`, `SimpleWrite`, `SimpleRead`, `SkipRead`, `Mixture`, `Iterate` or `Massive`. (The detailed descriptions are shown in next section)
  * The test's configurations are in `conf/testSuite/<TestCase>.xml`, and you can modify it as your wish.
 4. When TachyonPerf is running, the status of the testing job will be collected and printed on the console. For some reasons, if you want to abort the tests, you can just press `Ctrl + C` to terminate it and then type the command `perf/bin/tachyon-perf-abort` on the master node to abort test processes on each slave node.
 5. After all the tests finished successfully, each slave node will generate a result report, locates at `result/` by default. You can also generate a total report by the command `./bin/tachyon-perf-collect <TestCase>`.
 6. If any slaves failed, you can use `bin/tachyon-perf-log-collect all` to collect logs from all the slave nodes, or just the failed nodes, e.g. `bin/tachyon-perf-log-collect node1 node2`
 7. In addition, command `./bin/tachyon-perf-clean` is used to clean the workspace directory on Tachyon.
 8. A batch script `bin/tachyon-perf-batch` is also provided to run test with different xml configurations.
+
+##Test Cases
+The following shows what each of the test cases does exactly.
+
+* **Metadata**: This test repeats performing metadata operations for a while, including creating, existing, renaming and deleting files.
+
+* **SimpleWrite**: This test writes a set of files to the FS.
+
+* **SimpleRead**: This test reads a set of files from the FS byte-by-byte which are written by the *SimpleWrite* test. You can configure it to read locally or remotely.
+
+* **SkipRead**: This test is similar like the *SimpleRead* test, but it can read files in a `skip->read` pattern.
+
+* **Mixture**: This test mixes the read and write operations in a configurable ratio. You can configure a heavy read test or a heavy write test.
+
+* **Iterate**: This test reads/writes files iteratively that the output of the former iteration is the input of the next one. Two modes called *Shuffle* and *Non-Shuffle* are proviede. In *Shuffle* mode, each slave reads files from the whole workspace, which may lead to remote reading. In *Non-Shuffle* mode, each slave only reads the files written by itself, which keeps good locality.
+
+* **Massive**: This test randomly chooses to read or write concurrently for a time duration. It provides *Shuffle* and *Non-Shuffle* modes as well.
 
 ##Acknowledgement
 Tachyon-Perf is a project started in the Nanjing University [PASA Lab](http://pasa-bigdata.nju.edu.cn/English/index.html) and contributed to Tachyon. Any suggestions and furthure contributions are appreciated.

--- a/perf/README.md
+++ b/perf/README.md
@@ -23,7 +23,7 @@ The following steps show how to run a Tachyon-Perf test.
 1. Copy `perf/conf/tachyon-perf-env.sh.template` to `perf/conf/tachyon-perf-env.sh` and configure it as prompted.
 2. Edit `perf/conf/slaves` to add testing slave nodes. It's recommended to be the same as `{tachyon.home}/conf/workers`. By the way, duplicate slave name is allowed which implies start multi-processes tests on one slave node.
 3. The running test command is `perf/bin/tachyon-perf <TestCase>`
- * The parameter is the name of test case, and now it should be `Metadata`, `SimpleWrite`, `SimpleRead`, `SkipRead`, `Mixture` or `Iterate`.
+ * The parameter is the name of test case, and now it should be `Metadata`, `SimpleWrite`, `SimpleRead`, `SkipRead`, `Mixture`, `Iterate` or `Massive`.
  * The test's configurations are in `conf/testSuite/<TestCase>.xml`, and you can modify it as your wish.
 4. When TachyonPerf is running, the status of the testing job will be collected and printed on the console. For some reasons, if you want to abort the tests, you can just press `Ctrl + C` to terminate it and then type the command `perf/bin/tachyon-perf-abort` on the master node to abort test processes on each slave node.
 5. After all the tests finished successfully, each slave node will generate a result report, locates at `result/` by default. You can also generate a total report by the command `./bin/tachyon-perf-collect <TestCase>`.

--- a/perf/bin/tachyon-perf
+++ b/perf/bin/tachyon-perf
@@ -3,7 +3,7 @@
 function printUsage {
   echo "Usage: tachyon-perf <TestCase>"
   echo "now TestCase is one of:"
-  echo -e "  SimpleWrite SimpleRead SkipRead Metadata Mixture Iterate"
+  echo -e "  SimpleWrite SimpleRead SkipRead Metadata Mixture Iterate Massive"
   echo "the detailed configurations are in conf/testsuite/"
 }
 

--- a/perf/conf/test-case.xml
+++ b/perf/conf/test-case.xml
@@ -42,5 +42,12 @@
     <taskThreadClass>tachyon.perf.benchmark.iterate.IterateThread</taskThreadClass>
     <totalReportClass>tachyon.perf.benchmark.SimpleTotalReport</totalReportClass>
   </type>
+  <type>
+    <name>Massive</name>
+    <taskClass>tachyon.perf.benchmark.massive.MassiveTask</taskClass>
+    <taskContextClass>tachyon.perf.benchmark.massive.MassiveTaskContext</taskContextClass>
+    <taskThreadClass>tachyon.perf.benchmark.massive.MassiveThread</taskThreadClass>
+    <totalReportClass>tachyon.perf.benchmark.SimpleTotalReport</totalReportClass>
+  </type>
 </taskTypes>
 

--- a/perf/conf/testsuite/Massive.xml
+++ b/perf/conf/testsuite/Massive.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <property>
+    <name>time.seconds</name>
+    <value>5</value>
+    <description>the time duration of the whole test</description>
+  </property>
+  <property>
+    <name>shuffle.mode</name>
+    <value>false</value>
+    <description>workers will only read their own dataset by default, set shuffle mode to true to read from the entire dataset</description>
+  </property>
+  <property>
+    <name>basic.files.per.thread</name>
+    <value>2</value>
+    <description>the number of global files to write at the beginning for each thread</description>
+  </property>
+  <property>
+    <name>block.size.bytes</name>
+    <value>134217728</value>
+    <description>the block size of a file</description>
+  </property>
+  <property>
+    <name>file.length.bytes</name>
+    <value>134217728</value>
+    <description>the file size in bytes</description>
+  </property>
+  <property>
+    <name>buffer.size.bytes</name>
+    <value>4194304</value>
+    <description>the size of the buffer read and write once</description>
+  </property>
+  <property>
+    <name>read.type</name>
+    <value>CACHE</value>
+    <description>the ReadType of the read operation, now only used for TachyonFS</description>
+  </property>
+  <property>
+    <name>write.type</name>
+    <value>THROUGH</value>
+    <description>the WriteType of the write operation, now only used for TachyonFS</description>
+  </property>
+</configuration>
+

--- a/perf/src/main/java/tachyon/perf/benchmark/massive/MassiveTask.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/massive/MassiveTask.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.benchmark.massive;
+
+import tachyon.perf.basic.PerfTaskContext;
+import tachyon.perf.benchmark.SimpleTask;
+import tachyon.perf.conf.PerfConf;
+
+public class MassiveTask extends SimpleTask {
+  @Override
+  public String getCleanupDir() {
+    return PerfConf.get().WORK_DIR + "/massive";
+  }
+
+  @Override
+  protected boolean setupTask(PerfTaskContext taskContext) {
+    String workDir = PerfConf.get().WORK_DIR + "/massive";
+    mTaskConf.addProperty("work.dir", workDir);
+    LOG.info("Work dir " + workDir);
+    return true;
+  }
+}

--- a/perf/src/main/java/tachyon/perf/benchmark/massive/MassiveTaskContext.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/massive/MassiveTaskContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.benchmark.massive;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import tachyon.perf.basic.PerfThread;
+import tachyon.perf.benchmark.SimpleTaskContext;
+
+public class MassiveTaskContext extends SimpleTaskContext {
+  @Override
+  public void setFromThread(PerfThread[] threads) {
+    mAdditiveStatistics = new HashMap<String, List<Double>>(3);
+    List<Double> basicThroughputs = new ArrayList<Double>(threads.length);
+    List<Double> readThroughputs = new ArrayList<Double>(threads.length);
+    List<Double> writeThroughputs = new ArrayList<Double>(threads.length);
+    for (PerfThread thread : threads) {
+      if (!((MassiveThread) thread).getSuccess()) {
+        mSuccess = false;
+      }
+      basicThroughputs.add(((MassiveThread) thread).getBasicWriteThroughput());
+      readThroughputs.add(((MassiveThread) thread).getReadThroughput());
+      writeThroughputs.add(((MassiveThread) thread).getWriteThroughput());
+    }
+    mAdditiveStatistics.put("BasicWriteThroughput(MB/s)", basicThroughputs);
+    mAdditiveStatistics.put("ReadThroughput(MB/s)", readThroughputs);
+    mAdditiveStatistics.put("WriteThroughput(MB/s)", writeThroughputs);
+  }
+}

--- a/perf/src/main/java/tachyon/perf/benchmark/massive/MassiveThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/massive/MassiveThread.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.perf.benchmark.massive;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+
+import tachyon.perf.PerfConstants;
+import tachyon.perf.basic.PerfThread;
+import tachyon.perf.basic.TaskConfiguration;
+import tachyon.perf.benchmark.ListGenerator;
+import tachyon.perf.benchmark.Operators;
+import tachyon.perf.fs.PerfFS;
+
+public class MassiveThread extends PerfThread {
+  private Random mRand;
+
+  private int mBasicFilesNum;
+  private int mBufferSize;
+  private long mFileLength;
+  private PerfFS mFileSystem;
+  private long mLimitTimeMs;
+  private boolean mShuffle;
+  private String mWorkDir;
+
+  private double mBasicWriteThroughput; // in MB/s
+  private double mReadThroughput; // in MB/s
+  private boolean mSuccess;
+  private double mWriteThroughput; // in MB/s
+
+  public double getBasicWriteThroughput() {
+    return mBasicWriteThroughput;
+  }
+
+  public double getReadThroughput() {
+    return mReadThroughput;
+  }
+
+  public boolean getSuccess() {
+    return mSuccess;
+  }
+
+  public double getWriteThroughput() {
+    return mWriteThroughput;
+  }
+
+  private void initSyncBarrier() throws IOException {
+    mFileSystem.create(mWorkDir + "/sync/" + mTaskId + "-" + mId);
+  }
+
+  private void syncBarrier() throws IOException {
+    String syncDirPath = mWorkDir + "/sync";
+    String syncFileName = mTaskId + "-" + mId;
+    mFileSystem.delete(syncDirPath + "/" + syncFileName, false);
+    while (!mFileSystem.listFullPath(syncDirPath).isEmpty()) {
+      try {
+        Thread.sleep(300);
+      } catch (InterruptedException e) {
+        LOG.error("Error in Sync Barrier", e);
+      }
+    }
+  }
+
+  @Override
+  public void run() {
+    long basicBytes = 0;
+    long basicTimeMs = 0;
+    long readBytes = 0;
+    long readTimeMs = 0;
+    long writeBytes = 0;
+    long writeTimeMs = 0;
+    mSuccess = true;
+    String tmpDir = mWorkDir + "/tmp";
+    String dataDir;
+    if (mShuffle) {
+      dataDir = mWorkDir + "/data";
+    } else {
+      dataDir = mWorkDir + "/data/" + mTaskId;
+    }
+
+    long tTimeMs = System.currentTimeMillis();
+    for (int b = 0; b < mBasicFilesNum; b ++) {
+      try {
+        String fileName = mTaskId + "-" + mId + "-" + b;
+        Operators.writeSingleFile(mFileSystem, dataDir + "/" + fileName, mFileLength, mBufferSize);
+        basicBytes += mFileLength;
+      } catch (IOException e) {
+        LOG.error("Failed to write basic file", e);
+        mSuccess = false;
+        break;
+      }
+    }
+    tTimeMs = System.currentTimeMillis() - tTimeMs;
+    basicTimeMs += tTimeMs;
+
+    try {
+      syncBarrier();
+    } catch (IOException e) {
+      LOG.error("Error in Sync Barrier", e);
+      mSuccess = false;
+    }
+    int index = 0;
+    long limitTimeMs = System.currentTimeMillis() + mLimitTimeMs;
+    while ((tTimeMs = System.currentTimeMillis()) < limitTimeMs) {
+      if (mRand.nextBoolean()) { // read
+        try {
+          List<String> candidates = mFileSystem.listFullPath(dataDir);
+          String readFilePath = ListGenerator.generateRandomReadFiles(1, candidates).get(0);
+          readBytes += Operators.readSingleFile(mFileSystem, readFilePath, mBufferSize);
+        } catch (IOException e) {
+          LOG.error("Failed to read file", e);
+          mSuccess = false;
+        }
+        readTimeMs += System.currentTimeMillis() - tTimeMs;
+      } else { // write
+        try {
+          String writeFileName = mTaskId + "-" + mId + "--" + index;
+          Operators.writeSingleFile(mFileSystem, tmpDir + "/" + writeFileName, mFileLength,
+              mBufferSize);
+          writeBytes += mFileLength;
+          mFileSystem.rename(tmpDir + "/" + writeFileName, dataDir + "/" + writeFileName);
+        } catch (IOException e) {
+          LOG.error("Failed to write file", e);
+          mSuccess = false;
+        }
+        writeTimeMs += System.currentTimeMillis() - tTimeMs;
+      }
+      index ++;
+    }
+
+    mBasicWriteThroughput =
+        (basicBytes == 0) ? 0 : (basicBytes / 1024.0 / 1024.0) / (basicTimeMs / 1000.0);
+    mReadThroughput = (readBytes == 0) ? 0 : (readBytes / 1024.0 / 1024.0) / (readTimeMs / 1000.0);
+    mWriteThroughput =
+        (writeBytes == 0) ? 0 : (writeBytes / 1024.0 / 1024.0) / (writeTimeMs / 1000.0);
+  }
+
+  @Override
+  public boolean setupThread(TaskConfiguration taskConf) {
+    mRand = new Random(System.currentTimeMillis() + mTaskId + mId);
+    mBufferSize = taskConf.getIntProperty("buffer.size.bytes");
+    mFileLength = taskConf.getLongProperty("file.length.bytes");
+    mLimitTimeMs = taskConf.getLongProperty("time.seconds") * 1000;
+    mShuffle = taskConf.getBooleanProperty("shuffle.mode");
+    mWorkDir = taskConf.getProperty("work.dir");
+    mBasicFilesNum = taskConf.getIntProperty("basic.files.per.thread");
+    try {
+      mFileSystem = PerfConstants.getFileSystem();
+      initSyncBarrier();
+    } catch (IOException e) {
+      LOG.error("Failed to setup thread, task " + mTaskId + " - thread " + mId, e);
+      return false;
+    }
+    mSuccess = false;
+    mBasicWriteThroughput = 0;
+    mReadThroughput = 0;
+    mWriteThroughput = 0;
+    return true;
+  }
+
+  @Override
+  public boolean cleanupThread(TaskConfiguration taskConf) {
+    try {
+      mFileSystem.close();
+    } catch (IOException e) {
+      LOG.warn("Error when close file system, task " + mTaskId + " - thread " + mId, e);
+    }
+    return true;
+  }
+
+}

--- a/perf/src/main/java/tachyon/perf/benchmark/massive/MassiveThread.java
+++ b/perf/src/main/java/tachyon/perf/benchmark/massive/MassiveThread.java
@@ -143,10 +143,11 @@ public class MassiveThread extends PerfThread {
     }
 
     mBasicWriteThroughput =
-        (basicBytes == 0) ? 0 : (basicBytes / 1024.0 / 1024.0) / (basicTimeMs / 1000.0);
-    mReadThroughput = (readBytes == 0) ? 0 : (readBytes / 1024.0 / 1024.0) / (readTimeMs / 1000.0);
+        (basicTimeMs == 0) ? 0 : (basicBytes / 1024.0 / 1024.0) / (basicTimeMs / 1000.0);
+    mReadThroughput =
+        (readTimeMs == 0) ? 0 : (readBytes / 1024.0 / 1024.0) / (readTimeMs / 1000.0);
     mWriteThroughput =
-        (writeBytes == 0) ? 0 : (writeBytes / 1024.0 / 1024.0) / (writeTimeMs / 1000.0);
+        (writeTimeMs == 0) ? 0 : (writeBytes / 1024.0 / 1024.0) / (writeTimeMs / 1000.0);
   }
 
   @Override


### PR DESCRIPTION
The related JIRA https://tachyon.atlassian.net/browse/TACHYON-502

This is an addition to https://tachyon.atlassian.net/browse/TACHYON-326
Current there are several workloads in perf with some access patterns. This Massive workload doesn't have a determined access pattern, but to randomly choose read or write for some time concurrently.
This workload does not aim to show the excellent performance of tachyon but to find out the potential issues or bugs.