### PR TITLE
[TACHYON-495] Refactor remote block reader to use Netty

### DIFF
--- a/clients/unshaded/pom.xml
+++ b/clients/unshaded/pom.xml
@@ -23,6 +23,11 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.0.23.Final</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
     </dependency>

--- a/clients/unshaded/pom.xml
+++ b/clients/unshaded/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.23.Final</version>
+      <version>4.0.28.Final</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -192,7 +192,7 @@ public class TachyonFS extends AbstractTachyonFS {
     mMasterAddress = new InetSocketAddress(masterHost, masterPort);
     mZookeeperMode = mTachyonConf.getBoolean(Constants.USE_ZOOKEEPER, false);
     mExecutorService =
-        Executors.newFixedThreadPool(2, ThreadFactoryUtils.daemon("client-heartbeat-%d"));
+        Executors.newFixedThreadPool(2, ThreadFactoryUtils.build("client-heartbeat-%d", true));
     mMasterClient =
         mCloser.register(new MasterClient(mMasterAddress, mExecutorService, mTachyonConf));
     mWorkerClient =

--- a/clients/unshaded/src/main/java/tachyon/client/netty/ClientHandler.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/ClientHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.client.netty;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+import tachyon.Constants;
+import tachyon.network.protocol.RPCBlockResponse;
+import tachyon.network.protocol.RPCMessage;
+import tachyon.network.protocol.RPCResponse;
+
+@ChannelHandler.Sharable
+public final class ClientHandler extends SimpleChannelInboundHandler<RPCMessage> {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
+  public interface ResponseListener {
+    void onResponseReceived(RPCResponse response);
+  }
+
+  private final HashSet<ResponseListener> mListeners;
+
+  public ClientHandler() {
+    mListeners = new HashSet<ResponseListener>();
+  }
+
+  public void addListener(ResponseListener listener) {
+    mListeners.add(listener);
+  }
+
+  public void removeListener(ResponseListener listener) {
+    mListeners.remove(listener);
+  }
+
+  @Override
+  public void channelRead0(final ChannelHandlerContext ctx, final RPCMessage msg)
+      throws IOException {
+    switch (msg.getType()) {
+      case RPC_BLOCK_RESPONSE:
+        handleBlockResponse(ctx, (RPCBlockResponse) msg);
+        break;
+      default:
+        throw new IllegalArgumentException("No handler implementation for rpc response type: "
+            + msg.getType());
+    }
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    LOG.warn("Exception thrown while processing request", cause);
+    ctx.close();
+  }
+
+  private void handleBlockResponse(final ChannelHandlerContext ctx, final RPCResponse req)
+      throws IOException {
+    for (ResponseListener listener : mListeners) {
+      listener.onResponseReceived(req);
+    }
+  }
+}

--- a/clients/unshaded/src/main/java/tachyon/client/netty/ClientHandler.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/ClientHandler.java
@@ -30,11 +30,18 @@ import tachyon.network.protocol.RPCBlockResponse;
 import tachyon.network.protocol.RPCMessage;
 import tachyon.network.protocol.RPCResponse;
 
+/**
+ * This handles all the messages received by the client channel.
+ */
 @ChannelHandler.Sharable
 public final class ClientHandler extends SimpleChannelInboundHandler<RPCMessage> {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
+  /**
+   * The interface for listeners to implement to receive callbacks when messages are received.
+   */
   public interface ResponseListener {
+    /** This method will be called when a message is received on the client. */
     void onResponseReceived(RPCResponse response);
   }
 

--- a/clients/unshaded/src/main/java/tachyon/client/netty/ClientHandler.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/ClientHandler.java
@@ -66,7 +66,7 @@ public final class ClientHandler extends SimpleChannelInboundHandler<RPCMessage>
       handleResponse(ctx, (RPCResponse) msg);
     } else {
       // The client should only receive RPCResponse messages.
-      throw new IllegalArgumentException("No handler implementation for rpc response type: "
+      throw new IllegalArgumentException("No handler implementation for rpc message type: "
           + msg.getType());
     }
   }

--- a/clients/unshaded/src/main/java/tachyon/client/netty/ClientHandler.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/ClientHandler.java
@@ -78,10 +78,10 @@ public final class ClientHandler extends SimpleChannelInboundHandler<RPCMessage>
     ctx.close();
   }
 
