### PR TITLE
[TACHYON-605] Fix bug in DeleteDuringEvictionTest

### DIFF
--- a/integration-tests/src/test/java/tachyon/worker/block/meta/CapacityUsageIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/block/meta/CapacityUsageIntegrationTest.java
@@ -111,7 +111,7 @@ public class CapacityUsageIntegrationTest {
     // This test may not trigger eviction each time, repeat it 20 times.
     for (int i = 0; i < 20; i ++) {
       deleteDuringEviction(i);
-      CommonUtils.sleepMs(null, 5 * HEARTBEAT_INTERVAL_MS); // ensure second delete completes
+      CommonUtils.sleepMs(null, 2 * HEARTBEAT_INTERVAL_MS); // ensure second delete completes
     }
   }
 }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-605

This test fails when evicting a block is triggered before a separate command of deleting this block arrives. The cause of this bug is due to the missing creation of dirs in `LocalTachyonCluster`.

Since this test is non-deterministic, I also increased the number of iterations to increase chance to trigger the deletionDuringEviction case.