### PR TITLE
Update the dir in BlockMeta when moving BlockMeta

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -187,8 +187,10 @@ public class BlockMetadataManager {
     }
     StorageDir oldDir = blockMeta.getParentDir();
     oldDir.removeBlockMeta(blockMeta);
-    newDir.addBlockMeta(blockMeta);
-    return blockMeta;
+    BlockMeta newBlockMeta =
+        new BlockMeta(blockMeta.getBlockId(), blockMeta.getBlockSize(), newDir);
+    newDir.addBlockMeta(newBlockMeta);
+    return newBlockMeta;
   }
 
   /**


### PR DESCRIPTION
The storage dir in BlockMeta need to be updated when we move a BlockMeta.