-  private void handleBlockResponse(final ChannelHandlerContext ctx, final RPCResponse req)
+  private void handleBlockResponse(final ChannelHandlerContext ctx, final RPCBlockResponse resp)
       throws IOException {
     for (ResponseListener listener : mListeners) {
-      listener.onResponseReceived(req);
+      listener.onResponseReceived(resp);
     }
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.client.netty;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+import tachyon.Constants;
+import tachyon.client.RemoteBlockReader;
+import tachyon.conf.TachyonConf;
+import tachyon.network.ChannelType;
+import tachyon.network.NettyUtils;
+import tachyon.network.protocol.RPCBlockRequest;
+import tachyon.network.protocol.RPCBlockResponse;
+import tachyon.network.protocol.RPCMessage;
+import tachyon.network.protocol.RPCMessageDecoder;
+import tachyon.network.protocol.RPCMessageEncoder;
+import tachyon.network.protocol.RPCResponse;
+import tachyon.util.ThreadFactoryUtils;
+
+/**
+ * Read data from remote data server using Netty.
+ */
+public final class NettyRemoteBlockReader implements RemoteBlockReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
+  private final TachyonConf mTachyonConf;
+  private final ChannelType mChannelType;
+  private final Bootstrap mClientBootstrap;
+  private final EventLoopGroup mWorkerGroup;
+
+  private final ClientHandler mHandler;
+
+  // TODO: Creating a new remote block reader may be expensive, so consider a connection pool.
+  public NettyRemoteBlockReader() {
+    mTachyonConf = new TachyonConf();
+    mChannelType =
+        mTachyonConf.getEnum(Constants.WORKER_NETWORK_NETTY_CHANNEL, ChannelType.defaultType());
+    final int workerThreadCount = mTachyonConf.getInt(Constants.WORKER_NETTY_WORKER_THREADS, 1);
+    mWorkerGroup =
+        NettyUtils.createEventLoop(mChannelType, workerThreadCount, "netty-client-worker-%d");
+
+    mClientBootstrap = createClientBootstrap();
+    mHandler = new ClientHandler();
+  }
+
+  @Override
+  public ByteBuffer readRemoteBlock(String host, int port, long blockId, long offset, long length)
+      throws IOException {
+    InetSocketAddress address = new InetSocketAddress(host, port);
+
+    try {
+      ChannelFuture f = mClientBootstrap.connect(address).sync();
+
+      LOG.info("Connected to remote machine " + address);
+      Channel channel = f.channel();
+      SingleResponseListener listener = new SingleResponseListener();
+      mHandler.addListener(listener);
+      channel.writeAndFlush(new RPCBlockRequest(blockId, offset, length));
+
+      RPCResponse response = listener.get(1, TimeUnit.SECONDS);
+      f.channel().close().sync();
+
+      if (response.getType() == RPCMessage.Type.RPC_BLOCK_RESPONSE) {
+        RPCBlockResponse blockResponse = (RPCBlockResponse) response;
+        LOG.info("Data " + blockId + " from remote machine " + address + " received");
+        return blockResponse.getPayloadDataBuffer().getReadOnlyByteBuffer();
+      }
+    } catch (Exception e) {
+      LOG.error("exception in netty client: " + e.getMessage());
+    } finally {
+      mWorkerGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS);
+    }
+
+    return null;
+  }
+
+  private Bootstrap createClientBootstrap() {
+    final Bootstrap boot = new Bootstrap();
+
+    final Class<? extends SocketChannel> socketChannelClass =
+        NettyUtils.getClientChannelClass(mChannelType);
+    boot.group(mWorkerGroup).channel(socketChannelClass);
+    boot.option(ChannelOption.SO_KEEPALIVE, true);
+
+    boot.handler(new ChannelInitializer<SocketChannel>() {
+      @Override
+      public void initChannel(SocketChannel ch) throws Exception {
+        ChannelPipeline pipeline = ch.pipeline();
+
+        pipeline.addLast(RPCMessage.createFrameDecoder());
+        pipeline.addLast(new RPCMessageEncoder());
+        pipeline.addLast(new RPCMessageDecoder());
+        pipeline.addLast(mHandler);
+      }
+    });
+
+    return boot;
+  }
+}

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -56,14 +56,15 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
   private static final RPCMessageDecoder DECODER = new RPCMessageDecoder();
 
   private static final TachyonConf TACHYON_CONF = new TachyonConf();
-  private static final ChannelType CHANNEL_TYPE =
-      TACHYON_CONF.getEnum(Constants.WORKER_NETWORK_NETTY_CHANNEL, ChannelType.defaultType());
-  private static final Class<? extends SocketChannel> CLIENT_CHANNEL_CLASS =
-      NettyUtils.getClientChannelClass(CHANNEL_TYPE);
+  private static final ChannelType CHANNEL_TYPE = TACHYON_CONF.getEnum(
+      Constants.WORKER_NETWORK_NETTY_CHANNEL, ChannelType.defaultType());
+  private static final Class<? extends SocketChannel> CLIENT_CHANNEL_CLASS = NettyUtils
+      .getClientChannelClass(CHANNEL_TYPE);
   // Reuse EventLoopGroup for all clients.
