### PR TITLE
[SMALLFIX] Fix wrong version in `tachyon-config.sh` of branch-0.6

### DIFF
--- a/libexec/tachyon-config.sh
+++ b/libexec/tachyon-config.sh
@@ -25,7 +25,7 @@ if [ -z "$TACHYON_SYSTEM_INSTALLATION" ]; then
   export TACHYON_HOME=${TACHYON_PREFIX}
   export TACHYON_CONF_DIR="$TACHYON_HOME/conf"
   export TACHYON_LOGS_DIR="$TACHYON_HOME/logs"
-  export TACHYON_JAR=$TACHYON_HOME/core/target/tachyon-0.6.4-jar-with-dependencies.jar
+  export TACHYON_JAR=$TACHYON_HOME/core/target/tachyon-0.6.5-SNAPSHOT-jar-with-dependencies.jar
   export JAVA="$JAVA_HOME/bin/java"
 fi
 


### PR DESCRIPTION
0.6 is really in 0.6.5-SNAPSHOT, updating the script.