### PR TITLE
[TACHYON-559] Removed variable 'LOG'  in RPCMEssageEncoder.java

### DIFF
--- a/common/src/main/java/tachyon/network/protocol/RPCMessageEncoder.java
+++ b/common/src/main/java/tachyon/network/protocol/RPCMessageEncoder.java
@@ -37,7 +37,6 @@ import tachyon.network.protocol.databuffer.DataBuffer;
  */
 @ChannelHandler.Sharable
 public class RPCMessageEncoder extends MessageToMessageEncoder<RPCMessage> {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   @Override
   protected void encode(ChannelHandlerContext ctx, RPCMessage in, List<Object> out)


### PR DESCRIPTION
[TACHYON-559] Removed variable 'LOG'  in RPCMEssageEncoder.java
https://tachyon.atlassian.net/browse/TACHYON-559

sorry for my terrible git operation