-  private static final EventLoopGroup WORKER_GROUP =
-      NettyUtils.createEventLoop(CHANNEL_TYPE,
-          TACHYON_CONF.getInt(Constants.WORKER_NETTY_WORKER_THREADS, 1), "netty-client-worker-%d");
+  // Use daemon threads so the JVM is allowed to shutdown even when daemon threads are alive.
+  private static final EventLoopGroup WORKER_GROUP = NettyUtils
+      .createEventLoop(CHANNEL_TYPE, TACHYON_CONF.getInt(Constants.WORKER_NETTY_WORKER_THREADS, 1),
+          "netty-client-worker-%d", true);
 
   private final Bootstrap mClientBootstrap;
   private final ClientHandler mHandler;
@@ -98,8 +99,6 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
       }
     } catch (Exception e) {
       LOG.error("exception in netty client: " + e.getMessage());
-    } finally {
-//      WORKER_GROUP.shutdownGracefully(0, 0, TimeUnit.SECONDS);
     }
 
     return null;

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -115,6 +115,7 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
         NettyUtils.getClientChannelClass(mChannelType);
     boot.group(mWorkerGroup).channel(socketChannelClass);
     boot.option(ChannelOption.SO_KEEPALIVE, true);
+    boot.option(ChannelOption.TCP_NODELAY, true);
 
     boot.handler(new ChannelInitializer<SocketChannel>() {
       @Override

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -18,24 +18,20 @@ package tachyon.client.netty;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.epoll.EpollSocketChannel;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioSocketChannel;
 
 import tachyon.Constants;
 import tachyon.client.RemoteBlockReader;
@@ -48,7 +44,6 @@ import tachyon.network.protocol.RPCMessage;
 import tachyon.network.protocol.RPCMessageDecoder;
 import tachyon.network.protocol.RPCMessageEncoder;
 import tachyon.network.protocol.RPCResponse;
-import tachyon.util.ThreadFactoryUtils;
 
 /**
  * Read data from remote data server using Netty.
@@ -116,6 +111,7 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
     boot.group(mWorkerGroup).channel(socketChannelClass);
     boot.option(ChannelOption.SO_KEEPALIVE, true);
     boot.option(ChannelOption.TCP_NODELAY, true);
+    boot.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
 
     boot.handler(new ChannelInitializer<SocketChannel>() {
       @Override

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -65,8 +65,9 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
       .getClientChannelClass(CHANNEL_TYPE);
   // Reuse EventLoopGroup for all clients.
   // Use daemon threads so the JVM is allowed to shutdown even when daemon threads are alive.
+  // If number of worker threads is 0, Netty creates (#processors * 2) threads by default.
   private static final EventLoopGroup WORKER_GROUP = NettyUtils.createEventLoop(CHANNEL_TYPE,
-      TACHYON_CONF.getInt(Constants.USER_NETTY_WORKER_THREADS, 1), "netty-client-worker-%d", true);
+      TACHYON_CONF.getInt(Constants.USER_NETTY_WORKER_THREADS, 0), "netty-client-worker-%d", true);
 
   private final Bootstrap mClientBootstrap;
   private final ClientHandler mHandler;

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -49,9 +49,9 @@ import tachyon.network.protocol.RPCResponse;
  * Read data from remote data server using Netty.
  */
 public final class NettyRemoteBlockReader implements RemoteBlockReader {
-
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
+  // Share both the encoder and decoder with all the client pipelines.
   private static final RPCMessageEncoder ENCODER = new RPCMessageEncoder();
   private static final RPCMessageDecoder DECODER = new RPCMessageDecoder();
 

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -94,12 +94,16 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
       if (response.getType() == RPCMessage.Type.RPC_BLOCK_RESPONSE) {
         RPCBlockResponse blockResponse = (RPCBlockResponse) response;
         LOG.info("Data " + blockId + " from remote machine " + address + " received");
+
+        if (blockResponse.getBlockId() < 0) {
+          LOG.info("Data " + blockResponse.getBlockId() + " is not in remote machine.");
+          return null;
+        }
         return blockResponse.getPayloadDataBuffer().getReadOnlyByteBuffer();
       }
     } catch (Exception e) {
-      LOG.error("exception in netty client: " + e.getMessage());
+      LOG.error("exception in netty client: " + e + " message: " + e.getMessage());
     }
-
     return null;
   }
 

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -71,8 +71,8 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
 
   // TODO: Creating a new remote block reader may be expensive, so consider a connection pool.
   public NettyRemoteBlockReader() {
-    mClientBootstrap = createClientBootstrap();
     mHandler = new ClientHandler();
+    mClientBootstrap = createClientBootstrap();
   }
 
   @Override

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -57,14 +57,13 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
 
   private static final TachyonConf TACHYON_CONF = new TachyonConf();
   private static final ChannelType CHANNEL_TYPE = TACHYON_CONF.getEnum(
-      Constants.WORKER_NETWORK_NETTY_CHANNEL, ChannelType.defaultType());
+      Constants.USER_NETTY_CHANNEL, ChannelType.defaultType());
   private static final Class<? extends SocketChannel> CLIENT_CHANNEL_CLASS = NettyUtils
       .getClientChannelClass(CHANNEL_TYPE);
   // Reuse EventLoopGroup for all clients.
   // Use daemon threads so the JVM is allowed to shutdown even when daemon threads are alive.
