### PR TITLE
[TACHYON-617] Worker cleanup fix

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -325,14 +325,16 @@ public class BlockMetadataManager {
   }
 
   /**
-   * Cleans up the meta data of temp blocks created by the given user.
+   * Cleans up the meta data of the given temp block ids
    *
-   * @param userId the ID of the user
+   * @param userId the ID of the client associated with the temp blocks
+   * @param tempBlockIds the list of temporary block ids to be cleaned up, non temporary block
+   *                     ids will be ignored.
    */
-  public synchronized void cleanupUser(long userId) {
+  public synchronized void cleanupUserTempBlocks(long userId, List<Long> tempBlockIds) {
     for (StorageTier tier : mTiers) {
       for (StorageDir dir : tier.getStorageDirs()) {
-        dir.cleanupUser(userId);
+        dir.cleanupUserTempBlocks(userId, tempBlockIds);
       }
     }
   }

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -332,7 +332,7 @@ public class BlockMetadataManager {
   public synchronized void cleanupUser(long userId) {
     for (StorageTier tier : mTiers) {
       for (StorageDir dir : tier.getStorageDirs()) {
-        List<TempBlockMeta> blocksToRemove = dir.cleanupUser(userId);
+        dir.cleanupUser(userId);
       }
     }
   }

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -345,6 +345,16 @@ public class BlockMetadataManager {
     return ret;
   }
 
+  public synchronized List<TempBlockMeta> getUserTempBlocks(long userId) {
+    List<TempBlockMeta> userTempBlocks = new ArrayList<TempBlockMeta>();
+    for (StorageTier tier : mTiers) {
+      for (StorageDir dir : tier.getStorageDirs()) {
+        userTempBlocks.addAll(dir.getUserTempBlocks(userId));
+      }
+    }
+    return userTempBlocks;
+  }
+
   /**
    * Gets a summary of the meta data.
    *

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -328,21 +328,13 @@ public class BlockMetadataManager {
    * Cleans up the meta data of temp blocks created by the given user.
    *
    * @param userId the ID of the user
-   * @return A list of temp blocks created by the user in this block store
    */
-  public synchronized List<TempBlockMeta> cleanupUser(long userId) {
-    List<TempBlockMeta> ret = new ArrayList<TempBlockMeta>();
+  public synchronized void cleanupUser(long userId) {
     for (StorageTier tier : mTiers) {
       for (StorageDir dir : tier.getStorageDirs()) {
         List<TempBlockMeta> blocksToRemove = dir.cleanupUser(userId);
-        if (blocksToRemove != null) {
-          for (TempBlockMeta block : blocksToRemove) {
-            ret.add(block);
-          }
-        }
       }
     }
-    return ret;
   }
 
   /**

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -345,6 +345,13 @@ public class BlockMetadataManager {
     return ret;
   }
 
+  /**
+   * Gets all the temporary blocks associated with a user, empty list is returned if the user has
+   * no temporary blocks.
+   *
+   * @param userId the ID of the user
+   * @return A list of temp blocks associated with the user
+   */
   public synchronized List<TempBlockMeta> getUserTempBlocks(long userId) {
     List<TempBlockMeta> userTempBlocks = new ArrayList<TempBlockMeta>();
     for (StorageTier tier : mTiers) {

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -292,9 +292,12 @@ public class TieredBlockStore implements BlockStore {
       }
     }
 
+    // Release all locks the user is holding.
+    mLockManager.cleanupUser(userId);
+
+    // Delete the temporary metadata for the user.
     mEvictionLock.readLock().lock();
     mMetaManager.cleanupUserTempBlocks(userId, removedTempBlocks);
-    mLockManager.cleanupUser(userId);
     mEvictionLock.readLock().unlock();
   }
 

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -288,7 +288,7 @@ public class TieredBlockStore implements BlockStore {
     // TODO: Cleanup the user folder across tiered storage.
     for (String dirName : dirs) {
       if (!new File(dirName).delete()) {
-        LOG.error("Error in cleanup userId {}: cannot delete directory ", userId, dirName);
+        LOG.error("Error in cleanup userId {}: cannot delete directory {}", userId, dirName);
       }
     }
 

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -265,11 +265,7 @@ public class TieredBlockStore implements BlockStore {
 
   @Override
   public void cleanupUser(long userId) throws IOException {
-    mEvictionLock.readLock().lock();
-    List<TempBlockMeta> tempBlocksToRemove = mMetaManager.cleanupUser(userId);
-    mLockManager.cleanupUser(userId);
-    mEvictionLock.readLock().unlock();
-
+    List<TempBlockMeta> tempBlocksToRemove = mMetaManager.getUserTempBlocks(userId);
     // TODO: fix the block removing below, there is possible risk condition when the client which
     // is considered "dead" may still be using or committing this block.
     // A user may have multiple temporary directories for temp blocks, in diffrent StorageTier
@@ -293,6 +289,11 @@ public class TieredBlockStore implements BlockStore {
         LOG.error("Error in cleanup userId {}: cannot delete directory ", userId, dirName);
       }
     }
+
+    mEvictionLock.readLock().lock();
+    mMetaManager.cleanupUser(userId);
+    mLockManager.cleanupUser(userId);
+    mEvictionLock.readLock().unlock();
   }
 
   @Override

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -18,6 +18,7 @@ package tachyon.worker.block.meta;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -438,11 +439,13 @@ public class StorageDir {
    */
   public List<TempBlockMeta> getUserTempBlocks(long userId) {
     Set<Long> userTempBlockIds = mUserIdToTempBlockIdsMap.get(userId);
+
+    if (userTempBlockIds == null || userTempBlockIds.isEmpty()) {
+      return Collections.emptyList();
+    }
     List<TempBlockMeta> userTempBlocks = new ArrayList<TempBlockMeta>();
-    if (userTempBlockIds != null) {
-      for (long blockId : userTempBlockIds) {
-        userTempBlocks.add(mBlockIdToTempBlockMap.get(blockId));
-      }
+    for (long blockId : userTempBlockIds) {
+      userTempBlocks.add(mBlockIdToTempBlockMap.get(blockId));
     }
     return userTempBlocks;
   }

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -398,14 +398,12 @@ public class StorageDir {
    * @param userId the ID of the user to cleanup
    * @return A list of temp blocks removed from this dir
    */
-  public List<TempBlockMeta> cleanupUser(long userId) {
-    List<TempBlockMeta> blocksToRemove = new ArrayList<TempBlockMeta>();
+  public void cleanupUser(long userId) {
     Set<Long> userTempBlocks = mUserIdToTempBlockIdsMap.get(userId);
     if (userTempBlocks != null) {
       for (long blockId : userTempBlocks) {
         TempBlockMeta tempBlock = mBlockIdToTempBlockMap.remove(blockId);
         if (tempBlock != null) {
-          blocksToRemove.add(tempBlock);
           reclaimSpace(tempBlock.getBlockSize(), false);
         } else {
           LOG.error("Cannot find blockId {} when cleanup userId {}", blockId, userId);
@@ -413,7 +411,6 @@ public class StorageDir {
       }
       mUserIdToTempBlockIdsMap.remove(userId);
     }
-    return blocksToRemove;
   }
 
   /**

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -396,7 +396,6 @@ public class StorageDir {
    * Cleans up the temp block meta data of a specific user.
    *
    * @param userId the ID of the user to cleanup
-   * @return A list of temp blocks removed from this dir
    */
   public void cleanupUser(long userId) {
     Set<Long> userTempBlocks = mUserIdToTempBlockIdsMap.get(userId);

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -393,22 +393,33 @@ public class StorageDir {
   }
 
   /**
-   * Cleans up the temp block meta data of a specific user.
+   * Cleans up the temp block meta data for each block id passed in
    *
-   * @param userId the ID of the user to cleanup
+   * @param userId the ID of the client associated with the temporary blocks
+   * @param tempBlockIds the list of temporary blocks to clean up, non temporary blocks or
+   *                     nonexistent blocks will be ignored
    */
-  public void cleanupUser(long userId) {
+  public void cleanupUserTempBlocks(long userId, List<Long> tempBlockIds) {
     Set<Long> userTempBlocks = mUserIdToTempBlockIdsMap.get(userId);
-    if (userTempBlocks != null) {
-      for (long blockId : userTempBlocks) {
-        TempBlockMeta tempBlock = mBlockIdToTempBlockMap.remove(blockId);
-        if (tempBlock != null) {
-          reclaimSpace(tempBlock.getBlockSize(), false);
-        } else {
-          LOG.error("Cannot find blockId {} when cleanup userId {}", blockId, userId);
-        }
+    // The user's temporary blocks have already been removed.
+    if (userTempBlocks == null) {
+      return;
+    }
+    for (Long tempBlockId : tempBlockIds) {
+      if (!mBlockIdToTempBlockMap.containsKey(tempBlockId)) {
+        // This temp block does not exist in this dir, this is expected for some blocks since the
+        // input list is across all dirs
+        continue;
       }
+      userTempBlocks.remove(tempBlockId);
+      mBlockIdToTempBlockMap.remove(tempBlockId);
+    }
+    if (userTempBlocks.isEmpty()) {
       mUserIdToTempBlockIdsMap.remove(userId);
+    } else {
+      // This may happen if the client comes back during clean up and creates more blocks or some
+      // temporary blocks failed to be deleted
+      LOG.warn("Blocks still owned by user " + userId + " after cleanup.");
     }
   }
 

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -415,4 +415,15 @@ public class StorageDir {
     }
     return blocksToRemove;
   }
+
+  public List<TempBlockMeta> getUserTempBlocks(long userId) {
+    Set<Long> userTempBlockIds = mUserIdToTempBlockIdsMap.get(userId);
+    List<TempBlockMeta> userTempBlocks = new ArrayList<TempBlockMeta>();
+    if (userTempBlockIds != null) {
+      for (long blockId : userTempBlockIds) {
+        userTempBlocks.add(mBlockIdToTempBlockMap.get(blockId));
+      }
+    }
+    return userTempBlocks;
+  }
 }

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -412,7 +412,12 @@ public class StorageDir {
         continue;
       }
       userTempBlocks.remove(tempBlockId);
-      mBlockIdToTempBlockMap.remove(tempBlockId);
+      TempBlockMeta tempBlockMeta = mBlockIdToTempBlockMap.remove(tempBlockId);
+      if (tempBlockMeta != null) {
+        reclaimSpace(tempBlockMeta.getBlockSize(), false);
+      } else {
+        LOG.error("Cannot find blockId {} when cleanup userId {}", tempBlockId, userId);
+      }
     }
     if (userTempBlocks.isEmpty()) {
       mUserIdToTempBlockIdsMap.remove(userId);

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -416,6 +416,13 @@ public class StorageDir {
     return blocksToRemove;
   }
 
+  /**
+   * Gets the temporary blocks associated with a user in this StorageDir, an empty list is returned
+   * if the user has no temporary blocks in this StorageDir.
+   *
+   * @param userId the ID of the user
+   * @return A list of temporary blocks the user is associated with in this StorageDir
+   */
   public List<TempBlockMeta> getUserTempBlocks(long userId) {
     Set<Long> userTempBlockIds = mUserIdToTempBlockIdsMap.get(userId);
     List<TempBlockMeta> userTempBlocks = new ArrayList<TempBlockMeta>();

--- a/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerTest.java
@@ -270,7 +270,7 @@ public class BlockMetadataManagerTest {
     for (TempBlockMeta tempBlockMeta : toRemove) {
       toRemoveBlockIds.add(tempBlockMeta.getBlockId());
     }
-    Assert.assertEquals(Sets.<TempBlockMeta>newHashSet(), new HashSet<TempBlockMeta>(toRemove));
+    Assert.assertTrue(toRemove.isEmpty());
 
     // Clean up userId1 again, expect nothing to happen
     mMetaManager.cleanupUserTempBlocks(userId1, toRemoveBlockIds);

--- a/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerTest.java
@@ -245,26 +245,38 @@ public class BlockMetadataManagerTest {
     dir.addTempBlockMeta(tempBlockMeta3);
     dir.addBlockMeta(blockMeta);
 
-    // Cleanup userId1, expect to remove tempBlock1 and tempBlock2
-    List<TempBlockMeta> toRemove = mMetaManager.cleanupUser(userId1);
+    // Get temp blocks for userId1, expect to get tempBlock1 and tempBlock2
+    List<TempBlockMeta> toRemove = mMetaManager.getUserTempBlocks(userId1);
     Assert.assertEquals(Sets.newHashSet(tempBlockMeta1, tempBlockMeta2),
         new HashSet<TempBlockMeta>(toRemove));
+    Assert.assertTrue(dir.hasTempBlockMeta(tempBlockId1));
+    Assert.assertTrue(dir.hasTempBlockMeta(tempBlockId2));
+
+    // Clean up userId1, expect tempBlock1 and tempBlock2 to be removed.
+    mMetaManager.cleanupUser(userId1);
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId1));
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId2));
     Assert.assertTrue(dir.hasTempBlockMeta(tempBlockId3));
     Assert.assertTrue(dir.hasBlockMeta(TEST_BLOCK_ID));
 
-    // Cleanup userId1 again, expect to remove nothing
-    toRemove = mMetaManager.cleanupUser(userId1);
-    Assert.assertEquals(Sets.newHashSet(), new HashSet<TempBlockMeta>(toRemove));
+    // Get temp blocks for userId1 again, expect to get nothing
+    toRemove = mMetaManager.getUserTempBlocks(userId1);
+    Assert.assertEquals(Sets.<TempBlockMeta>newHashSet(), new HashSet<TempBlockMeta>(toRemove));
+
+    // Clean up userId1 again, expect nothing to happen
+    mMetaManager.cleanupUser(userId1);
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId1));
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId2));
     Assert.assertTrue(dir.hasTempBlockMeta(tempBlockId3));
     Assert.assertTrue(dir.hasBlockMeta(TEST_BLOCK_ID));
 
-    // Cleanup userId2, expect to remove tempBlock3
-    toRemove = mMetaManager.cleanupUser(userId2);
+    // Get temp blocks for userId2, expect to get tempBlock3
+    toRemove = mMetaManager.getUserTempBlocks(userId2);
     Assert.assertEquals(Sets.newHashSet(tempBlockMeta3), new HashSet<TempBlockMeta>(toRemove));
+    Assert.assertTrue(dir.hasTempBlockMeta(tempBlockId3));
+
+    // Clean up userId2, expect tempBlock3 to be removed
+    mMetaManager.cleanupUser(userId2);
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId1));
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId2));
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId3));

--- a/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerTest.java
@@ -16,6 +16,7 @@
 package tachyon.worker.block;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
@@ -247,13 +248,17 @@ public class BlockMetadataManagerTest {
 
     // Get temp blocks for userId1, expect to get tempBlock1 and tempBlock2
     List<TempBlockMeta> toRemove = mMetaManager.getUserTempBlocks(userId1);
+    List<Long> toRemoveBlockIds = new ArrayList<Long>(toRemove.size());
+    for (TempBlockMeta tempBlockMeta : toRemove) {
+      toRemoveBlockIds.add(tempBlockMeta.getBlockId());
+    }
     Assert.assertEquals(Sets.newHashSet(tempBlockMeta1, tempBlockMeta2),
         new HashSet<TempBlockMeta>(toRemove));
     Assert.assertTrue(dir.hasTempBlockMeta(tempBlockId1));
     Assert.assertTrue(dir.hasTempBlockMeta(tempBlockId2));
 
     // Clean up userId1, expect tempBlock1 and tempBlock2 to be removed.
-    mMetaManager.cleanupUser(userId1);
+    mMetaManager.cleanupUserTempBlocks(userId1, toRemoveBlockIds);
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId1));
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId2));
     Assert.assertTrue(dir.hasTempBlockMeta(tempBlockId3));
