### PR TITLE
[SMALLFIX] Document tcp remote reader deprecation

### DIFF
--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -378,8 +378,8 @@ The user configuration specifies values regarding file system access.
   <td>tachyon.user.remote.block.reader.class</td>
   <td>tachyon.client.netty.NettyRemoteBlockReader</td>
   <td>Selects networking stack to run the client with. Valid options are
-    tachyon.client.tcp.TCPRemoteBlockReader (read remote data using tcp)
-    and tachyon.client.netty.NettyRemoteBlockReader (read remote data using netty).</td>
+    tachyon.client.netty.NettyRemoteBlockReader (read remote data using netty) and
+    [DEPRECATED] tachyon.client.tcp.TCPRemoteBlockReader</td>
 </tr>
 <tr>
   <td>tachyon.user.remote.block.writer.class</td>


### PR DESCRIPTION
Adds a note to users that the tcp remote reader is deprecated.