### PR TITLE
[TACHYON-624] Distinguish between remote and local writes for client metrics

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/FileOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/FileOutStream.java
@@ -91,7 +91,6 @@ public class FileOutStream extends OutStream {
     }
     if (mCurrentBlockOutStream != null) {
       mPreviousBlockOutStreams.add(mCurrentBlockOutStream);
-      mTachyonFS.getClientMetrics().incBlocksWrittenLocal(1);
     }
 
     Boolean canComplete = false;
@@ -153,7 +152,6 @@ public class FileOutStream extends OutStream {
         throw new IOException("The current block still has space left, no need to get new block");
       }
       mPreviousBlockOutStreams.add(mCurrentBlockOutStream);
-      mTachyonFS.getClientMetrics().incBlocksWrittenLocal(1);
     }
 
     if (mWriteType.isCache()) {
@@ -189,14 +187,12 @@ public class FileOutStream extends OutStream {
           if (currentBlockLeftBytes >= tLen) {
             mCurrentBlockOutStream.write(b, tOff, tLen);
             mCachedBytes += tLen;
-            mTachyonFS.getClientMetrics().incBytesWrittenLocal(tLen);
             tLen = 0;
           } else {
             mCurrentBlockOutStream.write(b, tOff, (int) currentBlockLeftBytes);
             tOff += currentBlockLeftBytes;
             tLen -= currentBlockLeftBytes;
             mCachedBytes += currentBlockLeftBytes;
-            mTachyonFS.getClientMetrics().incBytesWrittenLocal(currentBlockLeftBytes);
           }
         }
       } catch (IOException e) {
@@ -226,7 +222,6 @@ public class FileOutStream extends OutStream {
         // TODO Cache the exception here.
         mCurrentBlockOutStream.write(b);
         mCachedBytes ++;
-        mTachyonFS.getClientMetrics().incBytesWrittenLocal(1);
       } catch (IOException e) {
         if (mWriteType.isMustCache()) {
           LOG.error(e.getMessage(), e);

--- a/clients/unshaded/src/main/java/tachyon/client/LocalBlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/LocalBlockOutStream.java
@@ -133,6 +133,7 @@ public class LocalBlockOutStream extends BlockOutStream {
     CommonUtils.cleanDirectBuffer(out);
     mInFileBytes += length;
     mAvailableBytes -= length;
+    mTachyonFS.getClientMetrics().incBytesWrittenLocal(length);
   }
 
   @Override
@@ -160,6 +161,7 @@ public class LocalBlockOutStream extends BlockOutStream {
       mCloser.close();
       mTachyonFS.cacheBlock(mBlockId);
       mClosed = true;
+      mTachyonFS.getClientMetrics().incBlocksWrittenLocal(1);
     }
   }
 

--- a/clients/unshaded/src/main/java/tachyon/client/LocalBlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/LocalBlockOutStream.java
@@ -159,9 +159,11 @@ public class LocalBlockOutStream extends BlockOutStream {
     if (!mClosed) {
       flush();
       mCloser.close();
-      mTachyonFS.cacheBlock(mBlockId);
+      if (mWrittenBytes > 0) {
+        mTachyonFS.cacheBlock(mBlockId);
+        mTachyonFS.getClientMetrics().incBlocksWrittenLocal(1);
+      }
       mClosed = true;
-      mTachyonFS.getClientMetrics().incBlocksWrittenLocal(1);
     }
   }
 

--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockOutStream.java
@@ -81,7 +81,8 @@ public class RemoteBlockOutStream extends BlockOutStream {
     super(file, opType, tachyonConf);
 
     if (!opType.isCache()) {
-      throw new IOException("RemoteBlockOutStream only support WriteType.CACHE");
+      throw new IOException("RemoteBlockOutStream only supports WriteType.CACHE. opType: "
+          + opType);
     }
 
     mBlockIndex = blockIndex;
@@ -112,6 +113,7 @@ public class RemoteBlockOutStream extends BlockOutStream {
       throws IOException {
     mRemoteWriter.write(bytes, offset, length);
     mFlushedBytes += length;
+    mTachyonFS.getClientMetrics().incBytesWrittenRemote(length);
   }
 
   // Flush the local buffer to the remote block.
@@ -141,6 +143,7 @@ public class RemoteBlockOutStream extends BlockOutStream {
       mCloser.close();
       if (mWrittenBytes > 0) {
         mTachyonFS.cacheBlock(mBlockId);
+        mTachyonFS.getClientMetrics().incBlocksWrittenRemote(1);
       }
       mClosed = true;
     }

--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -224,15 +224,16 @@ public class Constants {
   public static final boolean DEBUG = Boolean.valueOf(System.getProperty(TACHYON_DEBUG, "false"));
 
   public static final long CLIENT_METRICS_VERSION = 1L;
-  public static final int CLIENT_METRICS_SIZE = 9;
+  public static final int CLIENT_METRICS_SIZE = 11;
   public static final int CLIENT_METRICS_VERSION_INDEX = 0;
   public static final int BLOCKS_READ_LOCAL_INDEX = 1;
   public static final int BLOCKS_READ_REMOTE_INDEX = 2;
   public static final int BLOCKS_WRITTEN_LOCAL_INDEX = 3;
-  public static final int BYTES_READ_LOCAL_INDEX = 4;
-  public static final int BYTES_READ_REMOTE_INDEX = 5;
-  public static final int BYTES_READ_UFS_INDEX = 6;
-  public static final int BYTES_WRITTEN_LOCAL_INDEX = 7;
-  public static final int BYTES_WRITTEN_UFS_INDEX = 8;
-
+  public static final int BLOCKS_WRITTEN_REMOTE_INDEX = 4;
+  public static final int BYTES_READ_LOCAL_INDEX = 5;
+  public static final int BYTES_READ_REMOTE_INDEX = 6;
+  public static final int BYTES_READ_UFS_INDEX = 7;
+  public static final int BYTES_WRITTEN_LOCAL_INDEX = 8;
+  public static final int BYTES_WRITTEN_REMOTE_INDEX = 9;
+  public static final int BYTES_WRITTEN_UFS_INDEX = 10;
 }

--- a/common/src/main/java/tachyon/worker/ClientMetrics.java
+++ b/common/src/main/java/tachyon/worker/ClientMetrics.java
@@ -59,6 +59,11 @@ public class ClientMetrics {
         mMetrics.get(Constants.BLOCKS_WRITTEN_LOCAL_INDEX) + n);
   }
 
+  public synchronized void incBlocksWrittenRemote(long n) {
+    mMetrics.set(Constants.BLOCKS_WRITTEN_REMOTE_INDEX,
+        mMetrics.get(Constants.BLOCKS_WRITTEN_REMOTE_INDEX) + n);
+  }
+
   public synchronized void incBytesReadLocal(long n) {
     mMetrics.set(Constants.BYTES_READ_LOCAL_INDEX,
         mMetrics.get(Constants.BYTES_READ_LOCAL_INDEX) + n);
@@ -76,6 +81,11 @@ public class ClientMetrics {
   public synchronized void incBytesWrittenLocal(long n) {
     mMetrics.set(Constants.BYTES_WRITTEN_LOCAL_INDEX,
         mMetrics.get(Constants.BYTES_WRITTEN_LOCAL_INDEX) + n);
+  }
+
+  public synchronized void incBytesWrittenRemote(long n) {
+    mMetrics.set(Constants.BYTES_WRITTEN_REMOTE_INDEX,
+        mMetrics.get(Constants.BYTES_WRITTEN_REMOTE_INDEX) + n);
   }
 
   public synchronized void incBytesWrittenUfs(long n) {

--- a/servers/src/main/java/tachyon/worker/WorkerSource.java
+++ b/servers/src/main/java/tachyon/worker/WorkerSource.java
@@ -46,6 +46,8 @@ public class WorkerSource implements Source {
       .name("BlocksReadRemote"));
   private final Counter mBlocksWrittenLocal = mMetricRegistry.counter(MetricRegistry
       .name("BlocksWrittenLocal"));
+  private final Counter mBlocksWrittenRemote = mMetricRegistry.counter(MetricRegistry
+      .name("BlocksWrittenRemote"));
   private final Counter mBytesReadLocal = mMetricRegistry.counter(MetricRegistry
       .name("BytesReadLocal"));
   private final Counter mBytesReadRemote = mMetricRegistry.counter(MetricRegistry
@@ -54,6 +56,8 @@ public class WorkerSource implements Source {
       .name("BytesReadUfs"));
   private final Counter mBytesWrittenLocal = mMetricRegistry.counter(MetricRegistry
       .name("BytesWrittenLocal"));
+  private final Counter mBytesWrittenRemote = mMetricRegistry.counter(MetricRegistry
+      .name("BytesWrittenRemote"));
   private final Counter mBytesWrittenUfs = mMetricRegistry.counter(MetricRegistry
       .name("BytesWrittenUfs"));
 
@@ -99,6 +103,10 @@ public class WorkerSource implements Source {
     mBlocksWrittenLocal.inc(n);
   }
 
+  public void incBlocksWrittenRemote(long n) {
+    mBlocksWrittenRemote.inc(n);
+  }
+
   public void incBytesReadLocal(long n) {
     mBytesReadLocal.inc(n);
   }
@@ -113,6 +121,10 @@ public class WorkerSource implements Source {
 
   public void incBytesWrittenLocal(long n) {
     mBytesWrittenLocal.inc(n);
+  }
+
+  public void incBytesWrittenRemote(long n) {
+    mBytesWrittenRemote.inc(n);
   }
 
   public void incBytesWrittenUfs(long n) {

--- a/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
@@ -434,10 +434,12 @@ public class BlockDataManager {
       mWorkerSource.incBlocksReadLocal(metrics.get(Constants.BLOCKS_READ_LOCAL_INDEX));
       mWorkerSource.incBlocksReadRemote(metrics.get(Constants.BLOCKS_READ_REMOTE_INDEX));
       mWorkerSource.incBlocksWrittenLocal(metrics.get(Constants.BLOCKS_WRITTEN_LOCAL_INDEX));
+      mWorkerSource.incBlocksWrittenRemote(metrics.get(Constants.BLOCKS_WRITTEN_REMOTE_INDEX));
       mWorkerSource.incBytesReadLocal(metrics.get(Constants.BYTES_READ_LOCAL_INDEX));
       mWorkerSource.incBytesReadRemote(metrics.get(Constants.BYTES_READ_REMOTE_INDEX));
       mWorkerSource.incBytesReadUfs(metrics.get(Constants.BYTES_READ_UFS_INDEX));
       mWorkerSource.incBytesWrittenLocal(metrics.get(Constants.BYTES_WRITTEN_LOCAL_INDEX));
+      mWorkerSource.incBytesWrittenRemote(metrics.get(Constants.BYTES_WRITTEN_REMOTE_INDEX));
       mWorkerSource.incBytesWrittenUfs(metrics.get(Constants.BYTES_WRITTEN_UFS_INDEX));
     }
   }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-624

This PR adds client metrics for remote writes. They essentially mirror the statistics for "local blocks written" and "local bytes written".