@@ -261,10 +266,14 @@ public class BlockMetadataManagerTest {
 
     // Get temp blocks for userId1 again, expect to get nothing
     toRemove = mMetaManager.getUserTempBlocks(userId1);
+    toRemoveBlockIds = new ArrayList<Long>(toRemove.size());
+    for (TempBlockMeta tempBlockMeta : toRemove) {
+      toRemoveBlockIds.add(tempBlockMeta.getBlockId());
+    }
     Assert.assertEquals(Sets.<TempBlockMeta>newHashSet(), new HashSet<TempBlockMeta>(toRemove));
 
     // Clean up userId1 again, expect nothing to happen
-    mMetaManager.cleanupUser(userId1);
+    mMetaManager.cleanupUserTempBlocks(userId1, toRemoveBlockIds);
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId1));
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId2));
     Assert.assertTrue(dir.hasTempBlockMeta(tempBlockId3));
@@ -272,11 +281,15 @@ public class BlockMetadataManagerTest {
 
     // Get temp blocks for userId2, expect to get tempBlock3
     toRemove = mMetaManager.getUserTempBlocks(userId2);
+    toRemoveBlockIds = new ArrayList<Long>(toRemove.size());
+    for (TempBlockMeta tempBlockMeta : toRemove) {
+      toRemoveBlockIds.add(tempBlockMeta.getBlockId());
+    }
     Assert.assertEquals(Sets.newHashSet(tempBlockMeta3), new HashSet<TempBlockMeta>(toRemove));
     Assert.assertTrue(dir.hasTempBlockMeta(tempBlockId3));
 
     // Clean up userId2, expect tempBlock3 to be removed
-    mMetaManager.cleanupUser(userId2);
+    mMetaManager.cleanupUserTempBlocks(userId2, toRemoveBlockIds);
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId1));
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId2));
     Assert.assertFalse(dir.hasTempBlockMeta(tempBlockId3));

