### PR TITLE
[TACHYON-444] Fix test-jar dependencies

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -236,7 +236,7 @@
           </testExcludes>
         </configuration>
       </plugin>
-        <!-- TODO: Remove this generation when TachyonFSTestUtils is fixed. -->
+      <!-- TODO: Remove this generation when TachyonFSTestUtils is fixed. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -236,6 +236,18 @@
           </testExcludes>
         </configuration>
       </plugin>
+        <!-- TODO: Remove this generation when TachyonFSTestUtils is fixed. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/servers/pom.xml
+++ b/servers/pom.xml
@@ -124,4 +124,20 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -54,11 +54,17 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- TODO: consider better way to reference LocalTachyonCluster -->
+      <!-- TODO: remove this dependency for TachyonFSTestUtils -->
       <groupId>org.tachyonproject</groupId>
       <artifactId>tachyon-integration-tests</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.tachyonproject</groupId>
+      <artifactId>tachyon-minicluster</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
While many of the dependencies were extracted, there are still a few classes that are required by other tests, so the test jars are still necessary.