### PR TITLE
[TACHYON-670] Fix spark locality issue

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -117,7 +117,7 @@ public class BlockWorker {
     mThriftServer = createThriftServer();
     mWorkerNetAddress =
         new NetAddress(BlockWorkerUtils.getWorkerAddress(mTachyonConf).getAddress()
-            .getCanonicalHostName(), thriftServerPort, mDataServer.getPort());
+            .getHostAddress(), thriftServerPort, mDataServer.getPort());
 
     // Set up web server
     int webPort = mTachyonConf.getInt(Constants.WORKER_WEB_PORT, Constants.DEFAULT_WORKER_WEB_PORT);


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-670

With an empty Tachyon storage space, run `sc.textFile("tachyon://host:ip/file").count()` for the first time(suppose size of file can fit into Tachyon), the whole file will be loaded into Tachyon, then run the same command for the second time, more space will be consumed. But spark executor should be allocated to read local blocks from Tachyon.  

The problem may be: After getting `BlockInfo` of a block, spark compares its host field to current node's host, spark set the current node's host to raw IP string while Tachyon sets it to canonicalHostName, so no block will be matched to local blocks, then executor will try to read from remote TachyonWorker, and more space will be consumed. 

This is still a **guess**, it's only tested on a EC2 cluster experimentally. I'll comment below when I find proof in spark codes, please leave a comment if you have found out more, thanks!