### PR TITLE
[TACHYON-631]Fix wrong javadoc of tachyon.worker.block.meta.StorageTi…

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/meta/StorageTierView.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageTierView.java
@@ -63,9 +63,9 @@ public class StorageTierView {
    * Get a StorageDirView with a dirIndex
    *
    * @param dirIndex of the dirView requested
-   * @throws IOException if dirIndex is out of range
+   * @throws IndexOutOfBoundsException if dirIndex is out of range
    */
-  public StorageDirView getDirView(int dirIndex) throws IOException {
+  public StorageDirView getDirView(int dirIndex) {
     return mDirViews.get(dirIndex);
   }
 


### PR DESCRIPTION
List.get won't throw IOException, and IndexOutOfBoundsException is a RuntimeException and shouldn't be indicated method signature

Change-Id: I70f85c93ae3aaf194c78fbdee6ba732438f8b275