### PR TITLE
[TACHYON-664] Initialize worker storage directories

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -105,6 +105,7 @@ public class StorageDir {
 
     // Create the storage directory path if it does not exist
     if (!dir.exists()) {
+      // TODO: Make this a utility method
       if (dir.mkdirs()) {
         CommonUtils.changeLocalFilePermission(mDirPath, "777");
         CommonUtils.setLocalFileStickyBit(mDirPath);

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Sets;
 
 import tachyon.Constants;
 import tachyon.StorageDirId;
+import tachyon.util.CommonUtils;
 import tachyon.worker.block.BlockStoreLocation;
 
 /**
@@ -101,6 +102,16 @@ public class StorageDir {
    */
   private void initializeMeta() throws IOException {
     File dir = new File(mDirPath);
+
+    // Create the storage directory path if it does not exist
+    if (!dir.exists()) {
+      if (dir.mkdirs()) {
+        CommonUtils.changeLocalFilePermission(mDirPath, "777");
+        CommonUtils.setLocalFileStickyBit(mDirPath);
+      } else {
+        throw new IOException("Failed to create storage dir " + mDirPath);
+      }
+    }
     File[] paths = dir.listFiles();
     if (paths == null) {
       return;

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageTier.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageTier.java
@@ -50,9 +50,17 @@ public class StorageTier {
   }
 
   private void initStorageTier(TachyonConf tachyonConf) throws IOException {
+    String workerDataFolder =
+        tachyonConf.get(Constants.WORKER_DATA_FOLDER, Constants.DEFAULT_DATA_FOLDER);
     String tierDirPathConf =
         String.format(Constants.WORKER_TIERED_STORAGE_LEVEL_DIRS_PATH_FORMAT, mTierLevel);
     String[] dirPaths = tachyonConf.get(tierDirPathConf, "/mnt/ramdisk").split(",");
+
+    // Add the worker data folder path after each storage directory, the final path will be like
+    // /mnt/ramdisk/tachyonworker
+    for (int i = 0; i < dirPaths.length; i ++) {
+      dirPaths[i] = CommonUtils.concatPath(dirPaths[i].trim(), workerDataFolder);
+    }
 
     String tierDirCapacityConf =
         String.format(Constants.WORKER_TIERED_STORAGE_LEVEL_DIRS_QUOTA_FORMAT, mTierLevel);

--- a/servers/src/test/java/tachyon/worker/block/meta/BlockMetaBaseTest.java
+++ b/servers/src/test/java/tachyon/worker/block/meta/BlockMetaBaseTest.java
@@ -19,8 +19,11 @@ import java.io.IOException;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.worker.block.BlockStoreLocation;
 
@@ -42,17 +45,26 @@ public class BlockMetaBaseTest {
     }
   }
 
+  @Rule
+  public TemporaryFolder mFolder = new TemporaryFolder();
+
   private static final long TEST_BLOCK_ID = 9;
-  private static final String TEST_DIR_PATH = "/mnt/ramdisk/0/";
+  private String mTestDirPath;
   private StorageTier mTier;
   private StorageDir mDir;
   private BlockMetaBaseForTest mBlockMeta;
 
   @Before
   public void before() throws IOException {
+    mTestDirPath = mFolder.newFolder().getAbsolutePath();
+    // Set up tier with one storage dir under mTestDirPath with 100 bytes capacity.
     TachyonConf tachyonConf = new TachyonConf();
+    tachyonConf.set("tachyon.worker.tieredstore.level0.dirs.path", mTestDirPath);
+    tachyonConf.set("tachyon.worker.tieredstore.level0.dirs.quota", "100b");
+    tachyonConf.set(Constants.WORKER_DATA_FOLDER, "");
+
     mTier = StorageTier.newStorageTier(tachyonConf, 0 /* level */);
-    mDir = StorageDir.newStorageDir(mTier, 0 /* index */, 100 /* capacity */, TEST_DIR_PATH);
+    mDir = mTier.getDir(0);
     mBlockMeta = new BlockMetaBaseForTest(TEST_BLOCK_ID, mDir);
   }
 

--- a/servers/src/test/java/tachyon/worker/block/meta/BlockMetaTest.java
+++ b/servers/src/test/java/tachyon/worker/block/meta/BlockMetaTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -23,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import tachyon.Constants;
 import tachyon.TestUtils;
 import tachyon.conf.TachyonConf;
 import tachyon.util.CommonUtils;
@@ -40,10 +41,15 @@ public class BlockMetaTest {
 
   @Before
   public void before() throws IOException {
-    TachyonConf tachyonConf = new TachyonConf();
-    StorageTier tier = StorageTier.newStorageTier(tachyonConf, 0 /* level */);
     mTestDirPath = mFolder.newFolder().getAbsolutePath();
-    mDir = StorageDir.newStorageDir(tier, 0 /* index */, 100 /* capacity */, mTestDirPath);
+    // Set up tier with one storage dir under mTestDirPath with 100 bytes capacity.
+    TachyonConf tachyonConf = new TachyonConf();
+    tachyonConf.set("tachyon.worker.tieredstore.level0.dirs.path", mTestDirPath);
+    tachyonConf.set("tachyon.worker.tieredstore.level0.dirs.quota", "100b");
+    tachyonConf.set(Constants.WORKER_DATA_FOLDER, "");
+
+    StorageTier tier = StorageTier.newStorageTier(tachyonConf, 0 /* level */);
+    mDir = tier.getDir(0);
   }
 
   @Test

--- a/servers/src/test/java/tachyon/worker/block/meta/StorageDirTest.java
+++ b/servers/src/test/java/tachyon/worker/block/meta/StorageDirTest.java
@@ -45,9 +45,9 @@ public class StorageDirTest {
   private static final long TEST_BLOCK_SIZE = 20;
   private static final long TEST_TEMP_BLOCK_ID = 10;
   private static final long TEST_TEMP_BLOCK_SIZE = 30;
-  private static final String TEST_DIR_PATH = "/mnt/ramdisk/0/";
   private static final int TEST_DIR_INDEX = 1;
   private static final long TEST_DIR_CAPACITY = 1000;
+  private String mTestDirPath;
   private StorageTier mTier;
   private StorageDir mDir;
   private BlockMeta mBlockMeta;
@@ -61,9 +61,16 @@ public class StorageDirTest {
 
   @Before
   public void before() throws IOException {
+    // Creates a dummy test dir under mTestDirPath with 1 byte space so initialization can occur
+    mTestDirPath = mFolder.newFolder().getAbsolutePath();
     TachyonConf tachyonConf = new TachyonConf();
+    tachyonConf.set("tachyon.worker.tieredstore.level0.dirs.path", mFolder.newFolder()
+        .getAbsolutePath());
+    tachyonConf.set("tachyon.worker.tieredstore.level0.dirs.quota", "1b");
+    tachyonConf.set(Constants.WORKER_DATA_FOLDER, "");
+
     mTier = StorageTier.newStorageTier(tachyonConf, 0 /* level */);
-    mDir = StorageDir.newStorageDir(mTier, TEST_DIR_INDEX, TEST_DIR_CAPACITY, TEST_DIR_PATH);
+    mDir = StorageDir.newStorageDir(mTier, TEST_DIR_INDEX, TEST_DIR_CAPACITY, mTestDirPath);
     mBlockMeta = new BlockMeta(TEST_BLOCK_ID, TEST_BLOCK_SIZE, mDir);
     mTempBlockMeta =
         new TempBlockMeta(TEST_USER_ID, TEST_TEMP_BLOCK_ID, TEST_TEMP_BLOCK_SIZE, mDir);
@@ -187,7 +194,7 @@ public class StorageDirTest {
 
   @Test
   public void getDirPathTest() {
-    Assert.assertEquals(TEST_DIR_PATH, mDir.getDirPath());
+    Assert.assertEquals(mTestDirPath, mDir.getDirPath());
   }
 
   @Test

--- a/servers/src/test/java/tachyon/worker/block/meta/StorageTierTest.java
+++ b/servers/src/test/java/tachyon/worker/block/meta/StorageTierTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
 import tachyon.Constants;
 import tachyon.StorageLevelAlias;
@@ -32,27 +33,34 @@ public class StorageTierTest {
   private static final long TEST_USER_ID = 2;
   private static final long TEST_TEMP_BLOCK_ID = 10;
   private static final long TEST_BLOCK_SIZE = 20;
-  private static final String TEST_DIR1_PATH = "/mnt/ramdisk/0/";
-  private static final String TEST_DIR2_PATH = "/mnt/ramdisk/1/";
   private static final long TEST_DIR1_CAPACITY = 2000;
   private static final long TEST_DIR2_CAPACITY = 3000;
   private static final int TEST_TIER_LEVEL = 0;
   private static final int TEST_TIER_ALIAS = StorageLevelAlias.MEM.getValue();
+  private String mTestDirPath1;
+  private String mTestDirPath2;
   private StorageTier mTier;
   private StorageDir mDir1;
   private TempBlockMeta mTempBlockMeta;
+
+  @Rule
+  public TemporaryFolder mFolder = new TemporaryFolder();
 
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
 
   @Before
   public final void before() throws Exception {
+    mTestDirPath1 = mFolder.newFolder().getAbsolutePath();
+    mTestDirPath2 = mFolder.newFolder().getAbsolutePath();
+
     TachyonConf tachyonConf = new TachyonConf();
+    tachyonConf.set(Constants.WORKER_DATA_FOLDER, "");
     tachyonConf.set(
         String.format(Constants.WORKER_TIERED_STORAGE_LEVEL_ALIAS_FORMAT, TEST_TIER_LEVEL), "MEM");
     tachyonConf.set(
         String.format(Constants.WORKER_TIERED_STORAGE_LEVEL_DIRS_PATH_FORMAT, TEST_TIER_LEVEL),
-        TEST_DIR1_PATH + "," + TEST_DIR2_PATH);
+        mTestDirPath1 + "," + mTestDirPath2);
     tachyonConf.set(
         String.format(Constants.WORKER_TIERED_STORAGE_LEVEL_DIRS_QUOTA_FORMAT, TEST_TIER_LEVEL),
         TEST_DIR1_CAPACITY + "," + TEST_DIR2_CAPACITY);
@@ -96,9 +104,9 @@ public class StorageTierTest {
   public void getDirTest() {
     mThrown.expect(IndexOutOfBoundsException.class);
     StorageDir dir1 = mTier.getDir(0);
-    Assert.assertEquals(TEST_DIR1_PATH, dir1.getDirPath());
+    Assert.assertEquals(mTestDirPath1, dir1.getDirPath());
     StorageDir dir2 = mTier.getDir(1);
-    Assert.assertEquals(TEST_DIR2_PATH, dir2.getDirPath());
+    Assert.assertEquals(mTestDirPath2, dir2.getDirPath());
     // Get dir by a non-existing index, expect getDir to fail and throw IndexOutOfBoundsException
     mTier.getDir(2);
   }
@@ -107,7 +115,7 @@ public class StorageTierTest {
   public void getStorageDirsTest() {
     List<StorageDir> dirs = mTier.getStorageDirs();
     Assert.assertEquals(2, dirs.size());
-    Assert.assertEquals(TEST_DIR1_PATH, dirs.get(0).getDirPath());
-    Assert.assertEquals(TEST_DIR2_PATH, dirs.get(1).getDirPath());
+    Assert.assertEquals(mTestDirPath1, dirs.get(0).getDirPath());
+    Assert.assertEquals(mTestDirPath2, dirs.get(1).getDirPath());
   }
 }

--- a/servers/src/test/java/tachyon/worker/block/meta/TempBlockMetaTest.java
+++ b/servers/src/test/java/tachyon/worker/block/meta/TempBlockMetaTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -23,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.util.CommonUtils;
 
@@ -38,11 +39,16 @@ public class TempBlockMetaTest {
 
   @Before
   public void before() throws IOException {
-    TachyonConf tachyonConf = new TachyonConf();
-    StorageTier tier = StorageTier.newStorageTier(tachyonConf, 0 /* level */);
     mTestDirPath = mFolder.newFolder().getAbsolutePath();
-    StorageDir dir =
-        StorageDir.newStorageDir(tier, 0 /* index */, 100 /* capacity */, mTestDirPath);
+
+    // Set up tier with one storage dir under mTestDirPath with 100 bytes capacity.
+    TachyonConf tachyonConf = new TachyonConf();
+    tachyonConf.set("tachyon.worker.tieredstore.level0.dirs.path", mTestDirPath);
+    tachyonConf.set("tachyon.worker.tieredstore.level0.dirs.quota", "100b");
+    tachyonConf.set(Constants.WORKER_DATA_FOLDER, "");
+    
+    StorageTier tier = StorageTier.newStorageTier(tachyonConf, 0 /* level */);
+    StorageDir dir = tier.getDir(0);
     mTempBlockMeta = new TempBlockMeta(TEST_USER_ID, TEST_BLOCK_ID, TEST_BLOCK_SIZE, dir);
   }
 

--- a/servers/src/test/java/tachyon/worker/block/meta/TempBlockMetaTest.java
+++ b/servers/src/test/java/tachyon/worker/block/meta/TempBlockMetaTest.java
@@ -46,7 +46,7 @@ public class TempBlockMetaTest {
     tachyonConf.set("tachyon.worker.tieredstore.level0.dirs.path", mTestDirPath);
     tachyonConf.set("tachyon.worker.tieredstore.level0.dirs.quota", "100b");
     tachyonConf.set(Constants.WORKER_DATA_FOLDER, "");
-    
+
     StorageTier tier = StorageTier.newStorageTier(tachyonConf, 0 /* level */);
     StorageDir dir = tier.getDir(0);
     mTempBlockMeta = new TempBlockMeta(TEST_USER_ID, TEST_BLOCK_ID, TEST_BLOCK_SIZE, dir);


### PR DESCRIPTION
This patch makes the worker create directories if they do not exist and also adds the tachyon worker data folder to the directories, making paths like `/mnt/ramdisk/tachyonworker` like in previous versions of Tachyon.