### PR TITLE
[TACHYON-565] Fix String equals bug in CommonUtils

### DIFF
--- a/common/src/main/java/tachyon/util/CommonUtils.java
+++ b/common/src/main/java/tachyon/util/CommonUtils.java
@@ -170,7 +170,7 @@ public final class CommonUtils {
       String trimmedPath;
       if (k == 0) {
         trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimTrailingFrom(path);
-        if (path.startsWith("/")) {
+        if (path.startsWith(TachyonURI.SEPARATOR)) {
           isAbsPath = true;
         }
       } else {
@@ -182,7 +182,7 @@ public final class CommonUtils {
       trimmedPathList.add(trimmedPath);
     }
     if (trimmedPathList.size() == 1 && trimmedPathList.get(0).isEmpty() && isAbsPath) {
-      return "/";
+      return TachyonURI.SEPARATOR;
     }
     return Joiner.on(TachyonURI.SEPARATOR).join(trimmedPathList);
   }

--- a/common/src/main/java/tachyon/util/CommonUtils.java
+++ b/common/src/main/java/tachyon/util/CommonUtils.java
@@ -166,32 +166,22 @@ public final class CommonUtils {
    */
   public static String concatPath(Object... paths) {
     List<String> trimmedPathList = new ArrayList<String>();
-    String joinedPath;
-    String prefix = null;
-    if (paths.length == 0) {
-      return "";
-    }
-    if (paths[0] != null && !paths[0].toString().isEmpty()) {
-      prefix = paths[0].toString().trim();
-      prefix = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimTrailingFrom(prefix);
+    if (paths.length > 0 && paths[0] != null && !paths[0].toString().isEmpty()) {
+      trimmedPathList.add(CharMatcher.is(
+          TachyonURI.SEPARATOR.charAt(0)).trimTrailingFrom(paths[0].toString().trim()));
     }
     for (int k = 1; k < paths.length; ++ k) {
       String path = paths[k].toString().trim();
-      trimmedPathList.add(CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimFrom(path));
-    }
-    joinedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).collapseFrom(
-      Joiner.on(TachyonURI.SEPARATOR).join(trimmedPathList), TachyonURI.SEPARATOR.charAt(0));
-    if (prefix == null) {
-      return joinedPath;
-    }
-    if (joinedPath.isEmpty()) {
-      if (prefix.isEmpty()) {
-        return TachyonURI.SEPARATOR;
-      } else {
-        return prefix;
+      String trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimFrom(path);
+      if (!trimmedPath.isEmpty()) {
+        trimmedPathList.add(trimmedPath);
       }
     }
-    return prefix + TachyonURI.SEPARATOR + joinedPath;
+    if (trimmedPathList.size() == 1 && trimmedPathList.get(0).isEmpty()) {
+      // path[0] must be "[/]+"
+      return TachyonURI.SEPARATOR;
+    }
+    return Joiner.on(TachyonURI.SEPARATOR).join(trimmedPathList);
   }
 
   public static ByteBuffer generateNewByteBufferFromThriftRPCResults(ByteBuffer data) {

--- a/common/src/main/java/tachyon/util/CommonUtils.java
+++ b/common/src/main/java/tachyon/util/CommonUtils.java
@@ -159,20 +159,28 @@ public final class CommonUtils {
    * For example, {@code concatPath("/myroot/", "dir", 1L, "filename")} returns
    * {@code "/myroot/dir/1/filename"}, or
    * {@code concatPath("tachyon://myroot", "dir", "filename")} returns
-   * {@code "tachyon://myroot/dir/filename"}.
+   * {@code "tachyon://myroot/dir/filename"}. Note that a null element in paths
+   * is treated as empty string, i.e., "".
    *
    * @param paths to concatenate
    * @return joined path
+   * @throws IllegalArgumentException
    */
-  public static String concatPath(Object... paths) {
+  public static String concatPath(Object... paths) throws IllegalArgumentException {
     List<String> trimmedPathList = new ArrayList<String>();
+    if (paths == null) {
+      throw new IllegalArgumentException("Can not concatenate a null set of paths.");
+    }
     if (paths.length > 0 && paths[0] != null && !paths[0].toString().isEmpty()) {
       trimmedPathList.add(CharMatcher.is(
           TachyonURI.SEPARATOR.charAt(0)).trimTrailingFrom(paths[0].toString().trim()));
     }
     for (int k = 1; k < paths.length; ++ k) {
-      String path = paths[k].toString().trim();
-      String trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimFrom(path);
+      if (paths[k] == null) {
+        continue;
+      }
+      String trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimFrom(
+          paths[k].toString().trim());
       if (!trimmedPath.isEmpty()) {
         trimmedPathList.add(trimmedPath);
       }

--- a/common/src/main/java/tachyon/util/CommonUtils.java
+++ b/common/src/main/java/tachyon/util/CommonUtils.java
@@ -164,11 +164,15 @@ public final class CommonUtils {
    */
   public static String concatPath(Object... paths) {
     List<String> trimmedPathList = new ArrayList<String>();
+    boolean isAbsPath = false;
     for (int k = 0; k < paths.length; k ++) {
       String path = paths[k].toString().trim();
       String trimmedPath;
       if (k == 0) {
         trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimTrailingFrom(path);
+        if (path.startsWith("/")) {
+          isAbsPath = true;
+        }
       } else {
         trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimFrom(path);
         if (trimmedPath == null || trimmedPath.isEmpty()) {
@@ -176,6 +180,9 @@ public final class CommonUtils {
         }
       }
       trimmedPathList.add(trimmedPath);
+    }
+    if (trimmedPathList.size() == 1 && trimmedPathList.get(0).isEmpty() && isAbsPath) {
+      return "/";
     }
     return Joiner.on(TachyonURI.SEPARATOR).join(trimmedPathList);
   }

--- a/common/src/main/java/tachyon/util/CommonUtils.java
+++ b/common/src/main/java/tachyon/util/CommonUtils.java
@@ -168,19 +168,22 @@ public final class CommonUtils {
    */
   public static String concatPath(Object... paths) throws IllegalArgumentException {
     List<String> trimmedPathList = new ArrayList<String>();
+    String path;
+    String trimmedPath;
     if (paths == null) {
       throw new IllegalArgumentException("Can not concatenate a null set of paths.");
     }
     if (paths.length > 0 && paths[0] != null && !paths[0].toString().isEmpty()) {
-      trimmedPathList.add(CharMatcher.is(
-          TachyonURI.SEPARATOR.charAt(0)).trimTrailingFrom(paths[0].toString().trim()));
+      path = paths[0].toString().trim();
+      trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimTrailingFrom(path);
+      trimmedPathList.add(trimmedPath);
     }
-    for (int k = 1; k < paths.length; ++ k) {
+    for (int k = 1; k < paths.length; k ++) {
       if (paths[k] == null) {
         continue;
       }
-      String trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimFrom(
-          paths[k].toString().trim());
+      path = paths[k].toString().trim();
+      trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimFrom(path);
       if (!trimmedPath.isEmpty()) {
         trimmedPathList.add(trimmedPath);
       }

--- a/common/src/main/java/tachyon/util/CommonUtils.java
+++ b/common/src/main/java/tachyon/util/CommonUtils.java
@@ -167,19 +167,19 @@ public final class CommonUtils {
    * @throws IllegalArgumentException
    */
   public static String concatPath(Object... paths) throws IllegalArgumentException {
-    List<String> trimmedPathList = new ArrayList<String>();
-    String path;
-    String trimmedPath;
-    if (paths == null) {
+    if (null == paths) {
       throw new IllegalArgumentException("Can not concatenate a null set of paths.");
     }
+    String path;
+    String trimmedPath;
+    List<String> trimmedPathList = new ArrayList<String>();
     if (paths.length > 0 && paths[0] != null && !paths[0].toString().isEmpty()) {
       path = paths[0].toString().trim();
       trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimTrailingFrom(path);
       trimmedPathList.add(trimmedPath);
     }
     for (int k = 1; k < paths.length; k ++) {
-      if (paths[k] == null) {
+      if (null == paths[k]) {
         continue;
       }
       path = paths[k].toString().trim();
@@ -189,7 +189,7 @@ public final class CommonUtils {
       }
     }
     if (trimmedPathList.size() == 1 && trimmedPathList.get(0).isEmpty()) {
-      // path[0] must be "[/]+"
+      // paths[0] must be "[/]+"
       return TachyonURI.SEPARATOR;
     }
     return Joiner.on(TachyonURI.SEPARATOR).join(trimmedPathList);

--- a/common/src/main/java/tachyon/util/CommonUtils.java
+++ b/common/src/main/java/tachyon/util/CommonUtils.java
@@ -171,7 +171,7 @@ public final class CommonUtils {
         trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimTrailingFrom(path);
       } else {
         trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimFrom(path);
-        if (trimmedPath == "") {
+        if (trimmedPath == NULL || trimmedPath.isEmpty()) {
           continue;
         }
       }

--- a/common/src/main/java/tachyon/util/CommonUtils.java
+++ b/common/src/main/java/tachyon/util/CommonUtils.java
@@ -171,7 +171,7 @@ public final class CommonUtils {
         trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimTrailingFrom(path);
       } else {
         trimmedPath = CharMatcher.is(TachyonURI.SEPARATOR.charAt(0)).trimFrom(path);
-        if (trimmedPath == NULL || trimmedPath.isEmpty()) {
+        if (trimmedPath == null || trimmedPath.isEmpty()) {
           continue;
         }
       }

--- a/common/src/test/java/tachyon/util/CommonUtilsTest.java
+++ b/common/src/test/java/tachyon/util/CommonUtilsTest.java
@@ -65,12 +65,17 @@ public class CommonUtilsTest {
   @Test
   public void concatPath() {
     Assert.assertEquals("", CommonUtils.concatPath());
+    Assert.assertEquals("/", CommonUtils.concatPath("/"));
     Assert.assertEquals("/", CommonUtils.concatPath("/", ""));
     Assert.assertEquals("/bar", CommonUtils.concatPath("/", "bar"));
 
     Assert.assertEquals("foo", CommonUtils.concatPath("foo"));
     Assert.assertEquals("/foo", CommonUtils.concatPath("/foo"));
     Assert.assertEquals("/foo", CommonUtils.concatPath("/foo", ""));
+
+    // Null
+    Assert.assertEquals("/", CommonUtils.concatPath("/", null));
+    Assert.assertEquals("foo", CommonUtils.concatPath(null, "foo"));
 
     // Join base without trailing "/"
     Assert.assertEquals("/foo/bar", CommonUtils.concatPath("/foo", "bar"));

--- a/common/src/test/java/tachyon/util/CommonUtilsTest.java
+++ b/common/src/test/java/tachyon/util/CommonUtilsTest.java
@@ -65,6 +65,7 @@ public class CommonUtilsTest {
   @Test
   public void concatPath() {
     Assert.assertEquals("", CommonUtils.concatPath());
+    Assert.assertEquals("/", CommonUtils.concatPath("/", ""));
     Assert.assertEquals("/bar", CommonUtils.concatPath("/", "bar"));
 
     Assert.assertEquals("foo", CommonUtils.concatPath("foo"));

--- a/common/src/test/java/tachyon/util/CommonUtilsTest.java
+++ b/common/src/test/java/tachyon/util/CommonUtilsTest.java
@@ -99,5 +99,9 @@ public class CommonUtilsTest {
     // Non-string
     Assert.assertEquals("/foo/bar/1", CommonUtils.concatPath("/foo", "bar", 1));
     Assert.assertEquals("/foo/bar/2", CommonUtils.concatPath("/foo", "bar", 2L));
+
+    // Header
+    Assert.assertEquals(Constants.HEADER + "host:port/foo/bar",
+        CommonUtils.concatPath(Constants.HEADER + "host:port", "/foo", "bar"));
   }
 }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-565
Fix [TACHYON-565] Fix String equals bug in CommonUtils.

Previously proposed solution is trimmedPath.equals(""), but it is not null-safe and with potential performance overhead (see http://howtodoinjava.com/2013/03/31/always-use-length-instead-of-equals-to-check-empty-string-in-java/). A null-safe solution is "".equals(trimmedPath), but it does not fall into "continue" when trimmedPath is NULL. I guess the original intention is to "continue" whenever trimmedPath is NULL or empty, though trimFrom(path) will always return "".