### PR TITLE
[TACHYON-108] Fix flaky remote write integration test

### DIFF
--- a/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import tachyon.Constants;
+import tachyon.IntegrationTestConstants;
 import tachyon.TachyonURI;
 import tachyon.TestUtils;
 import tachyon.conf.TachyonConf;
@@ -86,6 +87,8 @@ public class FileOutStreamIntegrationTest {
     TachyonConf tachyonConf = new TachyonConf();
     tachyonConf.set(Constants.USER_FILE_BUFFER_BYTES, String.valueOf(BUFFER_BYTES));
     tachyonConf.set(Constants.USER_ENABLE_LOCAL_WRITE, Boolean.toString(mEnableLocalWrite));
+    // Only the Netty data server supports remote writes.
+    tachyonConf.set(Constants.WORKER_DATA_SERVER, IntegrationTestConstants.NETTY_DATA_SERVER);
     sLocalTachyonCluster.start(tachyonConf);
     mTfs = sLocalTachyonCluster.getClient();
     mMasterTachyonConf = sLocalTachyonCluster.getMasterTachyonConf();

--- a/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
@@ -78,6 +78,8 @@ public class RemoteBlockInStreamIntegrationTest {
   public final void after() throws Exception {
     mLocalTachyonCluster.stop();
     System.clearProperty("fs.hdfs.impl.disable.cache");
+    System.clearProperty(Constants.WORKER_DATA_SERVER);
+    System.clearProperty(Constants.USER_REMOTE_BLOCK_READER);
   }
 
   @Before


### PR DESCRIPTION
Two fixes to make the remote tests more stable:

- The remote read test was not clearing settings.
- The remote write test should only use the Netty data server (NIO data server does not support writes).