### PR TITLE
[TACHYON-601] Login Mechanism: Add OS_LOGIN_MODULE

### DIFF
--- a/common/src/main/java/tachyon/security/UserInformation.java
+++ b/common/src/main/java/tachyon/security/UserInformation.java
@@ -15,7 +15,6 @@
 
 package tachyon.security;
 
-import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +34,7 @@ public class UserInformation {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private static final String OS_LOGIN_MODULE_NAME;
-  private static final Class<? extends Principal> OS_PRINCIPAL_CLASS;
+  private static final String OS_PRINCIPAL_CLASS_NAME;
   private static final boolean WINDOWS = System.getProperty("os.name").startsWith("Windows");
   private static final boolean IS_64_BIT = System.getProperty("os.arch").contains("64");
   private static final boolean AIX = System.getProperty("os.name").equals("AIX");
@@ -44,7 +43,7 @@ public class UserInformation {
 
   static {
     OS_LOGIN_MODULE_NAME = getOSLoginModuleName();
-    OS_PRINCIPAL_CLASS = getOsPrincipalClass();
+    OS_PRINCIPAL_CLASS_NAME = getOsPrincipalClassName();
   }
 
   // Return the OS login module class name.
@@ -65,32 +64,26 @@ public class UserInformation {
     }
   }
 
-  // Return the OS principal class
-  static Class<? extends Principal> getOsPrincipalClass() {
-    ClassLoader cl = ClassLoader.getSystemClassLoader();
-    try {
-      String principalClass = null;
-      if (IBM_JAVA) {
-        if (IS_64_BIT) {
-          principalClass = "com.ibm.security.auth.UsernamePrincipal";
-        } else {
-          if (WINDOWS) {
-            principalClass = "com.ibm.security.auth.NTUserPrincipal";
-          } else if (AIX) {
-            principalClass = "com.ibm.security.auth.AIXPrincipal";
-          } else {
-            principalClass = "com.ibm.security.auth.LinuxPrincipal";
-          }
-        }
+  // Return the OS principal class name
+  static String getOsPrincipalClassName() {
+    String principalClassName = null;
+    if (IBM_JAVA) {
+      if (IS_64_BIT) {
+        principalClassName = "com.ibm.security.auth.UsernamePrincipal";
       } else {
-        principalClass = WINDOWS ? "com.sun.security.auth.NTUserPrincipal"
-            : "com.sun.security.auth.UnixPrincipal";
+        if (WINDOWS) {
+          principalClassName = "com.ibm.security.auth.NTUserPrincipal";
+        } else if (AIX) {
+          principalClassName = "com.ibm.security.auth.AIXPrincipal";
+        } else {
+          principalClassName = "com.ibm.security.auth.LinuxPrincipal";
+        }
       }
-      return (Class<? extends Principal>) cl.loadClass(principalClass);
-    } catch (ClassNotFoundException e) {
-      LOG.error("Unable to find JAAS classes:" + e.getMessage());
+    } else {
+      principalClassName = WINDOWS ? "com.sun.security.auth.NTUserPrincipal"
+          : "com.sun.security.auth.UnixPrincipal";
     }
-    return null;
+    return principalClassName;
   }
 
   /**

--- a/common/src/main/java/tachyon/security/UserInformation.java
+++ b/common/src/main/java/tachyon/security/UserInformation.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.security;
+
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tachyon.Constants;
+
+/**
+ * This class wraps a JAAS Subject and provides methods to determine the user's name. It supports
+ * Windows, Unix, and Kerberos login modules.
+ */
+public class UserInformation {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
+  private static final String OS_LOGIN_MODULE_NAME;
+  private static final Class<? extends Principal> OS_PRINCIPAL_CLASS;
+  private static final boolean WINDOWS = System.getProperty("os.name").startsWith("Windows");
+  private static final boolean IS_64_BIT = System.getProperty("os.arch").contains("64");
+  private static final boolean AIX = System.getProperty("os.name").equals("AIX");
+  public static final String JAVA_VENDOR_NAME = System.getProperty("java.vendor");
+  public static final boolean IBM_JAVA = JAVA_VENDOR_NAME.contains("IBM");
+
+  static {
+    OS_LOGIN_MODULE_NAME = getOSLoginModuleName();
+    OS_PRINCIPAL_CLASS = getOsPrincipalClass();
+  }
+
+  // Return the OS login module class name.
+  private static String getOSLoginModuleName() {
+    if (IBM_JAVA) {
+      if (WINDOWS) {
+        return IS_64_BIT ? "com.ibm.security.auth.module.Win64LoginModule"
+            : "com.ibm.security.auth.module.NTLoginModule";
+      } else if (AIX) {
+        return IS_64_BIT ? "com.ibm.security.auth.module.AIX64LoginModule"
+            : "com.ibm.security.auth.module.AIXLoginModule";
+      } else {
+        return "com.ibm.security.auth.module.LinuxLoginModule";
+      }
+    } else {
+      return WINDOWS ? "com.sun.security.auth.module.NTLoginModule"
+          : "com.sun.security.auth.module.UnixLoginModule";
+    }
+  }
+
+  // Return the OS principal class
+  static Class<? extends Principal> getOsPrincipalClass() {
+    ClassLoader cl = ClassLoader.getSystemClassLoader();
+    try {
+      String principalClass = null;
+      if (IBM_JAVA) {
+        if (IS_64_BIT) {
+          principalClass = "com.ibm.security.auth.UsernamePrincipal";
+        } else {
+          if (WINDOWS) {
+            principalClass = "com.ibm.security.auth.NTUserPrincipal";
+          } else if (AIX) {
+            principalClass = "com.ibm.security.auth.AIXPrincipal";
+          } else {
+            principalClass = "com.ibm.security.auth.LinuxPrincipal";
+          }
+        }
+      } else {
+        principalClass = WINDOWS ? "com.sun.security.auth.NTUserPrincipal"
+            : "com.sun.security.auth.UnixPrincipal";
+      }
+      return (Class<? extends Principal>) cl.loadClass(principalClass);
+    } catch (ClassNotFoundException e) {
+      LOG.error("Unable to find JAAS classes:" + e.getMessage());
+    }
+    return null;
+  }
+
+  /**
+   * A JAAS configuration that defines the login modules, by which we use to login.
+   */
+  static class TachyonJaasConfiguration extends Configuration {
+    private static final Map<String, String> BASIC_JAAS_OPTIONS = new HashMap<String,String>();
+
+    private static final AppConfigurationEntry OS_SPECIFIC_LOGIN =
+        new AppConfigurationEntry(OS_LOGIN_MODULE_NAME,
+            AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, BASIC_JAAS_OPTIONS);
+
+    // TODO: define AppConfigurationEntry TACHYON_LOGIN
+
+    private static final AppConfigurationEntry[] SIMPLE = new
+        AppConfigurationEntry[]{OS_SPECIFIC_LOGIN};
+
+    @Override
+    public AppConfigurationEntry[] getAppConfigurationEntry(String appName) {
+      // TODO: switch branch based on appName. (Simple, Kerberos, etc)
+      return SIMPLE;
+    }
+  }
+}

--- a/common/src/main/java/tachyon/security/UserInformation.java
+++ b/common/src/main/java/tachyon/security/UserInformation.java
@@ -25,9 +25,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import tachyon.Constants;
+import tachyon.util.PlatformUtils;
 
 /**
- * This class wraps a JAAS Subject and provides methods to determine the user's name. It supports
+ * This class wraps a JAAS Subject and provides methods to determine the user. It supports
  * Windows, Unix, and Kerberos login modules.
  */
 public class UserInformation {
@@ -35,11 +36,9 @@ public class UserInformation {
 
   private static final String OS_LOGIN_MODULE_NAME;
   private static final String OS_PRINCIPAL_CLASS_NAME;
-  private static final boolean WINDOWS = System.getProperty("os.name").startsWith("Windows");
-  private static final boolean IS_64_BIT = System.getProperty("os.arch").contains("64");
-  private static final boolean AIX = System.getProperty("os.name").equals("AIX");
-  public static final String JAVA_VENDOR_NAME = System.getProperty("java.vendor");
-  public static final boolean IBM_JAVA = JAVA_VENDOR_NAME.contains("IBM");
+  private static final boolean WINDOWS = PlatformUtils.OS_NAME.startsWith("Windows");
+  private static final boolean IS_64_BIT = PlatformUtils.PROCESSOR_BIT.contains("64");
+  private static final boolean AIX = PlatformUtils.OS_NAME.equals("AIX");
 
   static {
     OS_LOGIN_MODULE_NAME = getOSLoginModuleName();
@@ -48,7 +47,7 @@ public class UserInformation {
 
   // Return the OS login module class name.
   private static String getOSLoginModuleName() {
-    if (IBM_JAVA) {
+    if (PlatformUtils.IBM_JAVA) {
       if (WINDOWS) {
         return IS_64_BIT ? "com.ibm.security.auth.module.Win64LoginModule"
             : "com.ibm.security.auth.module.NTLoginModule";
@@ -67,7 +66,7 @@ public class UserInformation {
   // Return the OS principal class name
   static String getOsPrincipalClassName() {
     String principalClassName = null;
-    if (IBM_JAVA) {
+    if (PlatformUtils.IBM_JAVA) {
       if (IS_64_BIT) {
         principalClassName = "com.ibm.security.auth.UsernamePrincipal";
       } else {
@@ -107,4 +106,8 @@ public class UserInformation {
       return SIMPLE;
     }
   }
+
+  // TODO: TACHYON-602 - add TACHYON_LOGIN_MODULE to convert an OS user to Tachyon user.
+
+  // TODO: TACHYON-613 - add methods to get login user
 }

--- a/common/src/main/java/tachyon/util/PlatformUtils.java
+++ b/common/src/main/java/tachyon/util/PlatformUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.util;
+
+/**
+ * A helper class for getting info of the platform
+ */
+public class PlatformUtils {
+  /**
+   * The OS name
+   */
+  public static final String OS_NAME = System.getProperty("os.name");
+
+  /**
+   * The processor bit
+   */
+  public static final String PROCESSOR_BIT = System.getProperty("os.arch");
+
+  /**
+   * The java vendor name used in this platform.
+   */
+  public static final String JAVA_VENDOR_NAME = System.getProperty("java.vendor");
+
+  /**
+   * Indicate the current java vendor is IBM java or not.
+   */
+  public static final boolean IBM_JAVA = JAVA_VENDOR_NAME.contains("IBM");
+}

--- a/common/src/test/java/tachyon/security/LoginModuleTest.java
+++ b/common/src/test/java/tachyon/security/LoginModuleTest.java
@@ -33,7 +33,9 @@ public class LoginModuleTest {
    */
   @Test
   public void osLoginModuleTest() throws Exception {
-    Class<? extends Principal> clazz = UserInformation.getOsPrincipalClass();
+    String clazzName = UserInformation.getOsPrincipalClassName();
+    Class<? extends Principal> clazz = (Class<? extends Principal>) ClassLoader
+        .getSystemClassLoader().loadClass(clazzName);
     Subject subject = new Subject();
 
     // login and add OS user into subject

--- a/common/src/test/java/tachyon/security/LoginModuleTest.java
+++ b/common/src/test/java/tachyon/security/LoginModuleTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.security;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.LoginContext;
+import java.security.Principal;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test for the login module defined in {@link tachyon.security.UserInformation}
+ */
+public class LoginModuleTest {
+
+  /**
+   * This test verify whether the OS login module works in JAAS framework.
+   * @throws Exception
+   */
+  @Test
+  public void osLoginModuleTest() throws Exception {
+    Class<? extends Principal> clazz = UserInformation.getOsPrincipalClass();
+    Subject subject = new Subject();
+
+    // login and add OS user into subject
+    LoginContext loginContext = new LoginContext("simple", subject, null,
+        new UserInformation.TachyonJaasConfiguration());
+    loginContext.login();
+
+    // verify whether OS user is fetched
+    Assert.assertFalse(subject.getPrincipals(clazz).isEmpty());
+  }
+}

--- a/common/src/test/java/tachyon/security/LoginModuleTest.java
+++ b/common/src/test/java/tachyon/security/LoginModuleTest.java
@@ -15,9 +15,10 @@
 
 package tachyon.security;
 
+import java.security.Principal;
+
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginContext;
-import java.security.Principal;
 
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
JIRA: https://tachyon.atlassian.net/browse/TACHYON-601

This is the 1st step to implement LOGIN mechanism.
This patch adds a OS_LOGIN_MODULE following JAAS framework. This module leverages JAAS provided different OS LoingModule (such as com.sun.security.auth.module.UnixLoginModule) to import an OS user and associate it with current Subject.