### PR TITLE
[TACHYON-620] Allocate Space before moving a block

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
@@ -310,8 +310,8 @@ public class BlockDataManager {
   }
 
   /**
-   * Moves a block from its current location to a target location, currently only tier level moves
-   * are supported
+   * Migrates a block from its current location to a target location, currently only tier level
+   * moves are supported
    *
    * @param userId The id of the client
    * @param blockId The id of the block to move
@@ -319,9 +319,9 @@ public class BlockDataManager {
    * @throws IOException if an error occurs during move
    */
   // TODO: We should avoid throwing IOException
-  public void moveBlock(long userId, long blockId, int tierAlias) throws IOException {
+  public void migrateBlock(long userId, long blockId, int tierAlias) throws IOException {
     BlockStoreLocation dst = BlockStoreLocation.anyDirInTier(tierAlias);
-    mBlockStore.moveBlock(userId, blockId, dst);
+    mBlockStore.migrateBlock(userId, blockId, dst);
   }
 
   /**

--- a/servers/src/main/java/tachyon/worker/block/BlockServiceHandler.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockServiceHandler.java
@@ -154,7 +154,7 @@ public class BlockServiceHandler implements WorkerService.Iface {
   public boolean promoteBlock(long blockId) throws TException {
     try {
       // TODO: Make the top level configurable
-      mWorker.moveBlock(Users.MIGRATE_DATA_USER_ID, blockId, StorageLevelAlias.MEM.getValue());
+      mWorker.migrateBlock(Users.MIGRATE_DATA_USER_ID, blockId, StorageLevelAlias.MEM.getValue());
       return true;
     } catch (IOException ioe) {
       throw new TException(ioe);

--- a/servers/src/main/java/tachyon/worker/block/BlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockStore.java
@@ -148,14 +148,14 @@ interface BlockStore {
   BlockReader getBlockReader(long userId, long blockId, long lockId) throws IOException;
 
   /**
-   * Moves an existing block to a new location. If the block can not be found, throw IOException.
+   * Migrates an existing block to a new location. If the block can not be found, throw IOException.
    *
    * @param userId the ID of the user to move a block
    * @param blockId the ID of an existing block
    * @param newLocation the location of the destination
    * @throws IOException if blockId or newLocation is invalid, or block cannot be moved
    */
-  void moveBlock(long userId, long blockId, BlockStoreLocation newLocation) throws IOException;
+  void migrateBlock(long userId, long blockId, BlockStoreLocation newLocation) throws IOException;
 
   /**
    * Removes an existing block. If the block can not be found in this store, throw IOException.


### PR DESCRIPTION
Currently, worker doesn't allocate space for a block when the block is migrated among worker layers. such as promoteBlock
