### PR TITLE
[TACHYON-702] Use mUserId as HashCode

### DIFF
--- a/servers/src/main/java/tachyon/UserInfo.java
+++ b/servers/src/main/java/tachyon/UserInfo.java
@@ -57,8 +57,12 @@ public class UserInfo {
   
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     UserInfo userInfo = (UserInfo) o;
     return mUserId == userInfo.mUserId;
   }

--- a/servers/src/main/java/tachyon/UserInfo.java
+++ b/servers/src/main/java/tachyon/UserInfo.java
@@ -54,4 +54,17 @@ public class UserInfo {
     sb.append(")");
     return sb.toString();
   }
+  
+  @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserInfo userInfo = (UserInfo) o;
+        return mUserId == userInfo.mUserId;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) (mUserId ^ (mUserId >>> 32));
+    }
 }

--- a/servers/src/main/java/tachyon/UserInfo.java
+++ b/servers/src/main/java/tachyon/UserInfo.java
@@ -57,14 +57,14 @@ public class UserInfo {
   
   @Override
   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      UserInfo userInfo = (UserInfo) o;
-      return mUserId == userInfo.mUserId;
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    UserInfo userInfo = (UserInfo) o;
+    return mUserId == userInfo.mUserId;
   }
 
   @Override
   public int hashCode() {
-      return (int) (mUserId ^ (mUserId >>> 32));
+    return (int) (mUserId ^ (mUserId >>> 32));
   }
 }

--- a/servers/src/main/java/tachyon/UserInfo.java
+++ b/servers/src/main/java/tachyon/UserInfo.java
@@ -56,15 +56,15 @@ public class UserInfo {
   }
   
   @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        UserInfo userInfo = (UserInfo) o;
-        return mUserId == userInfo.mUserId;
-    }
+  public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      UserInfo userInfo = (UserInfo) o;
+      return mUserId == userInfo.mUserId;
+  }
 
-    @Override
-    public int hashCode() {
-        return (int) (mUserId ^ (mUserId >>> 32));
-    }
+  @Override
+  public int hashCode() {
+      return (int) (mUserId ^ (mUserId >>> 32));
+  }
 }


### PR DESCRIPTION
Why not override equals and hashCode to use mUserId to identify UserInfo object.
As mUserId is used to identify an UserInfo object.