### PR TITLE
[TACHYON-672] Fix Eviction and Delete Bug

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockHeartbeatReporter.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockHeartbeatReporter.java
@@ -65,10 +65,7 @@ public class BlockHeartbeatReporter extends BlockStoreEventListenerBase {
       BlockStoreLocation newLocation) {
     Long storageDirId = newLocation.getStorageDirId();
     synchronized (mLock) {
-      // Add the block to the removed block list to remove the previous location
-      // TODO: We should have a better mechanism to indicate block movement
-      mRemovedBlocks.add(blockId);
-      // Remove the block from our list of added blocks in this heartbeat, if it was added to
+      // Remove the block from our list of added blocks in this heartbeat, if it was added, to
       // prevent adding the block twice.
       removeBlockFromAddedBlocks(blockId);
       // Add the block back with the new storagedir.
@@ -105,10 +102,7 @@ public class BlockHeartbeatReporter extends BlockStoreEventListenerBase {
       BlockStoreLocation newLocation) {
     Long storageDirId = newLocation.getStorageDirId();
     synchronized (mLock) {
-      // Add the block to the removed block list to remove the previous location
-      // TODO: We should have a better mechanism to indicate block movement
-      mRemovedBlocks.add(blockId);
-      // Remove the block from our list of added blocks in this heartbeat, if it was added to
+      // Remove the block from our list of added blocks in this heartbeat, if it was added, to
       // prevent adding the block twice.
       removeBlockFromAddedBlocks(blockId);
       // Add the block back with the new storagedir.

--- a/servers/src/test/java/tachyon/worker/block/BlockHeartbeatReporterTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockHeartbeatReporterTest.java
@@ -77,13 +77,6 @@ public class BlockHeartbeatReporterTest {
     List<Long> addedBlocksHdd = addedBlocks.get(HDD_LOC.getStorageDirId());
     Assert.assertEquals(1, addedBlocksHdd.size());
     Assert.assertEquals(block3, addedBlocksHdd.get(0));
-
-    // All blocks should be "removed" to force an update of their location in master
-    List<Long> removedBlocks = report.getRemovedBlocks();
-    Assert.assertEquals(3, removedBlocks.size());
-    Assert.assertTrue(removedBlocks.contains(block1));
-    Assert.assertTrue(removedBlocks.contains(block2));
-    Assert.assertTrue(removedBlocks.contains(block3));
   }
 
   // Tests generating a report clears the state of the reporter
@@ -95,7 +88,6 @@ public class BlockHeartbeatReporterTest {
     // First report should have updates
     BlockHeartbeatReport report = mReporter.generateReport();
     Assert.assertFalse(report.getAddedBlocks().isEmpty());
-    Assert.assertFalse(report.getRemovedBlocks().isEmpty());
 
     // Second report should not have updates
     BlockHeartbeatReport nextReport = mReporter.generateReport();


### PR DESCRIPTION
Changes the worker to master communication to not report a block as removed and then readded when the block is moved. Instead we can just report it as added since the master assumes only one copy of the block is in the worker at a time and will update the metadata instead of appending a new block to it.