### PR TITLE
[SMALLFIX] Cast filesystem to distributed filesystem

### DIFF
--- a/integration-tests/src/test/java/tachyon/underfs/hdfs/LocalMiniDFSCluster.java
+++ b/integration-tests/src/test/java/tachyon/underfs/hdfs/LocalMiniDFSCluster.java
@@ -235,7 +235,7 @@ public class LocalMiniDFSCluster extends UnderFileSystemCluster {
         mNamenodePort = mDfsCluster.getNameNodePort();
       }
 
-      mDfsClient = mDfsCluster.getFileSystem();
+      mDfsClient = (DistributedFileSystem) mDfsCluster.getFileSystem();
       mIsStarted = true;
     }
   }


### PR DESCRIPTION
In older versions of hadoop the cast may be required.