--- a/servers/src/test/java/tachyon/worker/block/meta/StorageDirTest.java
+++ b/servers/src/test/java/tachyon/worker/block/meta/StorageDirTest.java
@@ -370,10 +370,15 @@ public class StorageDirTest {
     mDir.addTempBlockMeta(tempBlockMeta2);
     mDir.addTempBlockMeta(tempBlockMeta3);
 
-    List<TempBlockMeta> actual = mDir.cleanupUser(TEST_USER_ID);
+    // Check the temporary blocks belonging to TEST_USER_ID
+    List<TempBlockMeta> actual = mDir.getUserTempBlocks(TEST_USER_ID);
     Assert.assertEquals(Sets.newHashSet(tempBlockMeta1, tempBlockMeta2),
         new HashSet<TempBlockMeta>(actual));
+    Assert.assertTrue(mDir.hasTempBlockMeta(tempBlockId1));
+    Assert.assertTrue(mDir.hasTempBlockMeta(tempBlockId2));
+
     // Two temp blocks created by TEST_USER_ID are expected to be removed
+    mDir.cleanupUser(TEST_USER_ID);
     Assert.assertFalse(mDir.hasTempBlockMeta(tempBlockId1));
     Assert.assertFalse(mDir.hasTempBlockMeta(tempBlockId2));
     // Temp block created by otherUserId is expected to stay

--- a/servers/src/test/java/tachyon/worker/block/meta/StorageDirTest.java
+++ b/servers/src/test/java/tachyon/worker/block/meta/StorageDirTest.java
@@ -17,6 +17,7 @@ package tachyon.worker.block.meta;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
@@ -372,13 +373,17 @@ public class StorageDirTest {
 
     // Check the temporary blocks belonging to TEST_USER_ID
     List<TempBlockMeta> actual = mDir.getUserTempBlocks(TEST_USER_ID);
+    List<Long> actualBlockIds = new ArrayList<Long>(actual.size());
+    for (TempBlockMeta tempBlockMeta : actual) {
+      actualBlockIds.add(tempBlockMeta.getBlockId());
+    }
     Assert.assertEquals(Sets.newHashSet(tempBlockMeta1, tempBlockMeta2),
         new HashSet<TempBlockMeta>(actual));
     Assert.assertTrue(mDir.hasTempBlockMeta(tempBlockId1));
     Assert.assertTrue(mDir.hasTempBlockMeta(tempBlockId2));
 
     // Two temp blocks created by TEST_USER_ID are expected to be removed
-    mDir.cleanupUser(TEST_USER_ID);
+    mDir.cleanupUserTempBlocks(TEST_USER_ID, actualBlockIds);
     Assert.assertFalse(mDir.hasTempBlockMeta(tempBlockId1));
     Assert.assertFalse(mDir.hasTempBlockMeta(tempBlockId2));
     // Temp block created by otherUserId is expected to stay


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-617

This deals with the following race condition:

Storage device full, ie. 1 GB user temp data, 9 GB data (10 GB total)

1. Clean up user
2. User metadata is cleaned up, worker thinks it has 1 GB free space, but the device is really full.
3. Space is requested and used before the data on the device is deleted.

This will cause out of space exception on a storage device or overflow the ramdisk possibly causing out of memory errors in other processes or the Tachyon worker.