-  private static final EventLoopGroup WORKER_GROUP = NettyUtils
-      .createEventLoop(CHANNEL_TYPE, TACHYON_CONF.getInt(Constants.WORKER_NETTY_WORKER_THREADS, 1),
-          "netty-client-worker-%d", true);
+  private static final EventLoopGroup WORKER_GROUP = NettyUtils.createEventLoop(CHANNEL_TYPE,
+      TACHYON_CONF.getInt(Constants.USER_NETTY_WORKER_THREADS, 1), "netty-client-worker-%d", true);
 
   private final Bootstrap mClientBootstrap;
   private final ClientHandler mHandler;

--- a/clients/unshaded/src/main/java/tachyon/client/netty/SingleResponseListener.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/SingleResponseListener.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.client.netty;
+
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.SettableFuture;
+
+import tachyon.Constants;
+import tachyon.network.protocol.RPCResponse;
+
+public final class SingleResponseListener implements ClientHandler.ResponseListener {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
+  private SettableFuture<RPCResponse> mResponse = SettableFuture.create();
+
+  @Override
+  public void onResponseReceived(RPCResponse response) {
+    mResponse.set(response);
+  }
+
+  public RPCResponse get() throws ExecutionException, InterruptedException {
+    return mResponse.get();
+  }
+
+  public RPCResponse get(long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return mResponse.get(timeout, unit);
+  }
+}

--- a/clients/unshaded/src/main/java/tachyon/client/netty/SingleResponseListener.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/SingleResponseListener.java
@@ -41,10 +41,27 @@ public final class SingleResponseListener implements ClientHandler.ResponseListe
     mResponse.set(response);
   }
 
+  /**
+   * Waits to receive the response and returns the response message.
+   *
+   * @return The {@link RPCResponse} received from the remote server.
+   * @throws ExecutionException
+   * @throws InterruptedException
+   */
   public RPCResponse get() throws ExecutionException, InterruptedException {
     return mResponse.get();
   }
 
