### PR TITLE
[TACHYON-609] Add getBlockedBlocks in BlockLockManager

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockLockManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockLockManager.java
@@ -17,6 +17,7 @@ package tachyon.worker.block;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -197,6 +198,17 @@ public class BlockLockManager {
       }
       mUserIdToLockIdsMap.remove(userId);
     }
+  }
+
+  /**
+   * Get a set of currently locked blocks.
+   */
+  public Set<Long> getLockedBlocks() {
+    Set<Long> set = new HashSet<Long>();
+    for (LockRecord lockRecord : mLockIdToRecordMap.values()) {
+      set.add(lockRecord.blockId());
+    }
+    return set;
   }
 
   /**


### PR DESCRIPTION
Expose `getBlockedBlocks` in `BlockLockManager` so that `BlockStore`/`TieredBlockStore` can use this API to get a list of locked blocks.