### PR TITLE
[SMALLFIX] Update links in docs to be relative.

### DIFF
--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -94,7 +94,7 @@
                                         </a>
                                     </li>
                                 {% else %}
-                                    <li><a href="{{node.url}}">
+                                    <li><a href="{{ node.url | remove-first: '/' }}">
                                         {% if node.nickname == null %}
                                             {{node.title}}
                                         {% else %}

--- a/docs/_layouts/global.html
+++ b/docs/_layouts/global.html
@@ -94,6 +94,7 @@
                                         </a>
                                     </li>
                                 {% else %}
+                                    <!-- trim the leading slash to make the path relative to preserve version links -->
                                     <li><a href="{{ node.url | remove-first: '/' }}">
                                         {% if node.nickname == null %}
                                             {{node.title}}


### PR DESCRIPTION
If they are absolute it will not resolve to the correct version on the webpage but always go to the current version.