### PR TITLE
[TACHYON-710] Fix 'XBytesOnTiers' to be compatible in Master and Worker

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
@@ -200,7 +200,7 @@ public class BlockDataManager {
       Long storageDirId = loc.getStorageDirId();
       Long length = meta.getBlockSize();
       BlockStoreMeta storeMeta = mBlockStore.getBlockStoreMeta();
-      Long bytesUsedOnTier = storeMeta.getUsedBytesOnTiers().get(loc.tierLevel());
+      Long bytesUsedOnTier = storeMeta.getUsedBytesOnTiers().get(loc.tierAlias() - 1);
       mMasterClient
           .worker_cacheBlock(mWorkerId, bytesUsedOnTier, storageDirId, blockId, length);
     } catch (TException te) {

--- a/servers/src/main/java/tachyon/worker/block/BlockStoreMeta.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockStoreMeta.java
@@ -16,6 +16,7 @@
 package tachyon.worker.block;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -23,6 +24,7 @@ import java.util.Map;
 
 import com.google.common.base.Preconditions;
 
+import tachyon.StorageLevelAlias;
 import tachyon.worker.block.meta.StorageDir;
 import tachyon.worker.block.meta.StorageTier;
 
@@ -34,10 +36,20 @@ import tachyon.worker.block.meta.StorageTier;
 public class BlockStoreMeta {
   // TODO: the following two fields don't need to be computed on the creation of each
   // {@link BlockStoreMeta} instance.
-  private final List<Long> mCapacityBytesOnTiers = new ArrayList<Long>();
+  /**
+   * Capacity bytes on each tier alias (MEM, SSD and HDD).
+   * E.g., for two tiers [MEM: 1GB][HDD: 10GB], this list will be [0:1GB][1:0][2:10GB].
+   */
+  private final List<Long> mCapacityBytesOnTiers = new ArrayList<Long>(Collections.nCopies(
+      StorageLevelAlias.SIZE, 0L));
   private final Map<Long, Long> mCapacityBytesOnDirs = new HashMap<Long, Long>();
 
-  private final List<Long> mUsedBytesOnTiers = new ArrayList<Long>();
+  /**
+   * Used bytes on each tier alias (MEM, SSD and HDD).
+   * This list has the same format with <code>mCapacityBytesOnTiers</code>.
+   */
+  private final List<Long> mUsedBytesOnTiers = new ArrayList<Long>(Collections.nCopies(
+      StorageLevelAlias.SIZE, 0L));
   private final Map<Long, List<Long>> mBlockIdsOnDirs = new HashMap<Long, List<Long>>();
   private final Map<Long, Long> mUsedBytesOnDirs = new HashMap<Long, Long>();
   private final Map<Long, String> mDirPaths = new LinkedHashMap<Long, String>();
@@ -45,8 +57,11 @@ public class BlockStoreMeta {
   public BlockStoreMeta(BlockMetadataManager manager) {
     Preconditions.checkNotNull(manager);
     for (StorageTier tier : manager.getTiers()) {
-      mCapacityBytesOnTiers.add(tier.getCapacityBytes());
-      mUsedBytesOnTiers.add(tier.getCapacityBytes() - tier.getAvailableBytes());
+      int aliasIndex = tier.getTierAlias() - 1;
+      mCapacityBytesOnTiers.set(aliasIndex, mCapacityBytesOnTiers.get(aliasIndex)
+          + tier.getCapacityBytes());
+      mUsedBytesOnTiers.set(aliasIndex, mUsedBytesOnTiers.get(aliasIndex)
+          + (tier.getCapacityBytes() - tier.getAvailableBytes()));
       for (StorageDir dir : tier.getStorageDirs()) {
         mBlockIdsOnDirs.put(dir.getStorageDirId(), dir.getBlockIds());
         mCapacityBytesOnDirs.put(dir.getStorageDirId(), dir.getCapacityBytes());

--- a/servers/src/main/webapp/worker/general.jsp
+++ b/servers/src/main/webapp/worker/general.jsp
@@ -70,13 +70,15 @@
                 <% List<Long> capacityBytesOnTiers = (List<Long>) request.getAttribute("capacityBytesOnTiers"); %>
                 <% List<Long> usedBytesOnTiers = (List<Long>) request.getAttribute("usedBytesOnTiers"); %>
                 <% for (int i = 0; i < capacityBytesOnTiers.size(); i ++) { %>
-                <tr>
-                  <th><%= StorageLevelAlias.values()[i].name() %> Capacity / Used</th>
-                  <th>
-                    <%= CommonUtils.getSizeFromBytes(capacityBytesOnTiers.get(i)) %> /
-                    <%= CommonUtils.getSizeFromBytes(usedBytesOnTiers.get(i)) %>
-                  </th>
-                </tr>
+                  <% if (capacityBytesOnTiers.get(i) > 0) { %>
+                  <tr>
+                    <th><%= StorageLevelAlias.values()[i].name() %> Capacity / Used</th>
+                    <th>
+                      <%= CommonUtils.getSizeFromBytes(capacityBytesOnTiers.get(i)) %> /
+                      <%= CommonUtils.getSizeFromBytes(usedBytesOnTiers.get(i)) %>
+                    </th>
+                  </tr>
+                  <% } %>
                 <% } %>
               </tbody>
             </table>

--- a/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerTest.java
@@ -17,6 +17,7 @@ package tachyon.worker.block;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
@@ -298,6 +299,13 @@ public class BlockMetadataManagerTest {
 
   @Test
   public void getBlockStoreMetaTest() throws Exception {
-    Assert.assertNotNull(mMetaManager.getBlockStoreMeta());
+    BlockStoreMeta meta = mMetaManager.getBlockStoreMeta();
+    Assert.assertNotNull(meta);
+
+    // Assert the capacities are at alias level [MEM: 1000][SSD: 0][HDD: 8000]
+    List<Long> exceptedCapacityBytesOnTiers = new ArrayList<Long>(Arrays.asList(1000L, 0L, 8000L));
+    List<Long> exceptedUsedBytesOnTiers = new ArrayList<Long>(Arrays.asList(0L, 0L, 0L));
+    Assert.assertEquals(exceptedCapacityBytesOnTiers, meta.getCapacityBytesOnTiers());
+    Assert.assertEquals(exceptedUsedBytesOnTiers, meta.getUsedBytesOnTiers());
   }
 }


### PR DESCRIPTION
[TACHYON-710] https://tachyon.atlassian.net/browse/TACHYON-710

Master and WebUI treat `CapacityBytesOnTiers` at alias level. But Worker treats it at tier level.
This PR fixes the incompatibility by modifying Worker to treat at alias level.