### PR TITLE
[TACHYON-717]: Disable IPv6 stack on unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.14</version>
           <configuration>
-            <argLine>-Djava.security.krb5.realm= -Djava.security.krb5.kdc=</argLine>
+            <argLine>-Djava.net.preferIPv4Stack=true -Djava.security.krb5.realm= -Djava.security.krb5.kdc=</argLine>
             <redirectTestOutputToFile>${test.output.redirect}</redirectTestOutputToFile>
           </configuration>
         </plugin>


### PR DESCRIPTION
This update can avoid running unit tests on IPv4-mapped IPv6 addresses. 