### PR TITLE
[TACHYON-507] Fix ConcurrentModificationException in StorageDir

### DIFF
--- a/servers/src/main/java/tachyon/worker/tiered/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/tiered/StorageDir.java
@@ -494,10 +494,12 @@ public final class StorageDir {
    */
   public long getLockedSizeBytes() {
     long lockedBytes = 0;
-    for (long blockId : mUserPerLockedBlock.keySet()) {
-      Long blockSize = mBlockSizes.get(blockId);
-      if (blockSize != null) {
-        lockedBytes += blockSize;
+    synchronized (mUserPerLockedBlock) {
+      for (long blockId : mUserPerLockedBlock.keySet()) {
+        Long blockSize = mBlockSizes.get(blockId);
+        if (blockSize != null) {
+          lockedBytes += blockSize;
+        }
       }
     }
     return lockedBytes;


### PR DESCRIPTION
GetLockedBlockSize in StorageDir will iterate on mUserPerLockedBlock in StorageDir, but did not make it synchronized, during the iteration, the mUserPerLockedBlock may be changed in lockBlock/unlockBlock, and ConcurrentModificationException will be thrown.