### PR TITLE
[TACHYON-599] Provide evictors and allocators a narrow view of the block store

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
@@ -358,6 +358,8 @@ public class BlockDataManager {
    */
   // TODO: We should avoid throwing IOException
   public void requestSpace(long userId, long blockId, long additionalBytes) throws IOException {
+    mMasterClient.worker_getPinIdList();
+
     mBlockStore.requestSpace(userId, blockId, additionalBytes);
   }
 

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataView.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataView.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.worker.block;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Preconditions;
+
+import tachyon.worker.block.meta.BlockMeta;
+import tachyon.worker.block.meta.StorageDir;
+import tachyon.worker.block.meta.StorageTier;
+
+/**
+ * This class exposes a narrower view of {@link BlockMetadataManager} to Evictors and Allocators.
+ */
+public class BlockMetadataView {
+
+  private final BlockMetadataManager mMetadataManager;
+
+  public BlockMetadataView(BlockMetadataManager manager) {
+    mMetadataManager = Preconditions.checkNotNull(manager);
+  }
+
+  /**
+   * Redirecting to {@link BlockMetadataManager#getTier(int)}
+   *
+   * @param tierAlias the alias of this tier
+   * @return the StorageTier object associated with the alias
+   * @throws IOException if tierAlias is not found
+   */
+  public synchronized StorageTier getTier(int tierAlias) throws IOException {
+    return mMetadataManager.getTier(tierAlias);
+  }
+
+  /**
+   * Redirecting to {@link BlockMetadataManager#getTiers()}
+   *
+   * @return the list of StorageTiers
+   */
+  public synchronized List<StorageTier> getTiers() {
+    return mMetadataManager.getTiers();
+  }
+
+  /**
+   * Redirecting to {@link BlockMetadataManager#getTiersBelow(int)}
+   *
+   * @param tierAlias the alias of a tier
+   * @return the list of StorageTier
+   * @throws IOException if tierAlias is not found
+   */
+  public synchronized List<StorageTier> getTiersBelow(int tierAlias) throws IOException {
+    return mMetadataManager.getTiersBelow(tierAlias);
+  }
+
+  /**
+   * Redirecting to {@link BlockMetadataManager#getAvailableBytes(BlockStoreLocation)}
+   *
+   * @param location location the check available bytes
+   * @return available bytes
+   */
+  public synchronized long getAvailableBytes(BlockStoreLocation location) throws IOException {
+    return mMetadataManager.getAvailableBytes(location);
+  }
+
+  /**
+   * Redirecting to {@link BlockMetadataManager#getBlockMeta(long)}
+   *
+   * @param blockId the block ID
+   * @return metadata of the block or null
+   * @throws IOException if no BlockMeta for this blockId is found
+   */
+  public synchronized BlockMeta getBlockMeta(long blockId) throws IOException {
+    return getBlockMeta(blockId);
+  }
+}

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -89,18 +89,18 @@ public class TieredBlockStore implements BlockStore {
     mMetaManager = BlockMetadataManager.newBlockMetadataManager(mTachyonConf);
     mLockManager = new BlockLockManager(mMetaManager);
 
-    BlockMetadataView metadataView = new BlockMetadataView(mMetaManager);
+    BlockMetadataView fullMetadataView = new BlockMetadataView(mMetaManager, null, null);
 
     AllocatorType allocatorType =
         mTachyonConf.getEnum(Constants.WORKER_ALLOCATE_STRATEGY_TYPE, AllocatorType.DEFAULT);
-    mAllocator = AllocatorFactory.create(allocatorType, metadataView);
+    mAllocator = AllocatorFactory.create(allocatorType, fullMetadataView);
     if (mAllocator instanceof BlockStoreEventListener) {
       registerBlockStoreEventListener((BlockStoreEventListener) mAllocator);
     }
 
     EvictorType evictorType =
         mTachyonConf.getEnum(Constants.WORKER_EVICT_STRATEGY_TYPE, EvictorType.DEFAULT);
-    mEvictor = EvictorFactory.create(evictorType, metadataView);
+    mEvictor = EvictorFactory.create(evictorType, fullMetadataView);
     if (mEvictor instanceof BlockStoreEventListener) {
       registerBlockStoreEventListener((BlockStoreEventListener) mEvictor);
     }

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -89,7 +89,8 @@ public class TieredBlockStore implements BlockStore {
     mMetaManager = BlockMetadataManager.newBlockMetadataManager(mTachyonConf);
     mLockManager = new BlockLockManager(mMetaManager);
 
-    BlockMetadataView fullMetadataView = new BlockMetadataView(mMetaManager, null, null);
+    BlockMetadataView fullMetadataView = new BlockMetadataView(mMetaManager,
+        new ArrayList<Long>(), new ArrayList<Long>());
 
     AllocatorType allocatorType =
         mTachyonConf.getEnum(Constants.WORKER_ALLOCATE_STRATEGY_TYPE, AllocatorType.DEFAULT);

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -89,16 +89,18 @@ public class TieredBlockStore implements BlockStore {
     mMetaManager = BlockMetadataManager.newBlockMetadataManager(mTachyonConf);
     mLockManager = new BlockLockManager(mMetaManager);
 
+    BlockMetadataView metadataView = new BlockMetadataView(mMetaManager);
+
     AllocatorType allocatorType =
         mTachyonConf.getEnum(Constants.WORKER_ALLOCATE_STRATEGY_TYPE, AllocatorType.DEFAULT);
-    mAllocator = AllocatorFactory.create(allocatorType, mMetaManager);
+    mAllocator = AllocatorFactory.create(allocatorType, metadataView);
     if (mAllocator instanceof BlockStoreEventListener) {
       registerBlockStoreEventListener((BlockStoreEventListener) mAllocator);
     }
 
     EvictorType evictorType =
         mTachyonConf.getEnum(Constants.WORKER_EVICT_STRATEGY_TYPE, EvictorType.DEFAULT);
-    mEvictor = EvictorFactory.create(evictorType, mMetaManager);
+    mEvictor = EvictorFactory.create(evictorType, metadataView);
     if (mEvictor instanceof BlockStoreEventListener) {
       registerBlockStoreEventListener((BlockStoreEventListener) mEvictor);
     }

--- a/servers/src/main/java/tachyon/worker/block/allocator/AllocatorFactory.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/AllocatorFactory.java
@@ -16,7 +16,7 @@
 package tachyon.worker.block.allocator;
 
 
-import tachyon.worker.block.BlockMetadataManager;
+import tachyon.worker.block.BlockMetadataView;
 
 /**
  * Factory of {@link Allocator} based on {@link AllocatorType}
@@ -29,14 +29,14 @@ public class AllocatorFactory {
    * @param metaManager BlockMetadataManager to pass to Allocator
    * @return the generated Allocator
    */
-  public static Allocator create(AllocatorType allocatorType, BlockMetadataManager metaManager) {
+  public static Allocator create(AllocatorType allocatorType, BlockMetadataView metaView) {
     switch (allocatorType) {
       case GREEDY:
-        return new GreedyAllocator(metaManager);
+        return new GreedyAllocator(metaView);
       case MAX_FREE:
-        return new MaxFreeAllocator(metaManager);
+        return new MaxFreeAllocator(metaView);
       default:
-        return new GreedyAllocator(metaManager);
+        return new GreedyAllocator(metaView);
     }
   }
 

--- a/servers/src/main/java/tachyon/worker/block/allocator/GreedyAllocator.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/GreedyAllocator.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 
 import com.google.common.base.Preconditions;
 
+import tachyon.worker.block.BlockMetadataView;
 import tachyon.worker.block.BlockStoreLocation;
-import tachyon.worker.block.BlockMetadataManager;
 import tachyon.worker.block.meta.StorageDir;
 import tachyon.worker.block.meta.StorageTier;
 import tachyon.worker.block.meta.TempBlockMeta;
@@ -30,10 +30,10 @@ import tachyon.worker.block.meta.TempBlockMeta;
  * This class serves as an example how to implement an allocator.
  */
 public class GreedyAllocator implements Allocator {
-  private final BlockMetadataManager mMetaManager;
+  private final BlockMetadataView mMetaView;
 
-  public GreedyAllocator(BlockMetadataManager metadata) {
-    mMetaManager = Preconditions.checkNotNull(metadata);
+  public GreedyAllocator(BlockMetadataView metadata) {
+    mMetaView = Preconditions.checkNotNull(metadata);
   }
 
   @Override
@@ -42,7 +42,7 @@ public class GreedyAllocator implements Allocator {
     if (location.equals(BlockStoreLocation.anyTier())) {
       // When any tier is ok, loop over all storage tier and dir, and return the first dir that has
       // sufficient available space.
-      for (StorageTier tier : mMetaManager.getTiers()) {
+      for (StorageTier tier : mMetaView.getTiers()) {
         for (StorageDir dir : tier.getStorageDirs()) {
           if (dir.getAvailableBytes() >= blockSize) {
             return new TempBlockMeta(userId, blockId, blockSize, dir);
@@ -53,7 +53,7 @@ public class GreedyAllocator implements Allocator {
     }
 
     int tierAlias = location.tierAlias();
-    StorageTier tier = mMetaManager.getTier(tierAlias);
+    StorageTier tier = mMetaView.getTier(tierAlias);
     if (location.equals(BlockStoreLocation.anyDirInTier(tierAlias))) {
       // Loop over all dirs in the given tier
       for (StorageDir dir : tier.getStorageDirs()) {

--- a/servers/src/main/java/tachyon/worker/block/allocator/GreedyAllocator.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/GreedyAllocator.java
@@ -21,8 +21,8 @@ import com.google.common.base.Preconditions;
 
 import tachyon.worker.block.BlockMetadataView;
 import tachyon.worker.block.BlockStoreLocation;
-import tachyon.worker.block.meta.StorageDir;
-import tachyon.worker.block.meta.StorageTier;
+import tachyon.worker.block.meta.StorageDirView;
+import tachyon.worker.block.meta.StorageTierView;
 import tachyon.worker.block.meta.TempBlockMeta;
 
 /**
@@ -42,10 +42,11 @@ public class GreedyAllocator implements Allocator {
     if (location.equals(BlockStoreLocation.anyTier())) {
       // When any tier is ok, loop over all storage tier and dir, and return the first dir that has
       // sufficient available space.
-      for (StorageTier tier : mMetaView.getTiers()) {
-        for (StorageDir dir : tier.getStorageDirs()) {
+      for (StorageTierView tier : mMetaView.getTierViews()) {
+        for (StorageDirView dir : tier.getDirViews()) {
           if (dir.getAvailableBytes() >= blockSize) {
-            return new TempBlockMeta(userId, blockId, blockSize, dir);
+            // TODO: have to get underlying dir here, break the design of dirView
+            return new TempBlockMeta(userId, blockId, blockSize, dir.getDirForCreatingBlock());
           }
         }
       }
@@ -53,21 +54,22 @@ public class GreedyAllocator implements Allocator {
     }
 
     int tierAlias = location.tierAlias();
-    StorageTier tier = mMetaView.getTier(tierAlias);
+    StorageTierView tier = mMetaView.getTierView(tierAlias);
     if (location.equals(BlockStoreLocation.anyDirInTier(tierAlias))) {
       // Loop over all dirs in the given tier
-      for (StorageDir dir : tier.getStorageDirs()) {
+      for (StorageDirView dir : tier.getDirViews()) {
         if (dir.getAvailableBytes() >= blockSize) {
-          return new TempBlockMeta(userId, blockId, blockSize, dir);
+          // TODO: have to get underlying dir here, break the design of dirView
+          return new TempBlockMeta(userId, blockId, blockSize, dir.getDirForCreatingBlock());
         }
       }
       return null;
     }
 
     int dirIndex = location.dir();
-    StorageDir dir = tier.getDir(dirIndex);
+    StorageDirView dir = tier.getDirView(dirIndex);
     if (dir.getAvailableBytes() >= blockSize) {
-      return new TempBlockMeta(userId, blockId, blockSize, dir);
+      return new TempBlockMeta(userId, blockId, blockSize, dir.getDirForCreatingBlock());
     }
     return null;
   }

--- a/servers/src/main/java/tachyon/worker/block/allocator/MaxFreeAllocator.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/MaxFreeAllocator.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 
 import com.google.common.base.Preconditions;
 
+import tachyon.worker.block.BlockMetadataView;
 import tachyon.worker.block.BlockStoreLocation;
-import tachyon.worker.block.BlockMetadataManager;
 import tachyon.worker.block.meta.StorageDir;
 import tachyon.worker.block.meta.StorageTier;
 import tachyon.worker.block.meta.TempBlockMeta;
@@ -29,10 +29,10 @@ import tachyon.worker.block.meta.TempBlockMeta;
  * An allocator that allocates a block in the storage dir with most free space.
  */
 public class MaxFreeAllocator implements Allocator {
-  private final BlockMetadataManager mMetaManager;
+  private final BlockMetadataView mMetaView;
 
-  public MaxFreeAllocator(BlockMetadataManager metadata) {
-    mMetaManager = Preconditions.checkNotNull(metadata);
+  public MaxFreeAllocator(BlockMetadataView metadata) {
+    mMetaView = Preconditions.checkNotNull(metadata);
   }
 
   @Override
@@ -43,7 +43,7 @@ public class MaxFreeAllocator implements Allocator {
     long maxFreeBytes = blockSize;
 
     if (location.equals(BlockStoreLocation.anyTier())) {
-      for (StorageTier tier : mMetaManager.getTiers()) {
+      for (StorageTier tier : mMetaView.getTiers()) {
         for (StorageDir dir : tier.getStorageDirs()) {
           if (dir.getAvailableBytes() >= maxFreeBytes) {
             maxFreeBytes = dir.getAvailableBytes();
@@ -52,7 +52,7 @@ public class MaxFreeAllocator implements Allocator {
         }
       }
     } else if (location.equals(BlockStoreLocation.anyDirInTier(location.tierAlias()))) {
-      StorageTier tier = mMetaManager.getTier(location.tierAlias());
+      StorageTier tier = mMetaView.getTier(location.tierAlias());
       for (StorageDir dir : tier.getStorageDirs()) {
         if (dir.getAvailableBytes() >= maxFreeBytes) {
           maxFreeBytes = dir.getAvailableBytes();
@@ -60,7 +60,7 @@ public class MaxFreeAllocator implements Allocator {
         }
       }
     } else {
-      StorageTier tier = mMetaManager.getTier(location.tierAlias());
+      StorageTier tier = mMetaView.getTier(location.tierAlias());
       StorageDir dir = tier.getDir(location.dir());
       if (dir.getAvailableBytes() >= blockSize) {
         candidateDir = dir;

--- a/servers/src/main/java/tachyon/worker/block/allocator/MaxFreeAllocator.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/MaxFreeAllocator.java
@@ -68,8 +68,8 @@ public class MaxFreeAllocator implements Allocator {
     }
 
     // TODO: avoid getDirForCreatingBlock()
-    return candidateDir != null ?
-        new TempBlockMeta(userId, blockId, blockSize, candidateDir.getDirForCreatingBlock())
+    return candidateDir != null
+        ? new TempBlockMeta(userId, blockId, blockSize, candidateDir.getDirForCreatingBlock())
         : null;
   }
 }

--- a/servers/src/main/java/tachyon/worker/block/evictor/EvictorFactory.java
+++ b/servers/src/main/java/tachyon/worker/block/evictor/EvictorFactory.java
@@ -15,7 +15,7 @@
 
 package tachyon.worker.block.evictor;
 
-import tachyon.worker.block.BlockMetadataManager;
+import tachyon.worker.block.BlockMetadataView;
 
 /**
  * Factory of {@link Evictor} based on {@link EvictorType}
@@ -30,14 +30,14 @@ public class EvictorFactory {
    * @param metaManager BlockMetadataManager to pass to Evictor
    * @return the generated Evictor
    */
-  public static Evictor create(EvictorType evictorType, BlockMetadataManager metaManager) {
+  public static Evictor create(EvictorType evictorType, BlockMetadataView metaView) {
     switch (evictorType) {
       case GREEDY:
-        return new GreedyEvictor(metaManager);
+        return new GreedyEvictor(metaView);
       case LRU:
-        return new LRUEvictor(metaManager);
+        return new LRUEvictor(metaView);
       default:
-        return new GreedyEvictor(metaManager);
+        return new GreedyEvictor(metaView);
     }
   }
 }

--- a/servers/src/main/java/tachyon/worker/block/evictor/GreedyEvictor.java
+++ b/servers/src/main/java/tachyon/worker/block/evictor/GreedyEvictor.java
@@ -32,8 +32,8 @@ import tachyon.worker.block.BlockMetadataView;
 import tachyon.worker.block.BlockStoreEventListenerBase;
 import tachyon.worker.block.BlockStoreLocation;
 import tachyon.worker.block.meta.BlockMeta;
-import tachyon.worker.block.meta.StorageDir;
-import tachyon.worker.block.meta.StorageTier;
+import tachyon.worker.block.meta.StorageDirView;
+import tachyon.worker.block.meta.StorageTierView;
 
 /**
  * A simple evictor that evicts arbitrary blocks until the required size is met. This class serves
@@ -51,17 +51,17 @@ public class GreedyEvictor extends BlockStoreEventListenerBase implements Evicto
   public EvictionPlan freeSpace(long availableBytes, BlockStoreLocation location)
       throws IOException {
     // 1. Select a StorageDir that has enough capacity for required bytes.
-    StorageDir selectedDir = null;
+    StorageDirView selectedDir = null;
     if (location.equals(BlockStoreLocation.anyTier())) {
       selectedDir = selectDirToEvictBlocksFromAnyTier(availableBytes);
     } else {
       int tierAlias = location.tierAlias();
-      StorageTier tier = mMetaView.getTier(tierAlias);
+      StorageTierView tier = mMetaView.getTierView(tierAlias);
       if (location.equals(BlockStoreLocation.anyDirInTier(tierAlias))) {
         selectedDir = selectDirToEvictBlocksFromTier(tier, availableBytes);
       } else {
         int dirIndex = location.dir();
-        StorageDir dir = tier.getDir(dirIndex);
+        StorageDirView dir = tier.getDirView(dirIndex);
         if (canEvictBlocksFromDir(dir, availableBytes)) {
           selectedDir = dir;
         }
@@ -95,18 +95,20 @@ public class GreedyEvictor extends BlockStoreEventListenerBase implements Evicto
     }
 
     // 4. Make best effort to transfer victim blocks to lower tiers rather than evict them.
-    Map<StorageDir, Long> pendingBytesInDir = new HashMap<StorageDir, Long>();
+    Map<StorageDirView, Long> pendingBytesInDir = new HashMap<StorageDirView, Long>();
     for (BlockMeta block : victimBlocks) {
-      StorageTier fromTier = block.getParentDir().getParentTier();
-      List<StorageTier> toTiers = mMetaView.getTiersBelow(fromTier.getTierAlias());
-      StorageDir toDir = selectDirToTransferBlock(block, toTiers, pendingBytesInDir);
+      // TODO: should not allow actual dir and tier to be retrieved
+      StorageTierView fromTier =
+          mMetaView.getTierView(block.getParentDir().getParentTier().getTierAlias());
+      List<StorageTierView> toTiers = mMetaView.getTiersBelow(fromTier.getTierViewAlias());
+      StorageDirView toDir = selectDirToTransferBlock(block, toTiers, pendingBytesInDir);
       if (toDir == null) {
         // Not possible to transfer
         toEvict.add(block.getBlockId());
       } else {
-        StorageTier toTier = toDir.getParentTier();
+        StorageTierView toTier = toDir.getParentTier();
         toTransfer.add(new Pair<Long, BlockStoreLocation>(block.getBlockId(),
-            new BlockStoreLocation(toTier.getTierAlias(), toTier.getTierLevel(), toDir
+            new BlockStoreLocation(toTier.getTierViewAlias(), toTier.getTierViewLevel(), toDir
                 .getDirIndex())));
         if (pendingBytesInDir.containsKey(toDir)) {
           pendingBytesInDir.put(toDir, pendingBytesInDir.get(toDir) + block.getBlockSize());
@@ -119,13 +121,13 @@ public class GreedyEvictor extends BlockStoreEventListenerBase implements Evicto
   }
 
   // TODO: share this as a util function as it may be useful for other Evictors.
-  private boolean canEvictBlocksFromDir(StorageDir dir, long availableBytes) {
+  private boolean canEvictBlocksFromDir(StorageDirView dir, long availableBytes) {
     return dir.getAvailableBytes() + dir.getCommittedBytes() >= availableBytes;
   }
 
-  private StorageDir selectDirToEvictBlocksFromAnyTier(long availableBytes) {
-    for (StorageTier tier : mMetaView.getTiers()) {
-      for (StorageDir dir : tier.getStorageDirs()) {
+  private StorageDirView selectDirToEvictBlocksFromAnyTier(long availableBytes) {
+    for (StorageTierView tier : mMetaView.getTierViews()) {
+      for (StorageDirView dir : tier.getDirViews()) {
         if (canEvictBlocksFromDir(dir, availableBytes)) {
           return dir;
         }
@@ -134,8 +136,8 @@ public class GreedyEvictor extends BlockStoreEventListenerBase implements Evicto
     return null;
   }
 
-  private StorageDir selectDirToEvictBlocksFromTier(StorageTier tier, long availableBytes) {
-    for (StorageDir dir : tier.getStorageDirs()) {
+  private StorageDirView selectDirToEvictBlocksFromTier(StorageTierView tier, long availableBytes) {
+    for (StorageDirView dir : tier.getDirViews()) {
       if (canEvictBlocksFromDir(dir, availableBytes)) {
         return dir;
       }
@@ -143,10 +145,10 @@ public class GreedyEvictor extends BlockStoreEventListenerBase implements Evicto
     return null;
   }
 
-  private StorageDir selectDirToTransferBlock(BlockMeta block, List<StorageTier> toTiers,
-      Map<StorageDir, Long> pendingBytesInDir) {
-    for (StorageTier toTier : toTiers) {
-      for (StorageDir toDir : toTier.getStorageDirs()) {
+  private StorageDirView selectDirToTransferBlock(BlockMeta block, List<StorageTierView> toTiers,
+      Map<StorageDirView, Long> pendingBytesInDir) {
+    for (StorageTierView toTier : toTiers) {
+      for (StorageDirView toDir : toTier.getDirViews()) {
         long pendingBytes = 0;
         if (pendingBytesInDir.containsKey(toDir)) {
           pendingBytes = pendingBytesInDir.get(toDir);

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDirView.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDirView.java
@@ -15,25 +15,11 @@
 
 package tachyon.worker.block.meta;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 
-import tachyon.Constants;
-import tachyon.StorageDirId;
-import tachyon.worker.block.BlockMetadataManager;
 import tachyon.worker.block.BlockMetadataView;
 
 /**
@@ -56,9 +42,22 @@ public class StorageDirView {
     return mDir.getDirIndex();
   }
 
+  /**
+   * return a filtered list of block metadata,
+   * for blocks that are neither pinned or being read.
+   */
   public List<BlockMeta> getBlocks() {
-    // TODO: filter out blocks
-    return mDir.getBlocks();
+    List<Long> pinnedBlocks = mView.getPinnedBlocks();
+    List<Long> readingBlocks = mView.getReadingBlocks();
+    List<BlockMeta> filteredList = new ArrayList<BlockMeta>();
+
+    for (BlockMeta blockMeta : mDir.getBlocks()) {
+      long blockId = blockMeta.getBlockId();
+      if (!pinnedBlocks.contains(blockId) && !readingBlocks.contains(blockId)) {
+        filteredList.add(blockMeta);
+      }
+    }
+    return filteredList;
   }
 
   public long getAvailableBytes() {
@@ -66,7 +65,7 @@ public class StorageDirView {
   }
 
   public long getCommittedBytes() {
-    // TODO: filter out bytes that are caused by blocks in pinlists, etc
+    // TODO: does pinedList, etc. change this value?
     return mDir.getCommittedBytes();
   }
 

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDirView.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDirView.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.worker.block.meta;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+
+import tachyon.Constants;
+import tachyon.StorageDirId;
+import tachyon.worker.block.BlockMetadataManager;
+import tachyon.worker.block.BlockMetadataView;
+
+/**
+ * This class is a wrapper of {@link StorageDir} to provided more limited access
+ * and a filtered list of blocks.
+ */
+public class StorageDirView {
+
+  private final StorageDir mDir;
+  private final StorageTierView mTier;
+  private final BlockMetadataView mView;
+
+  public StorageDirView(StorageDir dir, StorageTierView tier, BlockMetadataView view) {
+    mDir = Preconditions.checkNotNull(dir);
+    mTier = tier;
+    mView = Preconditions.checkNotNull(view);
+  }
+
+  public int getDirIndex() {
+    return mDir.getDirIndex();
+  }
+
+  public List<BlockMeta> getBlocks() {
+    // TODO: filter out blocks
+    return mDir.getBlocks();
+  }
+
+  public long getAvailableBytes() {
+    return mDir.getAvailableBytes();
+  }
+
+  public long getCommittedBytes() {
+    // TODO: filter out bytes that are caused by blocks in pinlists, etc
+    return mDir.getCommittedBytes();
+  }
+
+  public StorageDir getDirForCreatingBlock() {
+    return mDir;
+  }
+
+  public StorageTierView getParentTier() {
+    return mTier;
+  }
+}

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageTierView.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageTierView.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.worker.block.meta;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+
+import tachyon.Constants;
+import tachyon.StorageDirId;
+import tachyon.worker.block.BlockMetadataManager;
+import tachyon.worker.block.BlockMetadataView;
+
+/**
+ * This class is a wrapper of {@link StorageTier} to provided more limited access
+ */
+public class StorageTierView {
+
+  private final StorageTier mTier;
+  private List<StorageDirView> mDirViews;
+  private final BlockMetadataView mView;
+
+  public StorageTierView(StorageTier tier, BlockMetadataView view) {
+    mTier = Preconditions.checkNotNull(tier);
+    mView = Preconditions.checkNotNull(view);
+
+    for (StorageDir dir : mTier.getStorageDirs()) {
+      StorageDirView dirView = new StorageDirView(dir, this, view);
+      mDirViews.add(dirView);
+    }
+  }
+
+  public List<StorageDirView> getDirViews() {
+    return mDirViews;
+  }
+
+  public StorageDirView getDirView(int dirIndex) throws IOException {
+    return mDirViews.get(dirIndex);
+  }
+
+  public int getTierViewAlias() {
+    return mTier.getTierAlias();
+  }
+
+  public int getTierViewLevel() {
+    return mTier.getTierLevel();
+  }
+}

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageTierView.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageTierView.java
@@ -15,25 +15,12 @@
 
 package tachyon.worker.block.meta;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 
-import tachyon.Constants;
-import tachyon.StorageDirId;
-import tachyon.worker.block.BlockMetadataManager;
 import tachyon.worker.block.BlockMetadataView;
 
 /**
@@ -42,7 +29,7 @@ import tachyon.worker.block.BlockMetadataView;
 public class StorageTierView {
 
   private final StorageTier mTier;
-  private List<StorageDirView> mDirViews;
+  private List<StorageDirView> mDirViews = new ArrayList<StorageDirView>();
   private final BlockMetadataView mView;
 
   public StorageTierView(StorageTier tier, BlockMetadataView view) {


### PR DESCRIPTION
Step1, Use BlockMetadataView as a proxy for BlockMetadataManager in Evictors and Allocators

See more detailed description in [TACHYON-599](https://tachyon.atlassian.net/browse/TACHYON-599)