### PR TITLE
[TACHYON-623] Add a new JCA provider which registers the PlainSaslServerFacroty to create instances of PlainSaslServer

### DIFF
--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -21,7 +21,7 @@ import java.security.Security;
  * Because the Java SunSASL provider doesn't support the server-side PLAIN mechanism.
  * There is a new provider {@link PlainSaslServerProvider} needed to support server-side
  * PLAIN mechanism.
- * PlainSaslHelper is used to register this provider
+ * PlainSaslHelper is used to register this provider.
  */
 public class PlainSaslHelper {
   static {

--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -18,19 +18,23 @@ package tachyon.security;
 import java.security.Security;
 
 import com.google.common.annotations.VisibleForTesting;
-
+/**
+ * Because the Java SunSASL provider doesn't support the server-side PLAIN mechanism.
+ * There is a new provider {@link PlainSaslServerProvider} needed to support
+ * server-side PLAIN mechanism.
+ * PlainSaslHelper is used to register this provider
+ */
 public class PlainSaslHelper {
-  // Register Plain SASL server provider
   static {
     Security.addProvider(new PlainSaslServerProvider());
   }
 
   /**
    * @param name the name of the provider
-   * @return
+   * @return true if the provider was registered
    */
   @VisibleForTesting
-  public static boolean isPlainSaslProviderAdd() {
-    return Security.getProvider(PlainSaslServerProvider.TACHYON_PLAIN_NAME) != null;
+  public static boolean isPlainSaslProviderAdded() {
+    return Security.getProvider(PlainSaslServerProvider.TACHYON_PROVIDER_NAME) != null;
   }
 }

--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -17,7 +17,6 @@ package tachyon.security;
 
 import java.security.Security;
 
-import com.google.common.annotations.VisibleForTesting;
 /**
  * Because the Java SunSASL provider doesn't support the server-side PLAIN mechanism.
  * There is a new provider {@link PlainSaslServerProvider} needed to support
@@ -33,8 +32,7 @@ public class PlainSaslHelper {
    * @param name the name of the provider
    * @return true if the provider was registered
    */
-  @VisibleForTesting
   public static boolean isPlainSaslProviderAdded() {
-    return Security.getProvider(PlainSaslServerProvider.TACHYON_PROVIDER_NAME) != null;
+    return Security.getProvider(PlainSaslServerProvider.PROVIDER) != null;
   }
 }

--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.security;
+
+import java.security.Security;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class PlainSaslHelper {
+  // Register Plain SASL server provider
+  static {
+    Security.addProvider(new PlainSaslServerProvider());
+  }
+
+  /**
+   * @param name the name of the provider
+   * @return
+   */
+  @VisibleForTesting
+  public static boolean isPlainSaslProviderAdd() {
+    return Security.getProvider(PlainSaslServerProvider.TACHYON_PLAIN_NAME) != null;
+  }
+}

--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -19,8 +19,8 @@ import java.security.Security;
 
 /**
  * Because the Java SunSASL provider doesn't support the server-side PLAIN mechanism.
- * There is a new provider {@link PlainSaslServerProvider} needed to support
- * server-side PLAIN mechanism.
+ * There is a new provider {@link PlainSaslServerProvider} needed to support server-side
+ * PLAIN mechanism.
  * PlainSaslHelper is used to register this provider
  */
 public class PlainSaslHelper {

--- a/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
+++ b/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
@@ -24,34 +24,31 @@ import javax.security.sasl.SaslServer;
 import javax.security.sasl.SaslServerFactory;
 
 /**
- * Because the Java SunSASL provider doesn't support the server-side PLAIN mechanism.
- * There is a new provider needed to register to support server-side PLAIN mechanism.
- * There are three basic steps in implementing a SASL security provider:
- * 1.Write a class that implements the SaslServer interface {@link PlainSaslServer}
- * 2.Write a factory class implements the SaslServerFactory
- * 3.Write a JCA provider that registers the factory
+ * The Java SunSASL provider supports CRAM-MD5, DIGEST-MD5 and GSSAPI mechanism for server side.
+ * When the SASL using PLAIN mechanism, there is no support the SASL server.
+ * So there is a new provider needed to register to support server-side PLAIN mechanism.
  */
 public class PlainSaslServerProvider extends Provider {
-  public static final String PROVIDER = "TachyonSaslPlain";
-  public static final String MECHANSIM = "PLAIN";
+  public static final String PROVIDER = "SaslPlain";
+  public static final String MECHANISM = "PLAIN";
 
   public PlainSaslServerProvider() {
     super(PROVIDER, 1.0, "Plain SASL provider");
-    put("SaslServerFactory." + MECHANSIM, PlainSaslServerFactory.class.getName());
+    put("SaslServerFactory." + MECHANISM, PlainSaslServerFactory.class.getName());
   }
 
   /**
-   * PlainSaslServerFactory was used to create instances of {@link PlainSaslServer}.
-   * The parameter mechanism must be "PLAIN" when this PlainSaslServerFactory was called, or
+   * PlainSaslServerFactory is used to create instances of {@link PlainSaslServer}.
+   * The parameter mechanism must be "PLAIN" when this PlainSaslServerFactory is called, or
    * the null will be return.
    */
   public static class PlainSaslServerFactory implements SaslServerFactory {
     /**
-     * Creates a <tt>SaslServer</tt> using the parameters supplied.
-     * It returns null if no <tt>SaslServer</tt> can be created using the parameters supplied.
-     * Throws <tt>SaslException</tt> if it cannot create a <tt>SaslServer</tt>
+     * Creates a SaslServer using the parameters supplied.
+     * It returns null if no SaslServer can be created using the parameters supplied.
+     * Throws SaslException if it cannot create a SaslServer
      * because of an error.
-     * @param mechanism The name of a SASL mechanism. (e.g. "PALIN").
+     * @param mechanism The name of a SASL mechanism. (e.g. "PLAIN").
      * @param protocol The non-null string name of the protocol for which
      * the authentication is being performed.
      * @param serverName The non-null fully qualified host name of the server
@@ -59,20 +56,17 @@ public class PlainSaslServerProvider extends Provider {
      * @param props The possibly null set of properties used to select the SASL
      * mechanism and to configure the authentication exchange of the selected
      * mechanism.
-     *
      * @param cbh The possibly null callback handler to used by the SASL
      * mechanisms to do further operation.
-     *
-     *@return A possibly null <tt>SaslServer</tt> created using the parameters
-     * supplied. If null, this factory cannot produce a <tt>SaslServer</tt>
+     *@return A possibly null SaslServer created using the parameters
+     * supplied. If null, this factory cannot produce a SaslServer
      * using the parameters supplied.
-     *@exception SaslException If cannot create a <tt>SaslServer</tt> because of an error.
+     *@exception SaslException If cannot create a SaslServer because of an error.
      */
     @Override
     public SaslServer createSaslServer(String mechanism, String protocol, String serverName,
-                                       Map<String, ?> props, CallbackHandler cbh)
-                                           throws SaslException {
-      if (MECHANSIM.equals(mechanism)) {
+        Map<String, ?> props, CallbackHandler cbh) throws SaslException {
+      if (MECHANISM.equals(mechanism)) {
         return new PlainSaslServer(cbh);
       }
       return null;
@@ -80,7 +74,7 @@ public class PlainSaslServerProvider extends Provider {
 
     @Override
     public String[] getMechanismNames(Map<String, ?> props) {
-      return new String[] {MECHANSIM};
+      return new String[] {MECHANISM};
     }
   }
 }

--- a/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
+++ b/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
@@ -55,9 +55,9 @@ public class PlainSaslServerProvider extends Provider {
      * mechanism and to configure the authentication exchange of the selected mechanism.
      * @param callbackHandler. The possibly null callback handler to used by the SASL
      * mechanisms to do further operation.
-     *@return A possibly null SaslServer created using the parameters supplied.
-     *If null, this factory cannot produce a SaslServer using the parameters supplied.
-     *@exception SaslException If cannot create a SaslServer because of an error.
+     * @return A possibly null SaslServer created using the parameters supplied.
+     * If null, this factory cannot produce a SaslServer using the parameters supplied.
+     * @exception SaslException If cannot create a SaslServer because of an error.
      */
     @Override
     public SaslServer createSaslServer(String mechanism, String protocol, String serverName,

--- a/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
+++ b/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
@@ -40,34 +40,30 @@ public class PlainSaslServerProvider extends Provider {
   /**
    * PlainSaslServerFactory is used to create instances of
    * {@link PlainSaslServer}. The parameter mechanism must be "PLAIN" when this
-   * PlainSaslServerFactory is called, or the null will be return.
+   * PlainSaslServerFactory is called, or null will be returned.
    */
   public static class PlainSaslServerFactory implements SaslServerFactory {
     /**
      * Creates a SaslServer using the parameters supplied.
      * It returns null if no SaslServer can be created using the parameters supplied.
-     * Throws SaslException if it cannot create a SaslServer
-     * because of an error.
+     * Throws SaslException if it cannot create a SaslServer because of an error.
      * @param mechanism The name of a SASL mechanism. (e.g. "PLAIN").
      * @param protocol The non-null string name of the protocol for which
      * the authentication is being performed.
-     * @param serverName The non-null fully qualified host name of the server
-     * to authenticate to.
+     * @param serverName The non-null fully qualified host name of the server to authenticate to.
      * @param props The possibly null set of properties used to select the SASL
-     * mechanism and to configure the authentication exchange of the selected
-     * mechanism.
-     * @param cbh The possibly null callback handler to used by the SASL
+     * mechanism and to configure the authentication exchange of the selected mechanism.
+     * @param callbackHandler. The possibly null callback handler to used by the SASL
      * mechanisms to do further operation.
-     *@return A possibly null SaslServer created using the parameters
-     * supplied. If null, this factory cannot produce a SaslServer
-     * using the parameters supplied.
+     *@return A possibly null SaslServer created using the parameters supplied.
+     *If null, this factory cannot produce a SaslServer using the parameters supplied.
      *@exception SaslException If cannot create a SaslServer because of an error.
      */
     @Override
     public SaslServer createSaslServer(String mechanism, String protocol, String serverName,
-        Map<String, ?> props, CallbackHandler cbh) throws SaslException {
+        Map<String, ?> props, CallbackHandler callbackHandler) throws SaslException {
       if (MECHANISM.equals(mechanism)) {
-        return new PlainSaslServer(cbh);
+        return new PlainSaslServer(callbackHandler);
       }
       return null;
     }

--- a/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
+++ b/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.security;
+
+import java.security.Provider;
+import java.util.Map;
+
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import javax.security.sasl.SaslServerFactory;
+
+public class PlainSaslServerProvider extends Provider {
+  public static final String TACHYON_PLAIN_NAME = "TachyonSaslPlain";
+
+  public PlainSaslServerProvider() {
+    super(TACHYON_PLAIN_NAME, 1.0, "Tachyon Plain SASL provider");
+    put("SaslServerFactory.PLAIN", SaslPlainServerFactory.class.getName());
+  }
+
+  public static class SaslPlainServerFactory implements SaslServerFactory {
+
+    @Override
+    public SaslServer createSaslServer(String mechanism, String protocol, String serverName,
+                                       Map<String, ?> props, CallbackHandler cbh) {
+      if ("PLAIN".equals(mechanism)) {
+        try {
+          return new PlainSaslServer(cbh);
+        } catch (SaslException e) {
+          /* This is to fulfill the contract of the interface which states that an exception shall
+             be thrown when a SaslServer cannot be created due to an error but null should be
+             returned when a Server can't be created due to the parameters supplied. And the only
+             thing PlainSaslServer can fail on is a non-supported authentication mechanism.
+             That's why we return null instead of throwing the Exception */
+          return null;
+        }
+      }
+      return null;
+    }
+
+    @Override
+    public String[] getMechanismNames(Map<String, ?> props) {
+      return new String[] {"PLAIN"};
+    }
+  }
+}

--- a/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
+++ b/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
@@ -23,37 +23,59 @@ import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 import javax.security.sasl.SaslServerFactory;
 
+/**
+ * Because the Java SunSASL provider doesn't support the server-side PLAIN mechanism.
+ * There is a new provider needed to register to support server-side PLAIN mechanism.
+ * There are three basic steps in implementing a SASL security provider:
+ * 1.Write a class that implements the SaslServer interface {@link PlainSaslServer}
+ * 2.Write a factory class implements the SaslServerFactory
+ * 3.Write a JCA provider that registers the factory
+ */
 public class PlainSaslServerProvider extends Provider {
-  public static final String TACHYON_PLAIN_NAME = "TachyonSaslPlain";
+  public static final String TACHYON_PROVIDER_NAME = "TachyonSaslPlain";
+  public static final String TACHYON_MECHANSIM_NAME = "PLAIN";
 
   public PlainSaslServerProvider() {
-    super(TACHYON_PLAIN_NAME, 1.0, "Tachyon Plain SASL provider");
-    put("SaslServerFactory.PLAIN", SaslPlainServerFactory.class.getName());
+    super(TACHYON_PROVIDER_NAME, 1.0, "Tachyon Plain SASL provider");
+    put("SaslServerFactory." + TACHYON_MECHANSIM_NAME, PlainSaslServerFactory.class.getName());
   }
 
-  public static class SaslPlainServerFactory implements SaslServerFactory {
-
+  public static class PlainSaslServerFactory implements SaslServerFactory {
+    /**
+     * Creates a <tt>SaslServer</tt> using the parameters supplied.
+     * It returns null if no <tt>SaslServer</tt> can be created using the parameters supplied.
+     * Throws <tt>SaslException</tt> if it cannot create a <tt>SaslServer</tt>
+     * because of an error.
+     * @param mechanism The name of a SASL mechanism. (e.g. "PALIN").
+     * @param protocol The non-null string name of the protocol for which
+     * the authentication is being performed.
+     * @param serverName The non-null fully qualified host name of the server
+     * to authenticate to.
+     * @param props The possibly null set of properties used to select the SASL
+     * mechanism and to configure the authentication exchange of the selected
+     * mechanism.
+     *
+     * @param cbh The possibly null callback handler to used by the SASL
+     * mechanisms to do further operation.
+     *
+     *@return A possibly null <tt>SaslServer</tt> created using the parameters
+     * supplied. If null, this factory cannot produce a <tt>SaslServer</tt>
+     * using the parameters supplied.
+     *@exception SaslException If cannot create a <tt>SaslServer</tt> because of an error.
+     */
     @Override
     public SaslServer createSaslServer(String mechanism, String protocol, String serverName,
-                                       Map<String, ?> props, CallbackHandler cbh) {
-      if ("PLAIN".equals(mechanism)) {
-        try {
-          return new PlainSaslServer(cbh);
-        } catch (SaslException e) {
-          /* This is to fulfill the contract of the interface which states that an exception shall
-             be thrown when a SaslServer cannot be created due to an error but null should be
-             returned when a Server can't be created due to the parameters supplied. And the only
-             thing PlainSaslServer can fail on is a non-supported authentication mechanism.
-             That's why we return null instead of throwing the Exception */
-          return null;
-        }
+                                       Map<String, ?> props, CallbackHandler cbh)
+                                           throws SaslException {
+      if (TACHYON_MECHANSIM_NAME.equals(mechanism)) {
+        return new PlainSaslServer(cbh);
       }
       return null;
     }
 
     @Override
     public String[] getMechanismNames(Map<String, ?> props) {
-      return new String[] {"PLAIN"};
+      return new String[] {TACHYON_MECHANSIM_NAME};
     }
   }
 }

--- a/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
+++ b/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
@@ -38,9 +38,9 @@ public class PlainSaslServerProvider extends Provider {
   }
 
   /**
-   * PlainSaslServerFactory is used to create instances of {@link PlainSaslServer}.
-   * The parameter mechanism must be "PLAIN" when this PlainSaslServerFactory is called, or
-   * the null will be return.
+   * PlainSaslServerFactory is used to create instances of
+   * {@link PlainSaslServer}. The parameter mechanism must be "PLAIN" when this
+   * PlainSaslServerFactory is called, or the null will be return.
    */
   public static class PlainSaslServerFactory implements SaslServerFactory {
     /**

--- a/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
+++ b/common/src/main/java/tachyon/security/PlainSaslServerProvider.java
@@ -32,14 +32,19 @@ import javax.security.sasl.SaslServerFactory;
  * 3.Write a JCA provider that registers the factory
  */
 public class PlainSaslServerProvider extends Provider {
-  public static final String TACHYON_PROVIDER_NAME = "TachyonSaslPlain";
-  public static final String TACHYON_MECHANSIM_NAME = "PLAIN";
+  public static final String PROVIDER = "TachyonSaslPlain";
+  public static final String MECHANSIM = "PLAIN";
 
   public PlainSaslServerProvider() {
-    super(TACHYON_PROVIDER_NAME, 1.0, "Tachyon Plain SASL provider");
-    put("SaslServerFactory." + TACHYON_MECHANSIM_NAME, PlainSaslServerFactory.class.getName());
+    super(PROVIDER, 1.0, "Plain SASL provider");
+    put("SaslServerFactory." + MECHANSIM, PlainSaslServerFactory.class.getName());
   }
 
+  /**
+   * PlainSaslServerFactory was used to create instances of {@link PlainSaslServer}.
+   * The parameter mechanism must be "PLAIN" when this PlainSaslServerFactory was called, or
+   * the null will be return.
+   */
   public static class PlainSaslServerFactory implements SaslServerFactory {
     /**
      * Creates a <tt>SaslServer</tt> using the parameters supplied.
@@ -67,7 +72,7 @@ public class PlainSaslServerProvider extends Provider {
     public SaslServer createSaslServer(String mechanism, String protocol, String serverName,
                                        Map<String, ?> props, CallbackHandler cbh)
                                            throws SaslException {
-      if (TACHYON_MECHANSIM_NAME.equals(mechanism)) {
+      if (MECHANSIM.equals(mechanism)) {
         return new PlainSaslServer(cbh);
       }
       return null;
@@ -75,7 +80,7 @@ public class PlainSaslServerProvider extends Provider {
 
     @Override
     public String[] getMechanismNames(Map<String, ?> props) {
-      return new String[] {TACHYON_MECHANSIM_NAME};
+      return new String[] {MECHANSIM};
     }
   }
 }

--- a/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
+++ b/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
@@ -32,7 +32,15 @@ public class PlainSaslServerProviderTest {
     // create plainSaslServer
     SaslServer server = Sasl.createSaslServer("PLAIN", "", "",
         new HashMap<String, String>(), null);
-    Assert.assertEquals("PLAIN", server.getMechanismName());
+    Assert.assertEquals(PlainSaslServerProvider.MECHANISM, server.getMechanismName());
+  }
+
+  @Test
+  public void createNoSupportSaslServerTest() throws Exception {
+    // create a SaslServer which PlainSaslServerProvider has not supported
+    SaslServer server = Sasl.createSaslServer("NO_PLAIN", "", "",
+        new HashMap<String, String>(), null);
+    Assert.assertNull(server);
   }
 
   @Test

--- a/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
+++ b/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
@@ -29,12 +29,10 @@ public class PlainSaslServerProviderTest {
 
   @Test
   public void createPlainSaslServerTest() throws Exception {
-    if (PlainSaslHelper.isPlainSaslProviderAdded()) {
-      // create plainSaslServer
-      SaslServer server = Sasl.createSaslServer("PLAIN", "", "",
-          new HashMap<String, String>(), null);
-      Assert.assertEquals("PLAIN", server.getMechanismName());
-    }
+    // create plainSaslServer
+    SaslServer server = Sasl.createSaslServer("PLAIN", "", "",
+        new HashMap<String, String>(), null);
+    Assert.assertEquals("PLAIN", server.getMechanismName());
   }
 
   @Test

--- a/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
+++ b/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
@@ -30,7 +30,7 @@ public class PlainSaslServerProviderTest {
   @Test
   public void createPlainSaslServerTest() throws Exception {
     // create plainSaslServer
-    SaslServer server = Sasl.createSaslServer(PlainSaslServerProvider.PROVIDER, "", "",
+    SaslServer server = Sasl.createSaslServer(PlainSaslServerProvider.MECHANISM, "", "",
         new HashMap<String, String>(), null);
     Assert.assertEquals(PlainSaslServerProvider.MECHANISM, server.getMechanismName());
   }

--- a/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
+++ b/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
@@ -30,7 +30,7 @@ public class PlainSaslServerProviderTest {
   @Test
   public void createPlainSaslServerTest() throws Exception {
     // create plainSaslServer
-    SaslServer server = Sasl.createSaslServer("PLAIN", "", "",
+    SaslServer server = Sasl.createSaslServer(PlainSaslServerProvider.PROVIDER, "", "",
         new HashMap<String, String>(), null);
     Assert.assertEquals(PlainSaslServerProvider.MECHANISM, server.getMechanismName());
   }

--- a/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
+++ b/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
@@ -29,11 +29,16 @@ public class PlainSaslServerProviderTest {
 
   @Test
   public void createPlainSaslServerTest() throws Exception {
-    if (PlainSaslHelper.isPlainSaslProviderAdd()) {
+    if (PlainSaslHelper.isPlainSaslProviderAdded()) {
       // create plainSaslServer
       SaslServer server = Sasl.createSaslServer("PLAIN", "", "",
           new HashMap<String, String>(), null);
       Assert.assertEquals("PLAIN", server.getMechanismName());
     }
+  }
+
+  @Test
+  public void plainSaslProviderHasRegisteredTest() throws Exception {
+    Assert.assertTrue(PlainSaslHelper.isPlainSaslProviderAdded());
   }
 }

--- a/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
+++ b/common/src/test/java/tachyon/security/PlainSaslServerProviderTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.security;
+
+import java.util.HashMap;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslServer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import tachyon.security.PlainSaslHelper;
+
+public class PlainSaslServerProviderTest {
+
+  @Test
+  public void createPlainSaslServerTest() throws Exception {
+    if (PlainSaslHelper.isPlainSaslProviderAdd()) {
+      // create plainSaslServer
+      SaslServer server = Sasl.createSaslServer("PLAIN", "", "",
+          new HashMap<String, String>(), null);
+      Assert.assertEquals("PLAIN", server.getMechanismName());
+    }
+  }
+}


### PR DESCRIPTION
Because the Java SunSASL provider doesn’t support the server-side PLAIN mechanism. There is a new provider needed to register to support server-side PLAIN mechanism. There are three basic steps in implementing a SASL security provider.
1.Write a class that implements the SaslServer interface (It has been merged into security branch)
2.Write a factory class that implements the SaslServerFactory which creates instances of the SaslServer
3.Write a JCA provider that registers the factory
This PR is the remaining two steps to implement the provider supported the server-side PLAIN mechanism