### PR TITLE
[TACHYON-614] Add authentication configuration and main entry

### DIFF
--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -230,4 +230,7 @@ public class Constants {
   public static final int BYTES_WRITTEN_LOCAL_INDEX = 7;
   public static final int BYTES_WRITTEN_UFS_INDEX = 8;
 
+  /** Security */
+  // Authentication
+  public static final String TACHYON_SECURITY_AUTHENTICATION = "tachyon.security.authentication";
 }

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.security.authentication;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tachyon.Constants;
+import tachyon.conf.TachyonConf;
+
+/**
+ * This class is the main entry for Tachyon authentication.
+ * It switches different modes based on configuration, and provides corresponding Thrift class
+ * for authenticated connection between Client and Server.
+ */
+public class AuthenticationFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
+  public enum AuthTypes {
+    NOSASL("NOSASL"),
+    SIMPLE("SIMPLE"),
+    KERBEROS("KERBEROS");
+
+    private final String mAuthType;
+
+    AuthTypes(String authType) {
+      mAuthType = authType;
+    }
+
+    public String getAuthName() {
+      return mAuthType;
+    }
+  }
+
+  private final String mAuthTypeStr;
+  private final TachyonConf mTachyonConf;
+
+  public AuthenticationFactory(TachyonConf tachyonConf) {
+    mTachyonConf = tachyonConf;
+    mAuthTypeStr = tachyonConf.get(Constants.TACHYON_SECURITY_AUTHENTICATION,
+        AuthTypes.NOSASL.getAuthName());
+  }
+
+  // TODO: add methods of getting different Thrift class in follow-up PR.
+}

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
@@ -29,9 +29,25 @@ import tachyon.conf.TachyonConf;
 public class AuthenticationFactory {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
+  /**
+   * Different authentication types for Tachyon.
+   */
   public enum AuthTypes {
+    /**
+     * Authentication is disabled. No user info in Tachyon.
+     */
     NOSASL("NOSASL"),
+
+    /**
+     * User is aware in Tachyon.
+     * Login user is OS user. The verification of client user is disabled.
+     */
     SIMPLE("SIMPLE"),
+
+    /**
+     * User is aware in Tachyon.
+     * The user is verified by Kerberos authentication.
+     */
     KERBEROS("KERBEROS");
 
     private final String mAuthType;
@@ -52,6 +68,10 @@ public class AuthenticationFactory {
     mTachyonConf = tachyonConf;
     mAuthTypeStr = tachyonConf.get(Constants.TACHYON_SECURITY_AUTHENTICATION,
         AuthTypes.NOSASL.getAuthName());
+  }
+
+  String getAuthTypeStr() {
+    return mAuthTypeStr;
   }
 
   // TODO: add methods of getting different Thrift class in follow-up PR.

--- a/common/src/main/resources/tachyon-default.properties
+++ b/common/src/main/resources/tachyon-default.properties
@@ -39,6 +39,9 @@ tachyon.test.mode=false
 tachyon.max.table.metadata.byte=5MB
 tachyon.host.resolution.timeout.ms=5000
 
+# Security properties
+tachyon.security.authentication=NOSASL
+
 # Master properties
 tachyon.master.journal.folder=${tachyon.home}/journal/
 tachyon.master.format.file_prefix=_format_

--- a/common/src/test/java/tachyon/security/authentication/AuthenticationFactoryTest.java
+++ b/common/src/test/java/tachyon/security/authentication/AuthenticationFactoryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.security.authentication;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import tachyon.Constants;
+import tachyon.conf.TachyonConf;
+
+/**
+ * Unit test for inner class {@link tachyon.security.authentication.AuthenticationFactory
+ * .AuthTypes} and methods of {@link tachyon.security.authentication.AuthenticationFactory}
+ */
+public class AuthenticationFactoryTest {
+
+  @Test
+  public void authTypesTest() {
+    TachyonConf tachyonConf = new TachyonConf();
+    tachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
+
+    AuthenticationFactory authenticationFactory = new AuthenticationFactory(tachyonConf);
+
+    Assert.assertEquals(AuthenticationFactory.AuthTypes.SIMPLE.getAuthName(),
+        authenticationFactory.getAuthTypeStr());
+  }
+
+  // TODO: add more tests for methods of AuthenticationFactory
+}


### PR DESCRIPTION
JIRA: https://tachyon.atlassian.net/browse/TACHYON-614

This patch adds a parameter to switch authentication mode in Tachyon configuration. Build a main entry class for authentication feature. It should provide methods invoked by original code based on different mode.

@calvinjia , @ooq , @apc999 , do you think we should set the default mode to `NOSASL` (security disabled) or `SIMPLE`?