### PR TITLE
[TACHYON-670] Fix location on the master side

### DIFF
--- a/servers/src/main/java/tachyon/master/BlockInfo.java
+++ b/servers/src/main/java/tachyon/master/BlockInfo.java
@@ -179,11 +179,9 @@ public class BlockInfo {
           try {
             String[] ipport = loc.split(":");
             if (ipport.length == 2) {
-              resolvedHost = NetworkUtils.resolveHostName(ipport[0]);
+              resolvedHost = ipport[0];
               resolvedPort = Integer.parseInt(ipport[1]);
             }
-          } catch (UnknownHostException uhe) {
-            continue;
           } catch (NumberFormatException nfe) {
             continue;
           }


### PR DESCRIPTION
#1123 Fixes the issue for when the block is in Tachyon by changing the worker addresses to not use `getCanonicalHostname`. When we retrieve the location from the under storage, we also should not resolve the hostname.