+  /**
+   * Waits to receive the response for at most a specified time, and returns the response message.
+   *
+   * @param timeout the maximum amount of time to wait.
+   * @param unit the {@link TimeUnit} of the timeout parameter.
+   * @return The {@link RPCResponse} received from the remote server.
+   * @throws InterruptedException
+   * @throws ExecutionException
+   * @throws TimeoutException
+   */
   public RPCResponse get(long timeout, TimeUnit unit)
       throws InterruptedException, ExecutionException, TimeoutException {
     return mResponse.get(timeout, unit);

--- a/clients/unshaded/src/main/java/tachyon/client/netty/SingleResponseListener.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/SingleResponseListener.java
@@ -28,6 +28,9 @@ import com.google.common.util.concurrent.SettableFuture;
 import tachyon.Constants;
 import tachyon.network.protocol.RPCResponse;
 
+/**
+ * A simple listener that waits for a single {@link RPCResponse} message from the remote server.
+ */
 public final class SingleResponseListener implements ClientHandler.ResponseListener {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.23.Final</version>
+      <version>4.0.28.Final</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -203,12 +203,16 @@ public class Constants {
   public static final String USER_FILE_BUFFER_BYTES = "tachyon.user.file.buffer.bytes";
   public static final String USER_HEARTBEAT_INTERVAL_MS = "tachyon.user.heartbeat.interval.ms";
   public static final String USER_DEFAULT_BLOCK_SIZE_BYTE = "tachyon.user.default.block.size.byte";
+  public static final String USER_NETTY_WORKER_THREADS =
+      "tachyon.user.network.netty.worker.threads";
+  public static final String USER_NETTY_CHANNEL = "tachyon.user.network.netty.channel";
   public static final String USER_REMOTE_READ_BUFFER_SIZE_BYTE =
       "tachyon.user.remote.read.buffer.size.byte";
   public static final String USER_DEFAULT_WRITE_TYPE = "tachyon.user.file.writetype.default";
   public static final String USER_REMOTE_BLOCK_READER = "tachyon.user.remote.block.reader.class";
   public static final String USER_ENABLE_LOCAL_READ = "tachyon.user.localread.enable";
   public static final String USER_ENABLE_LOCAL_WRITE = "tachyon.user.localwrite.enable";
+
 
   public static final String S3_ACCESS_KEY = "fs.s3n.awsAccessKeyId";
   public static final String S3_SECRET_KEY = "fs.s3n.awsSecretAccessKey";

--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -213,7 +213,6 @@ public class Constants {
   public static final String USER_ENABLE_LOCAL_READ = "tachyon.user.localread.enable";
   public static final String USER_ENABLE_LOCAL_WRITE = "tachyon.user.localwrite.enable";
 
-
   public static final String S3_ACCESS_KEY = "fs.s3n.awsAccessKeyId";
   public static final String S3_SECRET_KEY = "fs.s3n.awsSecretAccessKey";
 

--- a/common/src/main/java/tachyon/network/NettyUtils.java
+++ b/common/src/main/java/tachyon/network/NettyUtils.java
@@ -21,8 +21,11 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
 
 import tachyon.util.ThreadFactoryUtils;
 
@@ -62,6 +65,22 @@ public final class NettyUtils {
         return NioServerSocketChannel.class;
       case EPOLL:
         return EpollServerSocketChannel.class;
+      default:
+        throw new IllegalArgumentException("Unknown io type: " + type);
+    }
+  }
+
+  /**
+   * Returns the correct SocketChannel class based on ChannelType.
+   *
+   * @param type Selector for which form of low-level IO we should use
+   */
+  public static Class<? extends SocketChannel> getClientChannelClass(ChannelType type) {
+    switch (type) {
+      case NIO:
+        return NioSocketChannel.class;
+      case EPOLL:
+        return EpollSocketChannel.class;
       default:
         throw new IllegalArgumentException("Unknown io type: " + type);
     }

--- a/common/src/main/java/tachyon/network/NettyUtils.java
+++ b/common/src/main/java/tachyon/network/NettyUtils.java
@@ -39,10 +39,12 @@ public final class NettyUtils {
    * @param numThreads
    * @param threadPrefix name pattern for each thread. should contain '%d' to distinguish between
    *        threads.
+   * @param daemonThreads if true, the {@link java.util.concurrent.ThreadFactory} will create
+   *                      daemon threads.
    */
   public static EventLoopGroup createEventLoop(ChannelType type, int numThreads,
-      String threadPrefix) {
-    ThreadFactory threadFactory = ThreadFactoryUtils.build(threadPrefix);
+      String threadPrefix, boolean daemonThreads) {
+    ThreadFactory threadFactory = ThreadFactoryUtils.build(threadPrefix, daemonThreads);
 
     switch (type) {
       case NIO:

--- a/common/src/main/java/tachyon/network/NettyUtils.java
+++ b/common/src/main/java/tachyon/network/NettyUtils.java
@@ -39,12 +39,12 @@ public final class NettyUtils {
    * @param numThreads
    * @param threadPrefix name pattern for each thread. should contain '%d' to distinguish between
    *        threads.
-   * @param daemonThreads if true, the {@link java.util.concurrent.ThreadFactory} will create
-   *                      daemon threads.
+   * @param isDaemon if true, the {@link java.util.concurrent.ThreadFactory} will create
+   *                 daemon threads.
    */
   public static EventLoopGroup createEventLoop(ChannelType type, int numThreads,
-      String threadPrefix, boolean daemonThreads) {
-    ThreadFactory threadFactory = ThreadFactoryUtils.build(threadPrefix, daemonThreads);
+      String threadPrefix, boolean isDaemon) {
+    ThreadFactory threadFactory = ThreadFactoryUtils.build(threadPrefix, isDaemon);
 
     switch (type) {
       case NIO:

--- a/common/src/main/java/tachyon/network/protocol/RPCBlockResponse.java
+++ b/common/src/main/java/tachyon/network/protocol/RPCBlockResponse.java
@@ -71,6 +71,7 @@ public class RPCBlockResponse extends RPCResponse {
     long length = in.readLong();
     DataBuffer data = null;
     if (length > 0) {
+      // TODO: look into accessing Netty ByteBuf directly, to avoid copying the data.
       ByteBuffer buffer = ByteBuffer.allocate((int) length);
       in.readBytes(buffer);
       data = new DataByteBuffer(buffer, (int) length);

--- a/common/src/main/java/tachyon/util/ThreadFactoryUtils.java
+++ b/common/src/main/java/tachyon/util/ThreadFactoryUtils.java
@@ -23,22 +23,14 @@ public final class ThreadFactoryUtils {
   private ThreadFactoryUtils() {}
 
   /**
-   * Creates a {@link java.util.concurrent.ThreadFactory} that spawns off daemon threads.
-   * 
-   * @param nameFormat name pattern for each thread. should contain '%d' to distinguish between
-   *        threads.
-   */
-  public static ThreadFactory daemon(final String nameFormat) {
-    return new ThreadFactoryBuilder().setDaemon(true).setNameFormat(nameFormat).build();
-  }
-
-  /**
    * Creates a {@link java.util.concurrent.ThreadFactory} that spawns off threads.
    *
    * @param nameFormat name pattern for each thread. should contain '%d' to distinguish between
    *        threads.
+   * @param daemonThreads if true, the {@link java.util.concurrent.ThreadFactory} will create
+   *                      daemon threads.
    */
-  public static ThreadFactory build(final String nameFormat) {
-    return new ThreadFactoryBuilder().setDaemon(false).setNameFormat(nameFormat).build();
+  public static ThreadFactory build(final String nameFormat, boolean daemonThreads) {
+    return new ThreadFactoryBuilder().setDaemon(daemonThreads).setNameFormat(nameFormat).build();
   }
 }

--- a/common/src/main/java/tachyon/util/ThreadFactoryUtils.java
+++ b/common/src/main/java/tachyon/util/ThreadFactoryUtils.java
@@ -27,10 +27,10 @@ public final class ThreadFactoryUtils {
    *
    * @param nameFormat name pattern for each thread. should contain '%d' to distinguish between
    *        threads.
-   * @param daemonThreads if true, the {@link java.util.concurrent.ThreadFactory} will create
-   *                      daemon threads.
+   * @param isDaemon if true, the {@link java.util.concurrent.ThreadFactory} will create
+   *                 daemon threads.
    */
-  public static ThreadFactory build(final String nameFormat, boolean daemonThreads) {
-    return new ThreadFactoryBuilder().setDaemon(daemonThreads).setNameFormat(nameFormat).build();
+  public static ThreadFactory build(final String nameFormat, boolean isDaemon) {
+    return new ThreadFactoryBuilder().setDaemon(isDaemon).setNameFormat(nameFormat).build();
   }
 }

--- a/common/src/main/resources/tachyon-default.properties
+++ b/common/src/main/resources/tachyon-default.properties
@@ -85,3 +85,4 @@ tachyon.user.quota.unit.bytes=8MB
 tachyon.user.file.buffer.bytes=1MB
 tachyon.user.remote.block.reader.class=tachyon.client.tcp.TCPRemoteBlockReader
 tachyon.user.remote.read.buffer.size.byte=8MB
+tachyon.user.network.netty.worker.threads=1

--- a/common/src/main/resources/tachyon-default.properties
+++ b/common/src/main/resources/tachyon-default.properties
@@ -85,4 +85,4 @@ tachyon.user.quota.unit.bytes=8MB
 tachyon.user.file.buffer.bytes=1MB
 tachyon.user.remote.block.reader.class=tachyon.client.tcp.TCPRemoteBlockReader
 tachyon.user.remote.read.buffer.size.byte=8MB
-tachyon.user.network.netty.worker.threads=1
+tachyon.user.network.netty.worker.threads=0

--- a/integration-tests/src/test/java/tachyon/IntegrationTestConstants.java
+++ b/integration-tests/src/test/java/tachyon/IntegrationTestConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon;
+
+/**
+ * Constants for integration tests.
+ */
+public class IntegrationTestConstants {
+  // DataServer variations.
+  public static final String NETTY_DATA_SERVER = "tachyon.worker.netty.NettyDataServer";
+  public static final String NIO_DATA_SERVER = "tachyon.worker.nio.NIODataServer";
+
+  // Remote block reader variations.
+  public static final String TCP_BLOCK_READER = "tachyon.client.tcp.TCPRemoteBlockReader";
+  public static final String NETTY_BLOCK_READER = "tachyon.client.netty.NettyRemoteBlockReader";
+
+  // Netty transfer types.
+  public static final String MAPPED_TRANSFER = "MAPPED";
+  public static final String FILE_CHANNEL_TRANSFER = "TRANSFER";
+  public static final String UNUSED_TRANSFER = "UNUSED";
+}

--- a/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
@@ -56,8 +56,12 @@ public class RemoteBlockInStreamIntegrationTest {
     List<Object[]> list = new ArrayList<Object[]>();
     list.add(new Object[] { new String[] { "tachyon.worker.netty.NettyDataServer",
         "tachyon.client.tcp.TCPRemoteBlockReader" } });
+    list.add(new Object[] { new String[] { "tachyon.worker.netty.NettyDataServer",
+        "tachyon.client.netty.NettyRemoteBlockReader" } });
     list.add(new Object[] { new String[] { "tachyon.worker.nio.NIODataServer",
         "tachyon.client.tcp.TCPRemoteBlockReader" } });
+    list.add(new Object[] { new String[] { "tachyon.worker.nio.NIODataServer",
+        "tachyon.client.netty.NettyRemoteBlockReader" } });
     return list;
   }
 

--- a/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import tachyon.Constants;
+import tachyon.IntegrationTestConstants;
 import tachyon.TachyonURI;
 import tachyon.TestUtils;
 import tachyon.conf.TachyonConf;
@@ -54,14 +55,14 @@ public class RemoteBlockInStreamIntegrationTest {
   public static Collection<Object[]> data() {
     // creates a new instance of RemoteBlockInStreamTest for each network type
     List<Object[]> list = new ArrayList<Object[]>();
-    list.add(new Object[] { new String[] { "tachyon.worker.netty.NettyDataServer",
-        "tachyon.client.tcp.TCPRemoteBlockReader" } });
-    list.add(new Object[] { new String[] { "tachyon.worker.netty.NettyDataServer",
-        "tachyon.client.netty.NettyRemoteBlockReader" } });
-    list.add(new Object[] { new String[] { "tachyon.worker.nio.NIODataServer",
-        "tachyon.client.tcp.TCPRemoteBlockReader" } });
-    list.add(new Object[] { new String[] { "tachyon.worker.nio.NIODataServer",
-        "tachyon.client.netty.NettyRemoteBlockReader" } });
+    list.add(new Object[] { new String[] { IntegrationTestConstants.NETTY_DATA_SERVER,
+        IntegrationTestConstants.TCP_BLOCK_READER } });
+    list.add(new Object[] { new String[] { IntegrationTestConstants.NETTY_DATA_SERVER,
+        IntegrationTestConstants.NETTY_BLOCK_READER } });
+    list.add(new Object[] { new String[] { IntegrationTestConstants.NIO_DATA_SERVER,
+        IntegrationTestConstants.TCP_BLOCK_READER } });
+    list.add(new Object[] { new String[] { IntegrationTestConstants.NIO_DATA_SERVER,
+        IntegrationTestConstants.NETTY_BLOCK_READER } });
     return list;
   }
 

--- a/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
@@ -84,6 +84,7 @@ public class DataServerIntegrationTest {
     mLocalTachyonCluster.stop();
     System.clearProperty(Constants.WORKER_DATA_SERVER);
     System.clearProperty(Constants.WORKER_NETTY_FILE_TRANSFER_TYPE);
+    System.clearProperty(Constants.USER_REMOTE_BLOCK_READER);
   }
 
   /**
@@ -116,6 +117,8 @@ public class DataServerIntegrationTest {
   public final void before() throws IOException {
     System.setProperty(Constants.WORKER_DATA_SERVER, mDataServerClass);
     System.setProperty(Constants.WORKER_NETTY_FILE_TRANSFER_TYPE, mNettyTransferType);
+    System.setProperty(Constants.USER_REMOTE_BLOCK_READER,
+        "tachyon.client.netty.NettyRemoteBlockReader");
     mLocalTachyonCluster = new LocalTachyonCluster(WORKER_CAPACITY_BYTES, USER_QUOTA_UNIT_BYTES,
         Constants.GB);
     mLocalTachyonCluster.start();

--- a/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import tachyon.Constants;
+import tachyon.IntegrationTestConstants;
 import tachyon.TachyonURI;
 import tachyon.TestUtils;
 import tachyon.client.RemoteBlockReader;
@@ -53,30 +54,29 @@ public class DataServerIntegrationTest {
   private static final int WORKER_CAPACITY_BYTES = 1000;
   private static final int USER_QUOTA_UNIT_BYTES = 100;
 
-  // DataServer variations.
-  private static final String NETTY_DATA_SERVER = "tachyon.worker.netty.NettyDataServer";
-  private static final String NIO_DATA_SERVER = "tachyon.worker.nio.NIODataServer";
-
-  // Netty transfer variations.
-  private static final String MAPPED_TRANSFER = "MAPPED";
-  private static final String FILE_CHANNEL_TRANSFER = "TRANSFER";
-  private static final String UNUSED_TRANSFER = "UNUSED";
-
-  // Remote block reader variations.
-  private static final String TCP_BLOCK_READER = "tachyon.client.tcp.TCPRemoteBlockReader";
-  private static final String NETTY_BLOCK_READER = "tachyon.client.netty.NettyRemoteBlockReader";
-
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     // Creates a new instance of DataServerTest for different combinations of parameters..
     List<Object[]> list = new ArrayList<Object[]>();
-    list.add(new Object[] { NETTY_DATA_SERVER, MAPPED_TRANSFER, TCP_BLOCK_READER });
-    list.add(new Object[] { NETTY_DATA_SERVER, MAPPED_TRANSFER, NETTY_BLOCK_READER });
-    list.add(new Object[] { NETTY_DATA_SERVER, FILE_CHANNEL_TRANSFER, TCP_BLOCK_READER });
-    list.add(new Object[] { NETTY_DATA_SERVER, FILE_CHANNEL_TRANSFER, NETTY_BLOCK_READER });
+    list.add(new Object[] { IntegrationTestConstants.NETTY_DATA_SERVER,
+        IntegrationTestConstants.MAPPED_TRANSFER,
+        IntegrationTestConstants.TCP_BLOCK_READER });
+    list.add(new Object[] { IntegrationTestConstants.NETTY_DATA_SERVER,
+        IntegrationTestConstants.MAPPED_TRANSFER,
+        IntegrationTestConstants.NETTY_BLOCK_READER });
+    list.add(new Object[] { IntegrationTestConstants.NETTY_DATA_SERVER,
+        IntegrationTestConstants.FILE_CHANNEL_TRANSFER,
+        IntegrationTestConstants.TCP_BLOCK_READER });
+    list.add(new Object[] { IntegrationTestConstants.NETTY_DATA_SERVER,
+        IntegrationTestConstants.FILE_CHANNEL_TRANSFER,
+        IntegrationTestConstants.NETTY_BLOCK_READER });
     // The transfer type is not applicable to the NIODataServer.
-    list.add(new Object[] { NIO_DATA_SERVER, UNUSED_TRANSFER, TCP_BLOCK_READER });
-    list.add(new Object[] { NIO_DATA_SERVER, UNUSED_TRANSFER, NETTY_BLOCK_READER });
+    list.add(new Object[] { IntegrationTestConstants.NIO_DATA_SERVER,
+        IntegrationTestConstants.UNUSED_TRANSFER,
+        IntegrationTestConstants.TCP_BLOCK_READER });
+    list.add(new Object[] { IntegrationTestConstants.NIO_DATA_SERVER,
+        IntegrationTestConstants.UNUSED_TRANSFER,
+        IntegrationTestConstants.NETTY_BLOCK_READER });
     return list;
   }
 

--- a/servers/pom.xml
+++ b/servers/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.23.Final</version>
+      <version>4.0.28.Final</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -84,7 +84,7 @@ public class TachyonMaster {
   private int mMinWorkerThreads;
   private boolean mZookeeperMode = false;
   private final ExecutorService mExecutorService = Executors.newFixedThreadPool(2,
-      ThreadFactoryUtils.daemon("heartbeat-master-%d"));
+      ThreadFactoryUtils.build("heartbeat-master-%d", true));
 
   private LeaderSelectorClient mLeaderSelectorClient = null;
 

--- a/servers/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/servers/src/main/java/tachyon/worker/TachyonWorker.java
@@ -151,7 +151,7 @@ public class TachyonWorker implements Runnable {
   private final int mPort;
   private final int mDataPort;
   private final ExecutorService mExecutorService = Executors.newFixedThreadPool(1,
-      ThreadFactoryUtils.daemon("heartbeat-worker-%d"));
+      ThreadFactoryUtils.build("heartbeat-worker-%d", true));
   private final TachyonConf mTachyonConf;
 
   /**

--- a/servers/src/main/java/tachyon/worker/WorkerStorage.java
+++ b/servers/src/main/java/tachyon/worker/WorkerStorage.java
@@ -334,7 +334,8 @@ public class WorkerStorage {
 
     int checkpointThreads = mTachyonConf.getInt(Constants.WORKER_CHECKPOINT_THREADS, 1);
     mCheckpointExecutor =
-        Executors.newFixedThreadPool(checkpointThreads, ThreadFactoryUtils.build("checkpoint-%d"));
+        Executors.newFixedThreadPool(checkpointThreads,ThreadFactoryUtils.build("checkpoint-%d",
+            false));
 
     mWorkerSource = new WorkerSource(this);
   }

--- a/servers/src/main/java/tachyon/worker/netty/NettyDataServer.java
+++ b/servers/src/main/java/tachyon/worker/netty/NettyDataServer.java
@@ -122,9 +122,9 @@ public final class NettyDataServer implements DataServer {
     final int bossThreadCount = mTachyonConf.getInt(Constants.WORKER_NETTY_BOSS_THREADS, 1);
     final int workerThreadCount = mTachyonConf.getInt(Constants.WORKER_NETTY_WORKER_THREADS, 0);
     final EventLoopGroup bossGroup =
-        NettyUtils.createEventLoop(type, bossThreadCount, "data-server-boss-%d");
+        NettyUtils.createEventLoop(type, bossThreadCount, "data-server-boss-%d", false);
     final EventLoopGroup workerGroup =
-        NettyUtils.createEventLoop(type, workerThreadCount, "data-server-worker-%d");
+        NettyUtils.createEventLoop(type, workerThreadCount, "data-server-worker-%d", false);
 
     final Class<? extends ServerChannel> socketChannelClass =
         NettyUtils.getServerChannelClass(type);

--- a/servers/src/main/java/tachyon/worker/netty/NettyDataServer.java
+++ b/servers/src/main/java/tachyon/worker/netty/NettyDataServer.java
@@ -120,6 +120,7 @@ public final class NettyDataServer implements DataServer {
   private ServerBootstrap createBootstrapOfType(final ChannelType type) {
     final ServerBootstrap boot = new ServerBootstrap();
     final int bossThreadCount = mTachyonConf.getInt(Constants.WORKER_NETTY_BOSS_THREADS, 1);
+    // If number of worker threads is 0, Netty creates (#processors * 2) threads by default.
     final int workerThreadCount = mTachyonConf.getInt(Constants.WORKER_NETTY_WORKER_THREADS, 0);
     final EventLoopGroup bossGroup =
         NettyUtils.createEventLoop(type, bossThreadCount, "data-server-boss-%d", false);


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-495

This PR introduces a new remote block reader that uses Netty to communicate with the network. The Netty based block reader should eventually replace the existing TCP one, since Netty is far easier to maintain/extend.