### PR TITLE
[TACHYON-576] [TACHYON-577] remove redundant modifier private in enum constructor

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/ReadType.java
+++ b/clients/unshaded/src/main/java/tachyon/client/ReadType.java
@@ -36,7 +36,7 @@ public enum ReadType {
 
   private final int mValue;
 
-  private ReadType(int value) {
+  ReadType(int value) {
     mValue = value;
   }
 

--- a/clients/unshaded/src/main/java/tachyon/client/WriteType.java
+++ b/clients/unshaded/src/main/java/tachyon/client/WriteType.java
@@ -42,7 +42,7 @@ public enum WriteType {
 
   private final int mValue;
 
-  private WriteType(int value) {
+  WriteType(int value) {
     mValue = value;
   }
 


### PR DESCRIPTION
[TACHYON-577] Remove redundant modifier "private" in tachyon.client.ReadType constructor
[TACHYON-576] Remove redundant modifier "private" in tachyon.client.WriteType constructor