### PR TITLE
[TACHYON-596] Improve hash of blockId so mapping to locks is more evenly distributed

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockLockManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockLockManager.java
@@ -74,7 +74,7 @@ public class BlockLockManager {
    * @throws IOException
    */
   public long lockBlock(long userId, long blockId, BlockLockType blockLockType) throws IOException {
-    // hashing blockId into the range of (0, NUM_LOCKS-1)
+    // hashing blockId into the range of [0, NUM_LOCKS-1]
     int hashValue = Math.abs(mHashFunc.hashLong(blockId).asInt()) % NUM_LOCKS;
     ClientRWLock blockLock = mLockArray[hashValue];
     Lock lock;


### PR DESCRIPTION
Original PR to branch 'reabsed_worker_wip' (https://github.com/amplab/tachyon/pull/1029), now directly pull-requesting to master branch because 'reabsed_worker_wip' is merged into master.

The goal of this PR is to improve the mapping from blockId to locks in `BlockLockManager`.

We use `murmur3_32` from Guava as the hashing function, afters apply abs and modulo to make sure `hashValue` falls in [0, NUM_LOCKS-1].

Note #1037 is also closed because of messy commit history.