### PR TITLE
[SMALLFIX] Add javadoc to explain the unnecessary cast

### DIFF
--- a/integration-tests/src/test/java/tachyon/underfs/hdfs/LocalMiniDFSCluster.java
+++ b/integration-tests/src/test/java/tachyon/underfs/hdfs/LocalMiniDFSCluster.java
@@ -235,7 +235,7 @@ public class LocalMiniDFSCluster extends UnderFileSystemCluster {
         mNamenodePort = mDfsCluster.getNameNodePort();
       }
 
-      // For HDFS of eariler versions, getFileSystem() returns an instance of type
+      // For HDFS of earlier versions, getFileSystem() returns an instance of type
       // {@link org.apache.hadoop.fs.FileSystem} rather than {@link DistributedFileSystem}
       mDfsClient = (DistributedFileSystem) mDfsCluster.getFileSystem();
       mIsStarted = true;

--- a/integration-tests/src/test/java/tachyon/underfs/hdfs/LocalMiniDFSCluster.java
+++ b/integration-tests/src/test/java/tachyon/underfs/hdfs/LocalMiniDFSCluster.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 
-import tachyon.conf.TachyonConf;
 import tachyon.TachyonURI;
+import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.underfs.UnderFileSystemCluster;
 import tachyon.util.UnderFileSystemUtils;
@@ -235,6 +235,8 @@ public class LocalMiniDFSCluster extends UnderFileSystemCluster {
         mNamenodePort = mDfsCluster.getNameNodePort();
       }
 
+      // For HDFS of eariler versions, getFileSystem() returns an instance of type
+      // {@link org.apache.hadoop.fs.FileSystem} rather than {@link DistributedFileSystem}
       mDfsClient = (DistributedFileSystem) mDfsCluster.getFileSystem();
       mIsStarted = true;
     }


### PR DESCRIPTION
Compiling with some HDFS profiles, IDE will complain the unnecessary cast, which is in fact useful for some other HDFS profiles.