### PR TITLE
[TACHYON-639] Fix bug in `RemoteBlockInStream#retrieveByteBufferFromRemoteMachine`

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -347,7 +347,7 @@ public class RemoteBlockInStream extends BlockInStream {
       long blockId, long offset, long length, TachyonConf conf) throws IOException {
     // always clear the previous reader before assigning it to a new one
     closeReader();
-    RemoteBlockReader mCurrentReader = RemoteBlockReader.Factory.createRemoteBlockReader(conf);
+    mCurrentReader = RemoteBlockReader.Factory.createRemoteBlockReader(conf);
     return mCurrentReader.readRemoteBlock(
         address.getHostName(), address.getPort(), blockId, offset, length);
   }


### PR DESCRIPTION
JIRA: https://tachyon.atlassian.net/browse/TACHYON-639

From [TACHYON-639](https://tachyon.atlassian.net/browse/TACHYON-639), we keep a reference of current reader in `RemoteBlockInStream` so that we can call `closeReader` when we close the stream. In `#retrieveByteBufferFromRemoteMachine`, the created reader instance is not assigned to the reference but instead a local variable. This PR fixes it.

In the future, we should add integration tests to make sure underlying buffers from the reader are always released when a stream is closed [(TACHYON-721)](https://tachyon.atlassian.net/browse/TACHYON-721). To further eliminate buffer leakage, we also want to investigate a way to release buffer when threads exit unexpectedly [(TACHYON-722)](https://tachyon.atlassian.net/browse/TACHYON-722).