### PR TITLE
[TACHYON-627] Synchronized on final objects in TieredBlockStore

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -71,7 +71,7 @@ public class TieredBlockStore implements BlockStore {
   private final BlockLockManager mLockManager;
   private final Allocator mAllocator;
   private final Evictor mEvictor;
-  private List<BlockStoreEventListener> mBlockStoreEventListeners =
+  private final List<BlockStoreEventListener> mBlockStoreEventListeners =
       new ArrayList<BlockStoreEventListener>();
   /** A set of pinned inodes fetched from the master */
   private final Set<Integer> mPinnedInodes = new HashSet<Integer>();


### PR DESCRIPTION
mAllocator and mEvictor are not thread-safe, so we should synchronize on
them.