### PR TITLE
[TACHYON-599] Step1 of "Provide evictors and allocators a narrow view of the block store"

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataView.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataView.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.worker.block;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Preconditions;
+
+import tachyon.worker.block.meta.BlockMeta;
+import tachyon.worker.block.meta.StorageDir;
+import tachyon.worker.block.meta.StorageTier;
+
+/**
+ * This class exposes a narrower view of {@link BlockMetadataManager} to Evictors and Allocators.
+ */
+public class BlockMetadataView {
+
+  private final BlockMetadataManager mMetadataManager;
+
+  public BlockMetadataView(BlockMetadataManager manager) {
+    mMetadataManager = Preconditions.checkNotNull(manager);
+  }
+
+  /**
+   * Redirecting to {@link BlockMetadataManager#getTier(int)}
+   *
+   * @param tierAlias the alias of this tier
+   * @return the StorageTier object associated with the alias
+   * @throws IOException if tierAlias is not found
+   */
+  public synchronized StorageTier getTier(int tierAlias) throws IOException {
+    return mMetadataManager.getTier(tierAlias);
+  }
+
+  /**
+   * Redirecting to {@link BlockMetadataManager#getTiers()}
+   *
+   * @return the list of StorageTiers
+   */
+  public synchronized List<StorageTier> getTiers() {
+    return mMetadataManager.getTiers();
+  }
+
+  /**
+   * Redirecting to {@link BlockMetadataManager#getTiersBelow(int)}
+   *
+   * @param tierAlias the alias of a tier
+   * @return the list of StorageTier
+   * @throws IOException if tierAlias is not found
+   */
+  public synchronized List<StorageTier> getTiersBelow(int tierAlias) throws IOException {
+    return mMetadataManager.getTiersBelow(tierAlias);
+  }
+
+  /**
+   * Redirecting to {@link BlockMetadataManager#getAvailableBytes(BlockStoreLocation)}
+   *
+   * @param location location the check available bytes
+   * @return available bytes
+   */
+  public synchronized long getAvailableBytes(BlockStoreLocation location) throws IOException {
+    return mMetadataManager.getAvailableBytes(location);
+  }
+
+  /**
+   * Redirecting to {@link BlockMetadataManager#getBlockMeta(long)}
+   *
+   * @param blockId the block ID
+   * @return metadata of the block or null
+   * @throws IOException if no BlockMeta for this blockId is found
+   */
+  public synchronized BlockMeta getBlockMeta(long blockId) throws IOException {
+    return getBlockMeta(blockId);
+  }
+}

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -89,16 +89,18 @@ public class TieredBlockStore implements BlockStore {
     mMetaManager = BlockMetadataManager.newBlockMetadataManager(mTachyonConf);
     mLockManager = new BlockLockManager(mMetaManager);
 
+    BlockMetadataView metadataView = new BlockMetadataView(mMetaManager);
+
     AllocatorType allocatorType =
         mTachyonConf.getEnum(Constants.WORKER_ALLOCATE_STRATEGY_TYPE, AllocatorType.DEFAULT);
-    mAllocator = AllocatorFactory.create(allocatorType, mMetaManager);
+    mAllocator = AllocatorFactory.create(allocatorType, metadataView);
     if (mAllocator instanceof BlockStoreEventListener) {
       registerBlockStoreEventListener((BlockStoreEventListener) mAllocator);
     }
 
     EvictorType evictorType =
         mTachyonConf.getEnum(Constants.WORKER_EVICT_STRATEGY_TYPE, EvictorType.DEFAULT);
-    mEvictor = EvictorFactory.create(evictorType, mMetaManager);
+    mEvictor = EvictorFactory.create(evictorType, metadataView);
     if (mEvictor instanceof BlockStoreEventListener) {
       registerBlockStoreEventListener((BlockStoreEventListener) mEvictor);
     }

--- a/servers/src/main/java/tachyon/worker/block/allocator/AllocatorFactory.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/AllocatorFactory.java
@@ -16,7 +16,7 @@
 package tachyon.worker.block.allocator;
 
 
-import tachyon.worker.block.BlockMetadataManager;
+import tachyon.worker.block.BlockMetadataView;
 
 /**
  * Factory of {@link Allocator} based on {@link AllocatorType}
@@ -29,14 +29,14 @@ public class AllocatorFactory {
    * @param metaManager BlockMetadataManager to pass to Allocator
    * @return the generated Allocator
    */
-  public static Allocator create(AllocatorType allocatorType, BlockMetadataManager metaManager) {
+  public static Allocator create(AllocatorType allocatorType, BlockMetadataView metaView) {
     switch (allocatorType) {
       case GREEDY:
-        return new GreedyAllocator(metaManager);
+        return new GreedyAllocator(metaView);
       case MAX_FREE:
-        return new MaxFreeAllocator(metaManager);
+        return new MaxFreeAllocator(metaView);
       default:
-        return new GreedyAllocator(metaManager);
+        return new GreedyAllocator(metaView);
     }
   }
 

--- a/servers/src/main/java/tachyon/worker/block/allocator/GreedyAllocator.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/GreedyAllocator.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 
 import com.google.common.base.Preconditions;
 
+import tachyon.worker.block.BlockMetadataView;
 import tachyon.worker.block.BlockStoreLocation;
-import tachyon.worker.block.BlockMetadataManager;
 import tachyon.worker.block.meta.StorageDir;
 import tachyon.worker.block.meta.StorageTier;
 import tachyon.worker.block.meta.TempBlockMeta;
@@ -30,10 +30,10 @@ import tachyon.worker.block.meta.TempBlockMeta;
  * This class serves as an example how to implement an allocator.
  */
 public class GreedyAllocator implements Allocator {
-  private final BlockMetadataManager mMetaManager;
+  private final BlockMetadataView mMetaView;
 
-  public GreedyAllocator(BlockMetadataManager metadata) {
-    mMetaManager = Preconditions.checkNotNull(metadata);
+  public GreedyAllocator(BlockMetadataView metadata) {
+    mMetaView = Preconditions.checkNotNull(metadata);
   }
 
   @Override
@@ -42,7 +42,7 @@ public class GreedyAllocator implements Allocator {
     if (location.equals(BlockStoreLocation.anyTier())) {
       // When any tier is ok, loop over all storage tier and dir, and return the first dir that has
       // sufficient available space.
-      for (StorageTier tier : mMetaManager.getTiers()) {
+      for (StorageTier tier : mMetaView.getTiers()) {
         for (StorageDir dir : tier.getStorageDirs()) {
           if (dir.getAvailableBytes() >= blockSize) {
             return new TempBlockMeta(userId, blockId, blockSize, dir);
@@ -53,7 +53,7 @@ public class GreedyAllocator implements Allocator {
     }
 
     int tierAlias = location.tierAlias();
-    StorageTier tier = mMetaManager.getTier(tierAlias);
+    StorageTier tier = mMetaView.getTier(tierAlias);
     if (location.equals(BlockStoreLocation.anyDirInTier(tierAlias))) {
       // Loop over all dirs in the given tier
       for (StorageDir dir : tier.getStorageDirs()) {

--- a/servers/src/main/java/tachyon/worker/block/allocator/MaxFreeAllocator.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/MaxFreeAllocator.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 
 import com.google.common.base.Preconditions;
 
+import tachyon.worker.block.BlockMetadataView;
 import tachyon.worker.block.BlockStoreLocation;
-import tachyon.worker.block.BlockMetadataManager;
 import tachyon.worker.block.meta.StorageDir;
 import tachyon.worker.block.meta.StorageTier;
 import tachyon.worker.block.meta.TempBlockMeta;
@@ -29,10 +29,10 @@ import tachyon.worker.block.meta.TempBlockMeta;
  * An allocator that allocates a block in the storage dir with most free space.
  */
 public class MaxFreeAllocator implements Allocator {
-  private final BlockMetadataManager mMetaManager;
+  private final BlockMetadataView mMetaView;
 
-  public MaxFreeAllocator(BlockMetadataManager metadata) {
-    mMetaManager = Preconditions.checkNotNull(metadata);
+  public MaxFreeAllocator(BlockMetadataView metadata) {
+    mMetaView = Preconditions.checkNotNull(metadata);
   }
 
   @Override
@@ -43,7 +43,7 @@ public class MaxFreeAllocator implements Allocator {
     long maxFreeBytes = blockSize;
 
     if (location.equals(BlockStoreLocation.anyTier())) {
-      for (StorageTier tier : mMetaManager.getTiers()) {
+      for (StorageTier tier : mMetaView.getTiers()) {
         for (StorageDir dir : tier.getStorageDirs()) {
           if (dir.getAvailableBytes() >= maxFreeBytes) {
             maxFreeBytes = dir.getAvailableBytes();
@@ -52,7 +52,7 @@ public class MaxFreeAllocator implements Allocator {
         }
       }
     } else if (location.equals(BlockStoreLocation.anyDirInTier(location.tierAlias()))) {
-      StorageTier tier = mMetaManager.getTier(location.tierAlias());
+      StorageTier tier = mMetaView.getTier(location.tierAlias());
       for (StorageDir dir : tier.getStorageDirs()) {
         if (dir.getAvailableBytes() >= maxFreeBytes) {
           maxFreeBytes = dir.getAvailableBytes();
@@ -60,7 +60,7 @@ public class MaxFreeAllocator implements Allocator {
         }
       }
     } else {
-      StorageTier tier = mMetaManager.getTier(location.tierAlias());
+      StorageTier tier = mMetaView.getTier(location.tierAlias());
       StorageDir dir = tier.getDir(location.dir());
       if (dir.getAvailableBytes() >= blockSize) {
         candidateDir = dir;

--- a/servers/src/main/java/tachyon/worker/block/evictor/EvictorFactory.java
+++ b/servers/src/main/java/tachyon/worker/block/evictor/EvictorFactory.java
@@ -15,7 +15,7 @@
 
 package tachyon.worker.block.evictor;
 
-import tachyon.worker.block.BlockMetadataManager;
+import tachyon.worker.block.BlockMetadataView;
 
 /**
  * Factory of {@link Evictor} based on {@link EvictorType}
@@ -30,14 +30,14 @@ public class EvictorFactory {
    * @param metaManager BlockMetadataManager to pass to Evictor
    * @return the generated Evictor
    */
-  public static Evictor create(EvictorType evictorType, BlockMetadataManager metaManager) {
+  public static Evictor create(EvictorType evictorType, BlockMetadataView metaView) {
     switch (evictorType) {
       case GREEDY:
-        return new GreedyEvictor(metaManager);
+        return new GreedyEvictor(metaView);
       case LRU:
-        return new LRUEvictor(metaManager);
+        return new LRUEvictor(metaView);
       default:
-        return new GreedyEvictor(metaManager);
+        return new GreedyEvictor(metaView);
     }
   }
 }


### PR DESCRIPTION
Step1, Use BlockMetadataView as a proxy for BlockMetadataManager in Evictors and Allocators

See more detailed description in [TACHYON-599](https://tachyon.atlassian.net/browse/TACHYON-599)