### PR TITLE
[Tachyon-470] Consolidate the source of default value for TachyonConf

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
@@ -40,8 +40,7 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
    * @throws IOException If file already exists, or path is invalid.
    */
   public synchronized int createFile(TachyonURI path) throws IOException {
-    long defaultBlockSize = mTachyonConf.getBytes(Constants.USER_DEFAULT_BLOCK_SIZE_BYTE,
-        Constants.DEFAULT_BLOCK_SIZE_BYTE);
+    long defaultBlockSize = mTachyonConf.getBytes(Constants.USER_DEFAULT_BLOCK_SIZE_BYTE);
     return createFile(path, defaultBlockSize);
   }
 

--- a/clients/unshaded/src/main/java/tachyon/client/BlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/BlockOutStream.java
@@ -43,7 +43,7 @@ public abstract class BlockOutStream extends OutStream {
   public static BlockOutStream get(TachyonFile tachyonFile, WriteType opType, int blockIndex,
       TachyonConf tachyonConf) throws IOException {
     return get(tachyonFile, opType, blockIndex,
-        tachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES, 8 * Constants.MB), tachyonConf);
+        tachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES), tachyonConf);
   }
 
   /**

--- a/clients/unshaded/src/main/java/tachyon/client/LocalBlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/LocalBlockOutStream.java
@@ -70,8 +70,8 @@ public class LocalBlockOutStream extends BlockOutStream {
    */
   LocalBlockOutStream(TachyonFile file, WriteType opType, int blockIndex, TachyonConf tachyonConf)
       throws IOException {
-    this(file, opType, blockIndex, tachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES,
-        8 * Constants.MB), tachyonConf);
+    this(file, opType, blockIndex, tachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES),
+        tachyonConf);
   }
 
   /**
@@ -112,7 +112,7 @@ public class LocalBlockOutStream extends BlockOutStream {
         + ", blockId: " + mBlockId + ", blockCapacityByte: " + mBlockCapacityByte);
     mAvailableBytes += initialBytes;
 
-    mBufferBytes = mTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES, Constants.MB);
+    mBufferBytes = mTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES);
     mBuffer = ByteBuffer.allocate(Ints.checkedCast(mBufferBytes));
   }
 

--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -428,7 +428,7 @@ public class RemoteBlockInStream extends BlockInStream {
    */
   private boolean updateCurrentBuffer() throws IOException {
     long bufferSize =
-        mTachyonConf.getBytes(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE, 8 * Constants.MB);
+        mTachyonConf.getBytes(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE);
     if (mCurrentBuffer != null && mBufferStartPos <= mBlockPos
         && mBlockPos < Math.min(mBufferStartPos + bufferSize, mBlockInfo.length)) {
       // We move the buffer to read at mBlockPos

--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockOutStream.java
@@ -62,8 +62,8 @@ public class RemoteBlockOutStream extends BlockOutStream {
    */
   RemoteBlockOutStream(TachyonFile file, WriteType opType, int blockIndex, TachyonConf tachyonConf)
       throws IOException {
-    this(file, opType, blockIndex, tachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES,
-        8 * Constants.MB), tachyonConf);
+    this(file, opType, blockIndex, tachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES),
+        tachyonConf);
   }
 
   /**
@@ -91,7 +91,7 @@ public class RemoteBlockOutStream extends BlockOutStream {
     mCloser = Closer.create();
 
     // Create a local buffer.
-    mBufferBytes = mTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES, Constants.MB);
+    mBufferBytes = mTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES);
     mBuffer = ByteBuffer.allocate(Ints.checkedCast(mBufferBytes));
 
     // Open the remote writer.

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -185,7 +185,7 @@ public class TachyonFS extends AbstractTachyonFS {
     String masterHost =
         tachyonConf.get(Constants.MASTER_HOSTNAME,
             NetworkAddressUtils.getLocalHostName(tachyonConf));
-    int masterPort = tachyonConf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
+    int masterPort = tachyonConf.getInt(Constants.MASTER_PORT);
 
     mMasterAddress = new InetSocketAddress(masterHost, masterPort);
     mZookeeperMode = mTachyonConf.getBoolean(Constants.USE_ZOOKEEPER, false);
@@ -197,8 +197,7 @@ public class TachyonFS extends AbstractTachyonFS {
         mCloser.register(new WorkerClient(mMasterClient, mExecutorService, mTachyonConf,
             mClientMetrics));
     mUserFailedSpaceRequestLimits =
-        mTachyonConf.getInt(Constants.USER_FAILED_SPACE_REQUEST_LIMITS,
-            Constants.DEFAULT_USER_FAILED_SPACE_REQUEST_LIMITS);
+        mTachyonConf.getInt(Constants.USER_FAILED_SPACE_REQUEST_LIMITS);
 
     String scheme = mZookeeperMode ? Constants.SCHEME_FT : Constants.SCHEME;
     String authority = mMasterAddress.getHostName() + ":" + mMasterAddress.getPort();
@@ -368,7 +367,7 @@ public class TachyonFS extends AbstractTachyonFS {
   public synchronized int createRawTable(TachyonURI path, int columns, ByteBuffer metadata)
       throws IOException {
     validateUri(path);
-    int maxColumns = mTachyonConf.getInt(Constants.MAX_COLUMNS, 1000);
+    int maxColumns = mTachyonConf.getInt(Constants.MAX_COLUMNS);
     if (columns < 1 || columns > maxColumns) {
       throw new IOException("Column count " + columns + " is smaller than 1 or " + "bigger than "
           + maxColumns);

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -906,7 +906,7 @@ public class TachyonFS extends AbstractTachyonFS {
     }
 
     long userQuotaUnitBytes =
-        mTachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES, 8 * Constants.MB);
+        mTachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES);
 
     long toRequestSpaceBytes = Math.max(requestSpaceBytes, userQuotaUnitBytes);
     for (int attempt = 0; attempt < mUserFailedSpaceRequestLimits; attempt ++) {

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
@@ -508,7 +508,7 @@ public class TachyonFile implements Comparable<TachyonFile> {
       inputStream.skip(offset);
 
       int bufferBytes =
-          (int) mTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES, Constants.MB);
+          (int) mTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES);
       byte[] buffer = new byte[bufferBytes];
       bos = BlockOutStream.get(this, WriteType.TRY_CACHE, blockIndex, mTachyonConf);
       int limit;

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyClient.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyClient.java
@@ -53,11 +53,11 @@ public final class NettyClient {
   // Use daemon threads so the JVM is allowed to shutdown even when daemon threads are alive.
   // If number of worker threads is 0, Netty creates (#processors * 2) threads by default.
   private static final EventLoopGroup WORKER_GROUP = NettyUtils.createEventLoop(CHANNEL_TYPE,
-      TACHYON_CONF.getInt(Constants.USER_NETTY_WORKER_THREADS, 0), "netty-client-worker-%d", true);
+      TACHYON_CONF.getInt(Constants.USER_NETTY_WORKER_THREADS), "netty-client-worker-%d", true);
 
   // The maximum number of milliseconds to wait for a response from the server.
   public static final long TIMEOUT_MS =
-      TACHYON_CONF.getInt(Constants.USER_NETTY_TIMEOUT_MS, 3000);
+      TACHYON_CONF.getInt(Constants.USER_NETTY_TIMEOUT_MS);
 
   /**
    * Creates and returns a new Netty client bootstrap for clients to connect to remote servers.

--- a/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -283,8 +283,7 @@ abstract class AbstractTFS extends FileSystem {
 
   @Override
   public long getDefaultBlockSize() {
-    return mTachyonConf.getBytes(Constants.USER_DEFAULT_BLOCK_SIZE_BYTE,
-        Constants.DEFAULT_BLOCK_SIZE_BYTE);
+    return mTachyonConf.getBytes(Constants.USER_DEFAULT_BLOCK_SIZE_BYTE);
   }
 
   @Override

--- a/clients/unshaded/src/main/java/tachyon/hadoop/HdfsFileInputStream.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/HdfsFileInputStream.java
@@ -66,7 +66,7 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
     LOG.debug("PartitionInputStreamHdfs({}, {}, {}, {}, {}, {})", tfs, fileId, hdfsPath, conf,
         bufferSize, stats);
     mTachyonConf = tachyonConf;
-    long bufferBytes = mTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES, 0);
+    long bufferBytes = mTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES);
     mBuffer = new byte[Ints.checkedCast(bufferBytes) * 4];
     mCurrentPosition = 0;
     mTFS = tfs;

--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -316,6 +316,10 @@ public class TachyonConf {
     }
   }
 
+  public long getBytes(String key) {
+    return getBytes(key, 0L);
+  }
+
   public <T> Class<T> getClass(String key, Class<T> defaultValue) {
     if (mProperties.containsKey(key)) {
       String rawValue = mProperties.getProperty(key);

--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -241,10 +241,19 @@ public class TachyonConf {
   }
 
   public int getInt(String key) {
-    return getInt(key, 0);
+    if (mProperties.containsKey(key)) {
+      String rawValue = mProperties.getProperty(key);
+      try {
+        return Integer.parseInt(lookup(rawValue));
+      } catch (NumberFormatException e) {
+        throw new RuntimeException("Configuration cannot evaluate key " + key + " as integer.");
+      }
+    }
+    // if key is not found among the default properties
+    throw new RuntimeException("Invalid configuration key " + key + ".");
   }
 
-  public long getLong(String key, final long defaultValue) {
+  private long getLong(String key, final long defaultValue) {
     if (mProperties.containsKey(key)) {
       String rawValue = mProperties.getProperty(key);
       try {
@@ -256,7 +265,7 @@ public class TachyonConf {
     return defaultValue;
   }
 
-  public double getDouble(String key, final double defaultValue) {
+  private double getDouble(String key, final double defaultValue) {
     if (mProperties.containsKey(key)) {
       String rawValue = mProperties.getProperty(key);
       try {
@@ -268,7 +277,7 @@ public class TachyonConf {
     return defaultValue;
   }
 
-  public float getFloat(String key, final float defaultValue) {
+  private float getFloat(String key, final float defaultValue) {
     if (mProperties.containsKey(key)) {
       String rawValue = mProperties.getProperty(key);
       try {
@@ -307,7 +316,7 @@ public class TachyonConf {
     return defaultValue;
   }
 
-  public long getBytes(String key, long defaultValue) {
+  private long getBytes(String key, long defaultValue) {
     String rawValue = get(key, "");
     try {
       return FormatUtils.parseSpaceSize(rawValue);
@@ -317,7 +326,15 @@ public class TachyonConf {
   }
 
   public long getBytes(String key) {
-    return getBytes(key, 0L);
+    if (mProperties.containsKey(key)) {
+      String rawValue = get(key);
+      try {
+        return FormatUtils.parseSpaceSize(rawValue);
+      } catch (Exception ex) {
+        throw new RuntimeException("Configuration cannot evaluate key " + key + " as bytes.");
+      }
+    }
+    throw new RuntimeException("Invalid configuration key " + key + ".");
   }
 
   public <T> Class<T> getClass(String key, Class<T> defaultValue) {

--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -265,16 +265,17 @@ public class TachyonConf {
     return defaultValue;
   }
 
-  private double getDouble(String key, final double defaultValue) {
+  public double getDouble(String key) {
     if (mProperties.containsKey(key)) {
       String rawValue = mProperties.getProperty(key);
       try {
         return Double.parseDouble(lookup(rawValue));
       } catch (NumberFormatException e) {
-        LOG.warn("Configuration cannot evaluate key " + key + " as double.");
+        throw new RuntimeException("Configuration cannot evaluate key " + key + " as double.");
       }
     }
-    return defaultValue;
+    // if key is not found among the default properties
+    throw new RuntimeException("Invalid configuration key " + key + ".");
   }
 
   private float getFloat(String key, final float defaultValue) {
@@ -314,15 +315,6 @@ public class TachyonConf {
       return null == val ? defaultValue : Enum.valueOf(defaultValue.getDeclaringClass(), val);
     }
     return defaultValue;
-  }
-
-  private long getBytes(String key, long defaultValue) {
-    String rawValue = get(key, "");
-    try {
-      return FormatUtils.parseSpaceSize(rawValue);
-    } catch (Exception ex) {
-      return defaultValue;
-    }
   }
 
   public long getBytes(String key) {

--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -221,10 +221,7 @@ public class TachyonConf {
   }
 
   public String get(String key) {
-    String raw = mProperties.getProperty(key, null);
-    String value = lookup(raw);
-    LOG.debug("Get Tachyon property {} as {}", key, value);
-    return value;
+    return get(key, null);
   }
 
   public boolean containsKey(String key) {
@@ -241,6 +238,10 @@ public class TachyonConf {
       }
     }
     return defaultValue;
+  }
+
+  public int getInt(String key) {
+    return getInt(key, 0);
   }
 
   public long getLong(String key, final long defaultValue) {

--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -220,6 +220,13 @@ public class TachyonConf {
     return updated;
   }
 
+  public String get(String key) {
+    String raw = mProperties.getProperty(key, null);
+    String value = lookup(raw);
+    LOG.debug("Get Tachyon property {} as {}", key, value);
+    return value;
+  }
+
   public boolean containsKey(String key) {
     return mProperties.containsKey(key);
   }

--- a/common/src/main/java/tachyon/master/MasterClient.java
+++ b/common/src/main/java/tachyon/master/MasterClient.java
@@ -285,8 +285,8 @@ public final class MasterClient implements Closeable {
     }
 
     LeaderInquireClient leaderInquireClient =
-        LeaderInquireClient.getClient(mTachyonConf.get(Constants.ZOOKEEPER_ADDRESS, null),
-            mTachyonConf.get(Constants.ZOOKEEPER_LEADER_PATH, null));
+        LeaderInquireClient.getClient(mTachyonConf.get(Constants.ZOOKEEPER_ADDRESS),
+            mTachyonConf.get(Constants.ZOOKEEPER_LEADER_PATH));
     try {
       String temp = leaderInquireClient.getMasterAddress();
       return NetworkAddressUtils.parseInetSocketAddress(temp);

--- a/common/src/main/java/tachyon/master/MasterClient.java
+++ b/common/src/main/java/tachyon/master/MasterClient.java
@@ -174,7 +174,7 @@ public final class MasterClient implements Closeable {
     }
 
     Exception lastException = null;
-    int maxConnectsTry = mTachyonConf.getInt(Constants.MASTER_RETRY_COUNT, 29);
+    int maxConnectsTry = mTachyonConf.getInt(Constants.MASTER_RETRY_COUNT);
     RetryPolicy retry = new ExponentialBackoffRetry(50, Constants.SECOND_MS, maxConnectsTry);
     do {
       mMasterAddress = getMasterAddress();
@@ -193,7 +193,7 @@ public final class MasterClient implements Closeable {
 
         String threadName = "master-heartbeat-" + mMasterAddress;
         int interval =
-            mTachyonConf.getInt(Constants.USER_HEARTBEAT_INTERVAL_MS, Constants.SECOND_MS);
+            mTachyonConf.getInt(Constants.USER_HEARTBEAT_INTERVAL_MS);
         mHeartbeat =
             mExecutorService.submit(new HeartbeatThread(threadName, heartBeater, interval / 2));
       } catch (TTransportException e) {

--- a/common/src/main/java/tachyon/util/network/NetworkAddressUtils.java
+++ b/common/src/main/java/tachyon/util/network/NetworkAddressUtils.java
@@ -243,6 +243,8 @@ public final class NetworkAddressUtils {
   public static InetSocketAddress getMasterAddress(TachyonConf conf) {
     String masterHostname =
         conf.get(Constants.MASTER_HOSTNAME, getLocalHostName(conf));
+    // Cannot rely on tachyon-default.properties because GetMasterWorkerAddressTest will test with
+    // fake conf
     int masterPort = conf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
     return new InetSocketAddress(masterHostname, masterPort);
   }
@@ -257,6 +259,8 @@ public final class NetworkAddressUtils {
    */
   public static InetSocketAddress getLocalWorkerAddress(TachyonConf conf) {
     String workerHostname = getLocalHostName(conf);
+    // Cannot rely on tachyon-default.properties because GetMasterWorkerAddressTest will test with
+    // fake conf
     int workerPort = conf.getInt(Constants.WORKER_PORT, Constants.DEFAULT_WORKER_PORT);
     return new InetSocketAddress(workerHostname, workerPort);
   }

--- a/common/src/main/java/tachyon/worker/WorkerClient.java
+++ b/common/src/main/java/tachyon/worker/WorkerClient.java
@@ -259,8 +259,7 @@ public class WorkerClient implements Closeable {
       mHeartbeatExecutor =
           new WorkerClientHeartbeatExecutor(this, mMasterClient.getUserId());
       String threadName = "worker-heartbeat-" + mWorkerAddress;
-      int interval = mTachyonConf.getInt(Constants.USER_HEARTBEAT_INTERVAL_MS,
-          Constants.SECOND_MS);
+      int interval = mTachyonConf.getInt(Constants.USER_HEARTBEAT_INTERVAL_MS);
       mHeartbeat =
           mExecutorService.submit(new HeartbeatThread(threadName, mHeartbeatExecutor, interval));
 

--- a/common/src/main/resources/tachyon-default.properties
+++ b/common/src/main/resources/tachyon-default.properties
@@ -28,6 +28,7 @@ tachyon.underfs.hadoop.configuration=${tachyon.home}/conf/core-site.xml
 tachyon.underfs.address=${tachyon.home}/underFSStorage
 tachyon.underfs.hdfs.impl=org.apache.hadoop.hdfs.DistributedFileSystem
 tachyon.underfs.glusterfs.impl=org.apache.hadoop.fs.glusterfs.GlusterFileSystem
+tachyon.underfs.glusterfs.mapred.system.dir=glusterfs:///mapred/system
 tachyon.data.folder=${tachyon.underfs.address}/tachyon/data
 tachyon.workers.folder=${tachyon.underfs.address}/tachyon/workers
 tachyon.usezookeeper=false

--- a/common/src/test/java/tachyon/conf/TachyonConfTest.java
+++ b/common/src/test/java/tachyon/conf/TachyonConfTest.java
@@ -110,7 +110,7 @@ public class TachyonConfTest {
     intValue = sDefaultTachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT_MS);
     Assert.assertEquals(Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT_MS, intValue);
 
-    long longBytesValue = sDefaultTachyonConf.getBytes(Constants.MAX_TABLE_METADATA_BYTE, 0L);
+    long longBytesValue = sDefaultTachyonConf.getBytes(Constants.MAX_TABLE_METADATA_BYTE);
     Assert.assertTrue(longBytesValue == Constants.MB * 5);
   }
 
@@ -194,7 +194,7 @@ public class TachyonConfTest {
     intValue = sDefaultTachyonConf.getInt(Constants.WORKER_NETTY_WORKER_THREADS);
     Assert.assertTrue(intValue == 0);
 
-    long longValue = sDefaultTachyonConf.getBytes(Constants.WORKER_MEMORY_SIZE, 0L);
+    long longValue = sDefaultTachyonConf.getBytes(Constants.WORKER_MEMORY_SIZE);
     Assert.assertTrue(longValue == (128 * Constants.MB));
   }
 
@@ -206,13 +206,13 @@ public class TachyonConfTest {
     intValue = sDefaultTachyonConf.getInt(Constants.USER_HEARTBEAT_INTERVAL_MS);
     Assert.assertTrue(intValue == Constants.SECOND_MS);
 
-    long longValue = sDefaultTachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES, 0L);
+    long longValue = sDefaultTachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES);
     Assert.assertTrue(longValue == (8 * Constants.MB));
 
-    longValue = sDefaultTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES, 0L);
+    longValue = sDefaultTachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES);
     Assert.assertTrue(longValue == Constants.MB);
 
-    longValue = sDefaultTachyonConf.getBytes(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE, 0);
+    longValue = sDefaultTachyonConf.getBytes(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE);
     Assert.assertTrue(longValue == 8 * Constants.MB);
   }
 

--- a/common/src/test/java/tachyon/conf/TachyonConfTest.java
+++ b/common/src/test/java/tachyon/conf/TachyonConfTest.java
@@ -63,35 +63,35 @@ public class TachyonConfTest {
 
   @Test
   public void testCommonDefault() {
-    String tachyonHome = sDefaultTachyonConf.get(Constants.TACHYON_HOME, null);
+    String tachyonHome = sDefaultTachyonConf.get(Constants.TACHYON_HOME);
     Assert.assertTrue(tachyonHome != null);
     Assert.assertTrue("/mnt/tachyon_default_home".equals(tachyonHome));
 
-    String ufsAddress = sDefaultTachyonConf.get(Constants.UNDERFS_ADDRESS, null);
+    String ufsAddress = sDefaultTachyonConf.get(Constants.UNDERFS_ADDRESS);
     Assert.assertTrue(ufsAddress != null);
     Assert.assertTrue((tachyonHome + "/underFSStorage").equals(ufsAddress));
 
-    String value = sDefaultTachyonConf.get(Constants.WEB_RESOURCES, null);
+    String value = sDefaultTachyonConf.get(Constants.WEB_RESOURCES);
     Assert.assertTrue(value != null);
     Assert.assertTrue((tachyonHome + "/servers/src/main/webapp").equals(value));
 
-    value = sDefaultTachyonConf.get(Constants.UNDERFS_HDFS_IMPL, null);
+    value = sDefaultTachyonConf.get(Constants.UNDERFS_HDFS_IMPL);
     Assert.assertTrue(value != null);
     Assert.assertTrue("org.apache.hadoop.hdfs.DistributedFileSystem".equals(value));
 
-    value = sDefaultTachyonConf.get(Constants.UNDERFS_HADOOP_PREFIXS, null);
+    value = sDefaultTachyonConf.get(Constants.UNDERFS_HADOOP_PREFIXS);
     Assert.assertTrue(value != null);
     Assert.assertTrue(DEFAULT_HADOOP_UFS_PREFIX.equals(value));
 
-    value = sDefaultTachyonConf.get(Constants.UNDERFS_GLUSTERFS_IMPL, null);
+    value = sDefaultTachyonConf.get(Constants.UNDERFS_GLUSTERFS_IMPL);
     Assert.assertTrue(value != null);
     Assert.assertTrue("org.apache.hadoop.fs.glusterfs.GlusterFileSystem".equals(value));
 
-    value = sDefaultTachyonConf.get(Constants.UNDERFS_DATA_FOLDER, null);
+    value = sDefaultTachyonConf.get(Constants.UNDERFS_DATA_FOLDER);
     Assert.assertTrue(value != null);
     Assert.assertTrue((ufsAddress + "/tachyon/data").equals(value));
 
-    value = sDefaultTachyonConf.get(Constants.UNDERFS_WORKERS_FOLDER, null);
+    value = sDefaultTachyonConf.get(Constants.UNDERFS_WORKERS_FOLDER);
     Assert.assertTrue(value != null);
     Assert.assertTrue((ufsAddress + "/tachyon/workers").equals(value));
 
@@ -116,27 +116,27 @@ public class TachyonConfTest {
 
   @Test
   public void testMasterDefault() {
-    String tachyonHome = sDefaultTachyonConf.get(Constants.TACHYON_HOME, null);
+    String tachyonHome = sDefaultTachyonConf.get(Constants.TACHYON_HOME);
     Assert.assertTrue(tachyonHome != null);
     Assert.assertTrue("/mnt/tachyon_default_home".equals(tachyonHome));
 
-    String value = sDefaultTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER, null);
+    String value = sDefaultTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Assert.assertTrue(value != null);
     Assert.assertTrue((tachyonHome + "/journal/").equals(value));
 
-    value = sDefaultTachyonConf.get(Constants.MASTER_HOSTNAME, null);
+    value = sDefaultTachyonConf.get(Constants.MASTER_HOSTNAME);
     Assert.assertTrue(value != null);
     Assert.assertTrue(NetworkAddressUtils.getLocalHostName(100).equals(value));
 
-    value = sDefaultTachyonConf.get(Constants.MASTER_TEMPORARY_FOLDER, null);
+    value = sDefaultTachyonConf.get(Constants.MASTER_TEMPORARY_FOLDER);
     Assert.assertTrue(value != null);
     Assert.assertTrue("/tmp".equals(value));
 
-    value = sDefaultTachyonConf.get(Constants.MASTER_FORMAT_FILE_PREFIX, null);
+    value = sDefaultTachyonConf.get(Constants.MASTER_FORMAT_FILE_PREFIX);
     Assert.assertTrue(value != null);
     Assert.assertTrue(Constants.FORMAT_FILE_PREFIX.equals(value));
 
-    value = sDefaultTachyonConf.get(Constants.MASTER_ADDRESS, null);
+    value = sDefaultTachyonConf.get(Constants.MASTER_ADDRESS);
     Assert.assertTrue(value != null);
 
     int intValue = sDefaultTachyonConf.getInt(Constants.MASTER_PORT, 0);
@@ -160,7 +160,7 @@ public class TachyonConfTest {
 
   @Test
   public void testWorkerDefault() {
-    String value = sDefaultTachyonConf.get(Constants.WORKER_DATA_FOLDER, null);
+    String value = sDefaultTachyonConf.get(Constants.WORKER_DATA_FOLDER);
     Assert.assertTrue(value != null);
     Assert.assertTrue(("/mnt/ramdisk").equals(value));
 
@@ -218,40 +218,40 @@ public class TachyonConfTest {
 
   @Test
   public void testVariableSubstitutionSimple() {
-    String home = mCustomPropsTachyonConf.get("home", null);
+    String home = mCustomPropsTachyonConf.get("home");
     Assert.assertTrue("hometest".equals(home));
 
-    String homeAndPath = mCustomPropsTachyonConf.get("homeandpath", null);
+    String homeAndPath = mCustomPropsTachyonConf.get("homeandpath");
     Assert.assertTrue((home + "/path1").equals(homeAndPath));
 
-    String homeAndString = mCustomPropsTachyonConf.get("homeandstring", null);
+    String homeAndString = mCustomPropsTachyonConf.get("homeandstring");
     Assert.assertTrue((home + " string1").equals(homeAndString));
 
-    String path2 = mCustomPropsTachyonConf.get("path2", null);
+    String path2 = mCustomPropsTachyonConf.get("path2");
     Assert.assertTrue("path2".equals(path2));
 
-    String multiplesubs = mCustomPropsTachyonConf.get("multiplesubs", null);
+    String multiplesubs = mCustomPropsTachyonConf.get("multiplesubs");
     Assert.assertTrue((home + "/path1/" + path2).equals(multiplesubs));
 
-    String homePort = mCustomPropsTachyonConf.get("home.port", null);
+    String homePort = mCustomPropsTachyonConf.get("home.port");
     Assert.assertTrue(("8080").equals(homePort));
 
     sTestProperties.put("complex.address", "tachyon://${home}:${home.port}");
-    String complexAddress = mCustomPropsTachyonConf.get("complex.address", null);
+    String complexAddress = mCustomPropsTachyonConf.get("complex.address");
     Assert.assertTrue(("tachyon://" + home + ":" + homePort).equals(complexAddress));
 
   }
 
   @Test
   public void testVariableSubstitutionRecursive() {
-    String multiplesubs = mCustomPropsTachyonConf.get("multiplesubs", null);
-    String recursive = mCustomPropsTachyonConf.get("recursive", null);
+    String multiplesubs = mCustomPropsTachyonConf.get("multiplesubs");
+    String recursive = mCustomPropsTachyonConf.get("recursive");
     Assert.assertTrue(multiplesubs.equals(recursive));
   }
 
   @Test
   public void testSystemVariableSubstitutionSample() {
-    String masterAddress = mSystemPropsTachyonConf.get(Constants.MASTER_ADDRESS, null);
+    String masterAddress = mSystemPropsTachyonConf.get(Constants.MASTER_ADDRESS);
     Assert.assertTrue(masterAddress != null);
     Assert.assertTrue("tachyon-ft://master:20001".equals(masterAddress));
   }

--- a/common/src/test/java/tachyon/conf/TachyonConfTest.java
+++ b/common/src/test/java/tachyon/conf/TachyonConfTest.java
@@ -104,10 +104,10 @@ public class TachyonConfTest {
     booleanValue = sDefaultTachyonConf.getBoolean(Constants.ASYNC_ENABLED, true);
     Assert.assertTrue(!booleanValue);
 
-    int intValue = sDefaultTachyonConf.getInt(Constants.MAX_COLUMNS, 0);
+    int intValue = sDefaultTachyonConf.getInt(Constants.MAX_COLUMNS);
     Assert.assertTrue(intValue == 1000);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT_MS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.HOST_RESOLUTION_TIMEOUT_MS);
     Assert.assertEquals(Constants.DEFAULT_HOST_RESOLUTION_TIMEOUT_MS, intValue);
 
     long longBytesValue = sDefaultTachyonConf.getBytes(Constants.MAX_TABLE_METADATA_BYTE, 0L);
@@ -139,22 +139,22 @@ public class TachyonConfTest {
     value = sDefaultTachyonConf.get(Constants.MASTER_ADDRESS);
     Assert.assertTrue(value != null);
 
-    int intValue = sDefaultTachyonConf.getInt(Constants.MASTER_PORT, 0);
+    int intValue = sDefaultTachyonConf.getInt(Constants.MASTER_PORT);
     Assert.assertTrue(intValue == 19998);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.MASTER_WEB_PORT, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.MASTER_WEB_PORT);
     Assert.assertTrue(intValue == 19999);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.WEB_THREAD_COUNT, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.WEB_THREAD_COUNT);
     Assert.assertTrue(intValue == 1);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.MASTER_HEARTBEAT_INTERVAL_MS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.MASTER_HEARTBEAT_INTERVAL_MS);
     Assert.assertTrue(intValue == Constants.SECOND_MS);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.MASTER_MIN_WORKER_THREADS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.MASTER_MIN_WORKER_THREADS);
     Assert.assertTrue(intValue == Runtime.getRuntime().availableProcessors());
 
-    intValue = sDefaultTachyonConf.getInt(Constants.MASTER_WORKER_TIMEOUT_MS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.MASTER_WORKER_TIMEOUT_MS);
     Assert.assertTrue(intValue == 10 * Constants.SECOND_MS);
   }
 
@@ -164,34 +164,34 @@ public class TachyonConfTest {
     Assert.assertTrue(value != null);
     Assert.assertTrue(("/mnt/ramdisk").equals(value));
 
-    int intValue = sDefaultTachyonConf.getInt(Constants.WORKER_PORT, 0);
+    int intValue = sDefaultTachyonConf.getInt(Constants.WORKER_PORT);
     Assert.assertTrue(intValue == 29998);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_DATA_PORT, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_DATA_PORT);
     Assert.assertTrue(intValue == 29999);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS);
     Assert.assertTrue(intValue == 10 * Constants.SECOND_MS);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
     Assert.assertTrue(intValue == Constants.SECOND_MS);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_MIN_WORKER_THREADS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_MIN_WORKER_THREADS);
     Assert.assertTrue(intValue == Runtime.getRuntime().availableProcessors());
 
-    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_USER_TIMEOUT_MS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_USER_TIMEOUT_MS);
     Assert.assertTrue(intValue == 10 * Constants.SECOND_MS);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_CHECKPOINT_THREADS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_CHECKPOINT_THREADS);
     Assert.assertTrue(intValue == 1);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_PER_THREAD_CHECKPOINT_CAP_MB_SEC, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_PER_THREAD_CHECKPOINT_CAP_MB_SEC);
     Assert.assertTrue(intValue == 1000);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_NETTY_BOSS_THREADS, 1);
+    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_NETTY_BOSS_THREADS);
     Assert.assertTrue(intValue == 1);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_NETTY_WORKER_THREADS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.WORKER_NETTY_WORKER_THREADS);
     Assert.assertTrue(intValue == 0);
 
     long longValue = sDefaultTachyonConf.getBytes(Constants.WORKER_MEMORY_SIZE, 0L);
@@ -200,10 +200,10 @@ public class TachyonConfTest {
 
   @Test
   public void testUserDefault() {
-    int intValue = sDefaultTachyonConf.getInt(Constants.USER_FAILED_SPACE_REQUEST_LIMITS, 0);
+    int intValue = sDefaultTachyonConf.getInt(Constants.USER_FAILED_SPACE_REQUEST_LIMITS);
     Assert.assertTrue(intValue == 3);
 
-    intValue = sDefaultTachyonConf.getInt(Constants.USER_HEARTBEAT_INTERVAL_MS, 0);
+    intValue = sDefaultTachyonConf.getInt(Constants.USER_HEARTBEAT_INTERVAL_MS);
     Assert.assertTrue(intValue == Constants.SECOND_MS);
 
     long longValue = sDefaultTachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES, 0L);

--- a/examples/src/main/java/tachyon/examples/Performance.java
+++ b/examples/src/main/java/tachyon/examples/Performance.java
@@ -524,7 +524,7 @@ public class Performance {
 
     TachyonConf tachyonConf = new TachyonConf();
 
-    long fileBufferBytes = tachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES, 0);
+    long fileBufferBytes = tachyonConf.getBytes(Constants.USER_FILE_BUFFER_BYTES);
     sResultPrefix =
         String.format("Threads %d FilesPerThread %d TotalFiles %d "
             + "BLOCK_SIZE_KB %d BLOCKS_PER_FILE %d FILE_SIZE_MB %d "

--- a/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
@@ -232,8 +232,7 @@ public class FileOutStreamIntegrationTest {
     OutStream os = file.getOutStream(WriteType.THROUGH);
     Assert.assertTrue(os instanceof FileOutStream);
     os.write((byte) 0);
-    Thread.sleep(mMasterTachyonConf.getInt(Constants.USER_HEARTBEAT_INTERVAL_MS,
-        Constants.SECOND_MS) * 2);
+    Thread.sleep(mMasterTachyonConf.getInt(Constants.USER_HEARTBEAT_INTERVAL_MS) * 2);
     Assert.assertEquals(origId, mTfs.getUserId());
     os.write((byte) 1);
     os.close();

--- a/integration-tests/src/test/java/tachyon/client/TachyonFSIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFSIntegrationTest.java
@@ -171,7 +171,7 @@ public class TachyonFSIntegrationTest {
 
   @Test(expected = IOException.class)
   public void createRawTableWithTableColumnExceptionTest4() throws IOException {
-    int maxColumns = mMasterTachyonConf.getInt(Constants.MAX_COLUMNS, 1000);
+    int maxColumns = mMasterTachyonConf.getInt(Constants.MAX_COLUMNS);
     sTfs.createRawTable(new TachyonURI(PathUtils.uniqPath()), maxColumns);
   }
 
@@ -206,8 +206,7 @@ public class TachyonFSIntegrationTest {
       sTfs.delete(fileId, true);
       Assert.assertFalse(sTfs.exist(fileURI));
       int timeOutMs =
-          mWorkerTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS,
-              Constants.SECOND_MS) * 2 + 10;
+          mWorkerTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS) * 2 + 10;
       CommonUtils.sleepMs(null, timeOutMs);
       workers = sTfs.getWorkersInfo();
       Assert.assertEquals(1, workers.size());

--- a/integration-tests/src/test/java/tachyon/client/TachyonFSIntegrationTestIso.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFSIntegrationTestIso.java
@@ -60,8 +60,7 @@ public class TachyonFSIntegrationTestIso {
     mWorkerTachyonConf = mLocalTachyonCluster.getWorkerTachyonConf();
     mWorkerTachyonConf.set(Constants.MAX_COLUMNS, "257");
     mWorkerToMasterHeartbeatIntervalMs =
-        mWorkerTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS,
-            Constants.SECOND_MS);
+        mWorkerTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
   }
 
   @Test

--- a/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
@@ -53,7 +53,7 @@ public class UfsUtilsIntegrationTest {
     mTfs = mLocalTachyonCluster.getClient();
 
     TachyonConf masterConf = mLocalTachyonCluster.getMasterTachyonConf();
-    mUnderfsAddress = masterConf.get(Constants.UNDERFS_ADDRESS, null);
+    mUnderfsAddress = masterConf.get(Constants.UNDERFS_ADDRESS);
     mUfs = UnderFileSystem.get(mUnderfsAddress + TachyonURI.SEPARATOR, masterConf);
   }
 

--- a/integration-tests/src/test/java/tachyon/client/table/RawColumnIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/table/RawColumnIntegrationTest.java
@@ -46,7 +46,7 @@ public class RawColumnIntegrationTest {
   @Test
   public void basicTest() throws IOException, TException {
     TachyonConf conf = mLocalTachyonCluster.getMasterTachyonConf();
-    int maxCols = conf.getInt(Constants.MAX_COLUMNS, 1000);
+    int maxCols = conf.getInt(Constants.MAX_COLUMNS);
 
     int fileId = mTfs.createRawTable(new TachyonURI("/table"), maxCols / 10);
     RawTable table = mTfs.getRawTable(fileId);

--- a/integration-tests/src/test/java/tachyon/client/table/RawTableIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/table/RawTableIntegrationTest.java
@@ -51,7 +51,7 @@ public class RawTableIntegrationTest {
     mLocalTachyonCluster = new LocalTachyonCluster(10000, 1000, Constants.GB);
     mLocalTachyonCluster.start();
     mTfs = mLocalTachyonCluster.getClient();
-    mMaxCols =  mLocalTachyonCluster.getMasterTachyonConf().getInt(Constants.MAX_COLUMNS, 1000);
+    mMaxCols =  mLocalTachyonCluster.getMasterTachyonConf().getInt(Constants.MAX_COLUMNS);
   }
 
   @Test

--- a/integration-tests/src/test/java/tachyon/master/JournalIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/JournalIntegrationTest.java
@@ -75,7 +75,7 @@ public class JournalIntegrationTest {
   private void AddBlockTestUtil(ClientFileInfo fileInfo) throws IOException, InvalidPathException,
       FileDoesNotExistException {
     String masterJournal =
-        mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER, Constants.DEFAULT_JOURNAL_FOLDER);
+        mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info =
         new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService, mMasterTachyonConf);
@@ -112,8 +112,7 @@ public class JournalIntegrationTest {
 
   private void AddCheckpointTestUtil(ClientFileInfo fileInfo, ClientFileInfo ckFileInfo)
       throws IOException, InvalidPathException, FileDoesNotExistException {
-    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER,
-        Constants.DEFAULT_JOURNAL_FOLDER);
+    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info = new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService,
         mMasterTachyonConf);
@@ -201,8 +200,7 @@ public class JournalIntegrationTest {
 
   private void DeleteTestUtil() throws IOException, InvalidPathException,
       FileDoesNotExistException {
-    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER,
-        Constants.DEFAULT_JOURNAL_FOLDER);
+    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info = new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService,
         mMasterTachyonConf);
@@ -220,8 +218,7 @@ public class JournalIntegrationTest {
   @Test
   public void EmptyImageTest() throws Exception {
     mLocalTachyonCluster.stopTFS();
-    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER,
-        Constants.DEFAULT_JOURNAL_FOLDER);
+    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info = new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService,
         mMasterTachyonConf);
@@ -254,7 +251,7 @@ public class JournalIntegrationTest {
   private void FileFolderUtil() throws IOException, InvalidPathException,
       FileDoesNotExistException {
     String masterJournal =
-        mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER, Constants.DEFAULT_JOURNAL_FOLDER);
+        mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info =
         new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService, mMasterTachyonConf);
@@ -288,8 +285,7 @@ public class JournalIntegrationTest {
 
   private void FileTestUtil(ClientFileInfo fileInfo) throws IOException, InvalidPathException,
       FileDoesNotExistException {
-    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER,
-        Constants.DEFAULT_JOURNAL_FOLDER);
+    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info = new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService,
         mMasterTachyonConf);
@@ -324,8 +320,7 @@ public class JournalIntegrationTest {
 
   private void PinTestUtil(ClientFileInfo folder, ClientFileInfo file0, ClientFileInfo file1)
       throws IOException, InvalidPathException, FileDoesNotExistException {
-    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER,
-        Constants.DEFAULT_JOURNAL_FOLDER);
+    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info = new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService,
         mMasterTachyonConf);
@@ -365,7 +360,7 @@ public class JournalIntegrationTest {
   private void FolderTest(ClientFileInfo fileInfo) throws IOException, InvalidPathException,
       FileDoesNotExistException {
     String masterJournal =
-        mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER, Constants.DEFAULT_JOURNAL_FOLDER);
+        mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info =
         new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService, mMasterTachyonConf);
@@ -396,8 +391,7 @@ public class JournalIntegrationTest {
 
   private void ManyFileTestUtil() throws IOException, InvalidPathException,
       FileDoesNotExistException {
-    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER,
-        Constants.DEFAULT_JOURNAL_FOLDER);
+    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info = new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService,
         mMasterTachyonConf);
@@ -431,8 +425,7 @@ public class JournalIntegrationTest {
 
   private void MultiEditLogTestUtil() throws IOException, InvalidPathException,
       FileDoesNotExistException {
-    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER,
-        Constants.DEFAULT_JOURNAL_FOLDER);
+    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info = new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService,
         mMasterTachyonConf);
@@ -519,8 +512,7 @@ public class JournalIntegrationTest {
 
   private void RenameTestUtil()
       throws IOException, InvalidPathException, FileDoesNotExistException {
-    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER,
-        Constants.DEFAULT_JOURNAL_FOLDER);
+    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info = new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService,
         mMasterTachyonConf);
@@ -554,8 +546,7 @@ public class JournalIntegrationTest {
 
   private void TableTest(ClientFileInfo fileInfo) throws IOException, InvalidPathException,
       FileDoesNotExistException {
-    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER,
-        Constants.DEFAULT_JOURNAL_FOLDER);
+    String masterJournal = mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
     Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
     MasterInfo info = new MasterInfo(new InetSocketAddress(9999), journal, mExecutorService,
         mMasterTachyonConf);

--- a/integration-tests/src/test/java/tachyon/master/MasterInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/MasterInfoIntegrationTest.java
@@ -308,7 +308,7 @@ public class MasterInfoIntegrationTest {
       concurrentCreator.call();
 
       String masterJournal =
-          mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER, Constants.DEFAULT_JOURNAL_FOLDER);
+          mMasterTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
       Journal journal = new Journal(masterJournal, "image.data", "log.data", mMasterTachyonConf);
       MasterInfo info =
           new MasterInfo(

--- a/integration-tests/src/test/java/tachyon/master/MasterInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/MasterInfoIntegrationTest.java
@@ -679,7 +679,7 @@ public class MasterInfoIntegrationTest {
   @Test(expected = TableColumnException.class)
   public void tooManyColumnsTest() throws InvalidPathException, FileAlreadyExistException,
       TableColumnException, TachyonException {
-    int maxColumns = new TachyonConf().getInt(Constants.MAX_COLUMNS, 1000);
+    int maxColumns = new TachyonConf().getInt(Constants.MAX_COLUMNS);
     mMasterInfo.createRawTable(new TachyonURI("/testTable"), maxColumns + 1, (ByteBuffer) null);
   }
 

--- a/integration-tests/src/test/java/tachyon/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -47,7 +47,7 @@ public class UnderStorageSystemInterfaceIntegrationTest {
     mLocalTachyonCluster = new LocalTachyonCluster(10000, 1000, 128);
     mLocalTachyonCluster.start();
     TachyonConf masterConf = mLocalTachyonCluster.getMasterTachyonConf();
-    mUnderfsAddress = masterConf.get(Constants.UNDERFS_ADDRESS, null);
+    mUnderfsAddress = masterConf.get(Constants.UNDERFS_ADDRESS);
     mUfs = UnderFileSystem.get(mUnderfsAddress + TachyonURI.SEPARATOR, masterConf);
   }
 

--- a/integration-tests/src/test/java/tachyon/underfs/glusterfs/GlusterFSCluster.java
+++ b/integration-tests/src/test/java/tachyon/underfs/glusterfs/GlusterFSCluster.java
@@ -34,10 +34,10 @@ public class GlusterFSCluster extends UnderFileSystemCluster {
     if (conf == null) {
       throw new NullPointerException("Null Tachyon Configuration provided");
     }
-    if (StringUtils.isEmpty(conf.get(Constants.UNDERFS_GLUSTERFS_MOUNTS, null))) {
+    if (StringUtils.isEmpty(conf.get(Constants.UNDERFS_GLUSTERFS_MOUNTS))) {
       throw new IllegalArgumentException("Gluster FS Mounts are undefined");
     }
-    if (StringUtils.isEmpty(conf.get(Constants.UNDERFS_GLUSTERFS_VOLUMES, null))) {
+    if (StringUtils.isEmpty(conf.get(Constants.UNDERFS_GLUSTERFS_VOLUMES))) {
       throw new IllegalArgumentException("Gluster FS Volumes are undefined");
     }
   }

--- a/integration-tests/src/test/java/tachyon/worker/BlockServiceHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/BlockServiceHandlerIntegrationTest.java
@@ -281,6 +281,6 @@ public class BlockServiceHandlerIntegrationTest {
   // Sleeps for a duration so that the worker heartbeat to master can be processed
   private void waitForHeartbeat() {
     CommonUtils.sleepMs(null, mWorkerTachyonConf.getInt(
-        Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS, Constants.SECOND_MS) * 3);
+        Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS) * 3);
   }
 }

--- a/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
@@ -191,7 +191,7 @@ public class DataServerIntegrationTest {
     assertValid(recvMsg2, length, block2.getBlockId(), 0, length);
 
     CommonUtils.sleepMs(null, mWorkerTachyonConf.getInt(
-        Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS, Constants.SECOND_MS) * 2 + 10);
+        Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS) * 2 + 10);
     ClientFileInfo fileInfo = mTFS.getFileStatus(-1, new TachyonURI("/readFile1"));
     Assert.assertEquals(0, fileInfo.inMemoryPercentage);
   }

--- a/integration-tests/src/test/java/tachyon/worker/block/meta/TieredStoreIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/block/meta/TieredStoreIntegrationTest.java
@@ -68,7 +68,7 @@ public class TieredStoreIntegrationTest {
     mTFS = mLocalTachyonCluster.getClient();
     mWorkerConf = mLocalTachyonCluster.getWorkerTachyonConf();
     mWorkerToMasterHeartbeatIntervalMs =
-        mWorkerConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS, Constants.SECOND_MS);
+        mWorkerConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
   }
 
   // Tests that deletes go through despite failing initially due to concurrent read

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
@@ -224,7 +224,7 @@ public final class LocalTachyonCluster {
         mWorkerCapacityBytes + "");
     mkdir(mTachyonHome + "/ramdisk");
 
-    int maxLevel = mWorkerConf.getInt(Constants.WORKER_MAX_TIERED_STORAGE_LEVEL, 1);
+    int maxLevel = mWorkerConf.getInt(Constants.WORKER_MAX_TIERED_STORAGE_LEVEL);
     for (int level = 1; level < maxLevel; level ++) {
       String tierLevelDirPath = String.format(
           Constants.WORKER_TIERED_STORAGE_LEVEL_DIRS_PATH_FORMAT, level);

--- a/servers/src/main/java/tachyon/Format.java
+++ b/servers/src/main/java/tachyon/Format.java
@@ -62,18 +62,15 @@ public class Format {
     if (args[0].toUpperCase().equals("MASTER")) {
 
       String masterJournal =
-          tachyonConf.get(Constants.MASTER_JOURNAL_FOLDER, Constants.DEFAULT_JOURNAL_FOLDER);
+          tachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
       if (!formatFolder("JOURNAL_FOLDER", masterJournal, tachyonConf)) {
         System.exit(-1);
       }
 
-      String tachyonHome = tachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
-      String ufsAddress =
-          tachyonConf.get(Constants.UNDERFS_ADDRESS, tachyonHome + "/underFSStorage");
       String ufsDataFolder =
-          tachyonConf.get(Constants.UNDERFS_DATA_FOLDER, ufsAddress + "/tachyon/data");
+          tachyonConf.get(Constants.UNDERFS_DATA_FOLDER);
       String ufsWorkerFolder =
-          tachyonConf.get(Constants.UNDERFS_WORKERS_FOLDER, ufsAddress + "/tachyon/workers");
+          tachyonConf.get(Constants.UNDERFS_WORKERS_FOLDER);
       if (!formatFolder("UNDERFS_DATA_FOLDER", ufsDataFolder, tachyonConf)
           || !formatFolder("UNDERFS_WORKERS_FOLDER", ufsWorkerFolder, tachyonConf)) {
         System.exit(-1);

--- a/servers/src/main/java/tachyon/Format.java
+++ b/servers/src/main/java/tachyon/Format.java
@@ -81,7 +81,7 @@ public class Format {
     } else if (args[0].toUpperCase().equals("WORKER")) {
       String workerDataFolder =
           tachyonConf.get(Constants.WORKER_DATA_FOLDER, Constants.DEFAULT_DATA_FOLDER);
-      int maxStorageLevels = tachyonConf.getInt(Constants.WORKER_MAX_TIERED_STORAGE_LEVEL, 1);
+      int maxStorageLevels = tachyonConf.getInt(Constants.WORKER_MAX_TIERED_STORAGE_LEVEL);
       for (int level = 0; level < maxStorageLevels; level ++) {
         String tierLevelDirPath =
             String.format(Constants.WORKER_TIERED_STORAGE_LEVEL_DIRS_PATH_FORMAT, level);

--- a/servers/src/main/java/tachyon/Users.java
+++ b/servers/src/main/java/tachyon/Users.java
@@ -120,7 +120,7 @@ public class Users {
         mUsers.get(userId).heartbeat();
       } else {
         int userTimeoutMs =
-            mTachyonConf.getInt(Constants.WORKER_USER_TIMEOUT_MS, 10 * Constants.SECOND_MS);
+            mTachyonConf.getInt(Constants.WORKER_USER_TIMEOUT_MS);
         mUsers.put(userId, new UserInfo(userId, userTimeoutMs));
       }
     }

--- a/servers/src/main/java/tachyon/master/Dependency.java
+++ b/servers/src/main/java/tachyon/master/Dependency.java
@@ -201,7 +201,7 @@ public class Dependency extends ImageWriter {
     // TODO We should support different types of command in the future.
     // For now, assume there is only one command model.
     StringBuilder sb = new StringBuilder(parseCommandPrefix());
-    sb.append(" ").append(mTachyonConf.get(Constants.MASTER_ADDRESS, null));
+    sb.append(" ").append(mTachyonConf.get(Constants.MASTER_ADDRESS));
     sb.append(" ").append(mId);
     for (int k = 0; k < mChildrenFiles.size(); k ++) {
       int id = mChildrenFiles.get(k);

--- a/servers/src/main/java/tachyon/master/MasterInfo.java
+++ b/servers/src/main/java/tachyon/master/MasterInfo.java
@@ -97,7 +97,7 @@ public class MasterInfo extends ImageWriter {
       synchronized (mWorkers) {
         for (Entry<Long, MasterWorkerInfo> worker : mWorkers.entrySet()) {
           int masterWorkerTimeoutMs =
-              mTachyonConf.getInt(Constants.MASTER_WORKER_TIMEOUT_MS, 10 * Constants.SECOND_MS);
+              mTachyonConf.getInt(Constants.MASTER_WORKER_TIMEOUT_MS);
           if (CommonUtils.getCurrentMs()
               - worker.getValue().getLastUpdatedTimeMs() > masterWorkerTimeoutMs) {
             LOG.error("The worker " + worker.getValue() + " got timed out!");
@@ -1076,7 +1076,7 @@ public class MasterInfo extends ImageWriter {
       TachyonException {
     LOG.info("createRawTable" + FormatUtils.parametersToString(path, columns));
 
-    int maxColumns = mTachyonConf.getInt(Constants.MAX_COLUMNS, 1000);
+    int maxColumns = mTachyonConf.getInt(Constants.MAX_COLUMNS);
     if (columns <= 0 || columns >= maxColumns) {
       throw new TableColumnException("Column " + columns + " should between 0 to " + maxColumns);
     }
@@ -1874,7 +1874,7 @@ public class MasterInfo extends ImageWriter {
     mHeartbeat =
         mExecutorService.submit(new HeartbeatThread("Master Heartbeat",
             new MasterInfoHeartbeatExecutor(), mTachyonConf.getInt(
-                Constants.MASTER_HEARTBEAT_INTERVAL_MS, Constants.SECOND_MS)));
+                Constants.MASTER_HEARTBEAT_INTERVAL_MS)));
 
     mRecompute = mExecutorService.submit(new RecomputationScheduler());
   }

--- a/servers/src/main/java/tachyon/master/MasterInfo.java
+++ b/servers/src/main/java/tachyon/master/MasterInfo.java
@@ -150,7 +150,7 @@ public class MasterInfo extends ImageWriter {
                 dep.addLostFile(tFile.getId());
                 LOG.info("File " + tFile.getId() + " got lost from worker " + worker.getId()
                     + " . Trying to recompute it using dependency " + dep.mId);
-                String tmp = mTachyonConf.get(Constants.MASTER_TEMPORARY_FOLDER, "/tmp");
+                String tmp = mTachyonConf.get(Constants.MASTER_TEMPORARY_FOLDER);
                 if (!getPath(tFile).toString().startsWith(tmp)) {
                   mMustRecomputedDpendencies.add(depId);
                 }
@@ -165,7 +165,7 @@ public class MasterInfo extends ImageWriter {
       if (hadFailedWorker) {
         LOG.warn("Restarting failed workers.");
         try {
-          String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
+          String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME);
           java.lang.Runtime.getRuntime()
               .exec(tachyonHome + "/bin/tachyon-start.sh restart_workers");
         } catch (IOException e) {
@@ -226,7 +226,7 @@ public class MasterInfo extends ImageWriter {
         }
 
         for (String cmd : cmds) {
-          String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
+          String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME);
           String filePath = tachyonHome + "/logs/rerun-" + mRerunCounter.incrementAndGet();
           // TODO use bounded threads (ExecutorService)
           Thread thread = new Thread(new RecomputeCommand(cmd, filePath));

--- a/servers/src/main/java/tachyon/master/RawTables.java
+++ b/servers/src/main/java/tachyon/master/RawTables.java
@@ -172,7 +172,7 @@ public class RawTables extends ImageWriter {
     if (metadata == null) {
       data.setSecond(ByteBuffer.allocate(0));
     } else {
-      long maxVal = mTachyonConf.getBytes(Constants.MAX_TABLE_METADATA_BYTE, 0L);
+      long maxVal = mTachyonConf.getBytes(Constants.MAX_TABLE_METADATA_BYTE);
       if (metadata.limit() - metadata.position() >= maxVal) {
         throw new TachyonException("Too big table metadata: " + metadata.toString());
       }

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -141,11 +141,10 @@ public class TachyonMaster {
       mServerTServerSocket = new TServerSocket(addressListening);
       mPort = NetworkAddressUtils.getPort(mServerTServerSocket);
 
-      String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
       String journalFolder =
-          mTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER, tachyonHome + "/journal/");
+          mTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
       String formatFilePrefix =
-          mTachyonConf.get(Constants.MASTER_FORMAT_FILE_PREFIX, Constants.FORMAT_FILE_PREFIX);
+          mTachyonConf.get(Constants.MASTER_FORMAT_FILE_PREFIX);
       UnderFileSystem ufs = UnderFileSystem.get(journalFolder, mTachyonConf);
       if (ufs.providesStorage()) {
         Preconditions.checkState(isFormatted(journalFolder, formatFilePrefix),
@@ -161,9 +160,9 @@ public class TachyonMaster {
         // InetSocketAddress.toString causes test issues, so build the string by hand
         String zkName =
             NetworkAddressUtils.getFqdnHost(mMasterAddress) + ":" + mMasterAddress.getPort();
-        String zkAddress = mTachyonConf.get(Constants.ZOOKEEPER_ADDRESS, null);
-        String zkElectionPath = mTachyonConf.get(Constants.ZOOKEEPER_ELECTION_PATH, "/election");
-        String zkLeaderPath = mTachyonConf.get(Constants.ZOOKEEPER_LEADER_PATH, "/leader");
+        String zkAddress = mTachyonConf.get(Constants.ZOOKEEPER_ADDRESS);
+        String zkElectionPath = mTachyonConf.get(Constants.ZOOKEEPER_ELECTION_PATH);
+        String zkLeaderPath = mTachyonConf.get(Constants.ZOOKEEPER_LEADER_PATH);
         mLeaderSelectorClient =
             new LeaderSelectorClient(zkAddress, zkElectionPath, zkLeaderPath, zkName);
         mEditLogProcessor =
@@ -239,9 +238,8 @@ public class TachyonMaster {
   }
 
   private void connectToUFS() throws IOException {
-    String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
     String ufsAddress =
-        mTachyonConf.get(Constants.UNDERFS_ADDRESS, tachyonHome + "/underFSStorage");
+        mTachyonConf.get(Constants.UNDERFS_ADDRESS);
     UnderFileSystem ufs = UnderFileSystem.get(ufsAddress, mTachyonConf);
     ufs.connectFromMaster(mTachyonConf, NetworkAddressUtils.getFqdnHost(mMasterAddress));
   }

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -96,8 +96,8 @@ public class TachyonMaster {
   public TachyonMaster(TachyonConf tachyonConf) {
     mTachyonConf = tachyonConf;
 
-    int port = mTachyonConf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
-    int webPort = mTachyonConf.getInt(Constants.MASTER_WEB_PORT, Constants.DEFAULT_MASTER_WEB_PORT);
+    int port = mTachyonConf.getInt(Constants.MASTER_PORT);
+    int webPort = mTachyonConf.getInt(Constants.MASTER_WEB_PORT);
 
     TachyonConf.assertValidPort(port, mTachyonConf);
     TachyonConf.assertValidPort(webPort, mTachyonConf);
@@ -126,8 +126,7 @@ public class TachyonMaster {
             .availableProcessors());
 
     mMaxWorkerThreads =
-        mTachyonConf.getInt(Constants.MASTER_MAX_WORKER_THREADS,
-            Constants.DEFAULT_MASTER_MAX_WORKER_THREADS);
+        mTachyonConf.getInt(Constants.MASTER_MAX_WORKER_THREADS);
     Preconditions.checkArgument(mMaxWorkerThreads >= mMinWorkerThreads,
         Constants.MASTER_MAX_WORKER_THREADS + " can not be less than "
             + Constants.MASTER_MIN_WORKER_THREADS);

--- a/servers/src/main/java/tachyon/metrics/MetricsSystem.java
+++ b/servers/src/main/java/tachyon/metrics/MetricsSystem.java
@@ -82,7 +82,7 @@ public class MetricsSystem {
   public MetricsSystem(String instance, TachyonConf tachyonConf) {
     mInstance = instance;
     mTachyonConf = tachyonConf;
-    mMetricsConfig = new MetricsConfig(mTachyonConf.get(Constants.METRICS_CONF_FILE, null));
+    mMetricsConfig = new MetricsConfig(mTachyonConf.get(Constants.METRICS_CONF_FILE));
   }
 
   /**

--- a/servers/src/main/java/tachyon/web/UIWebServer.java
+++ b/servers/src/main/java/tachyon/web/UIWebServer.java
@@ -81,7 +81,7 @@ public abstract class UIWebServer {
 
     mWebAppContext = new WebAppContext();
     mWebAppContext.setContextPath(TachyonURI.SEPARATOR);
-    String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
+    String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME);
     File warPath =
         new File(mTachyonConf.get(Constants.WEB_RESOURCES, tachyonHome + "/core/src/main/webapp"));
     mWebAppContext.setWar(warPath.getAbsolutePath());

--- a/servers/src/main/java/tachyon/web/UIWebServer.java
+++ b/servers/src/main/java/tachyon/web/UIWebServer.java
@@ -66,7 +66,7 @@ public abstract class UIWebServer {
     mTachyonConf = conf;
 
     QueuedThreadPool threadPool = new QueuedThreadPool();
-    int webThreadCount = mTachyonConf.getInt(Constants.WEB_THREAD_COUNT, 1);
+    int webThreadCount = mTachyonConf.getInt(Constants.WEB_THREAD_COUNT);
 
     mServer = new Server();
     SelectChannelConnector connector = new SelectChannelConnector();

--- a/servers/src/main/java/tachyon/web/WebInterfaceBrowseLogsServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceBrowseLogsServlet.java
@@ -115,9 +115,9 @@ public class WebInterfaceBrowseLogsServlet extends HttpServlet {
     request.setAttribute("baseUrl", "./browseLogs");
     request.setAttribute("currentPath", "");
 
-    String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
+    String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME);
     String logsPath =
-        mTachyonConf.get(Constants.LOGS_DIR, PathUtils.concatPath(tachyonHome, "logs"));
+        mTachyonConf.get(Constants.LOGS_DIR);
     File logsDir = new File(logsPath);
     String requestFile = request.getParameter("path");
 

--- a/servers/src/main/java/tachyon/web/WebInterfaceDownloadLocalServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceDownloadLocalServlet.java
@@ -62,7 +62,7 @@ public class WebInterfaceDownloadLocalServlet extends HttpServlet {
     }
 
     // Download a file from the local filesystem.
-    String baseDir = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
+    String baseDir = mTachyonConf.get(Constants.TACHYON_HOME);
     File logsDir = new File(baseDir, "logs");
 
     // Only allow filenames as the path, to avoid downloading arbitrary local files.

--- a/servers/src/main/java/tachyon/web/WebInterfaceHeaderServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceHeaderServlet.java
@@ -49,7 +49,7 @@ public class WebInterfaceHeaderServlet extends HttpServlet {
   protected void doGet(HttpServletRequest request, HttpServletResponse response)
       throws ServletException, IOException {
     int masterWebPort =
-        mTachyonConf.getInt(Constants.MASTER_WEB_PORT, Constants.DEFAULT_MASTER_WEB_PORT);
+        mTachyonConf.getInt(Constants.MASTER_WEB_PORT);
     String masterHostName =
         mTachyonConf.get(Constants.MASTER_HOSTNAME,
             NetworkAddressUtils.getLocalHostName(mTachyonConf));

--- a/servers/src/main/java/tachyon/web/WebInterfaceWorkersServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceWorkersServlet.java
@@ -159,7 +159,6 @@ public class WebInterfaceWorkersServlet extends HttpServlet {
     NodeInfo[] failedNodeInfos = generateOrderedNodeInfos(lostWorkerInfos);
     request.setAttribute("failedNodeInfos", failedNodeInfos);
 
-    request.setAttribute("workerWebPort", mTachyonConf.getInt(Constants.WORKER_WEB_PORT,
-        Constants.DEFAULT_WORKER_WEB_PORT));
+    request.setAttribute("workerWebPort", mTachyonConf.getInt(Constants.WORKER_WEB_PORT));
   }
 }

--- a/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
@@ -98,9 +98,9 @@ public class BlockDataManager {
             mMasterClientExecutorService, mTachyonConf);
 
     // Create Under FileSystem Client
-    String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
+    String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME);
     String ufsAddress =
-        mTachyonConf.get(Constants.UNDERFS_ADDRESS, tachyonHome + "/underFSStorage");
+        mTachyonConf.get(Constants.UNDERFS_ADDRESS);
     mUfs = UnderFileSystem.get(ufsAddress, mTachyonConf);
 
     // Connect to UFS to handle UFS security

--- a/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
@@ -82,9 +82,9 @@ public class BlockMasterSync implements Runnable {
         new MasterClient(NetworkAddressUtils.getMasterAddress(mTachyonConf),
             mMasterClientExecutorService, mTachyonConf);
     mHeartbeatIntervalMs =
-        mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS, Constants.SECOND_MS);
+        mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
     mHeartbeatTimeoutMs =
-        mTachyonConf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS, 10 * Constants.SECOND_MS);
+        mTachyonConf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS);
 
     mRunning = true;
     mWorkerId = 0;

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -77,7 +77,7 @@ public class BlockMetadataManager {
   private void initBlockMetadataManager() throws AlreadyExistsException,
       IOException, OutOfSpaceException {
     // Initialize storage tiers
-    int totalTiers = WorkerContext.getConf().getInt(Constants.WORKER_MAX_TIERED_STORAGE_LEVEL, 1);
+    int totalTiers = WorkerContext.getConf().getInt(Constants.WORKER_MAX_TIERED_STORAGE_LEVEL);
     mAliasToTiers = new HashMap<Integer, StorageTier>(totalTiers);
     mTiers = new ArrayList<StorageTier>(totalTiers);
     for (int level = 0; level < totalTiers; level ++) {

--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -148,11 +148,11 @@ public class BlockWorker {
     // Setup user metadata mapping
     // TODO: Have a top level register that gets the worker id.
     long workerId = mBlockMasterSync.getWorkerId();
-    String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME, Constants.DEFAULT_HOME);
+    String tachyonHome = mTachyonConf.get(Constants.TACHYON_HOME);
     String ufsAddress =
-        mTachyonConf.get(Constants.UNDERFS_ADDRESS, tachyonHome + "/underFSStorage");
+        mTachyonConf.get(Constants.UNDERFS_ADDRESS);
     String ufsWorkerFolder =
-        mTachyonConf.get(Constants.UNDERFS_WORKERS_FOLDER, ufsAddress + "/tachyon/workers");
+        mTachyonConf.get(Constants.UNDERFS_WORKERS_FOLDER);
     Users users = new Users(PathUtils.concatPath(ufsWorkerFolder, workerId), mTachyonConf);
 
     // Give BlockDataManager a pointer to the user metadata mapping

--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -109,7 +109,7 @@ public class BlockWorker {
 
     // Set up DataServer
     int dataServerPort =
-        mTachyonConf.getInt(Constants.WORKER_DATA_PORT, Constants.DEFAULT_WORKER_DATA_SERVER_PORT);
+        mTachyonConf.getInt(Constants.WORKER_DATA_PORT);
     InetSocketAddress dataServerAddress =
         new InetSocketAddress(NetworkAddressUtils.getLocalHostName(mTachyonConf), dataServerPort);
     mDataServer =
@@ -125,7 +125,7 @@ public class BlockWorker {
             .getHostAddress(), thriftServerPort, mDataServer.getPort());
 
     // Set up web server
-    int webPort = mTachyonConf.getInt(Constants.WORKER_WEB_PORT, Constants.DEFAULT_WORKER_WEB_PORT);
+    int webPort = mTachyonConf.getInt(Constants.WORKER_WEB_PORT);
     mWebServer =
         new WorkerUIWebServer("Tachyon Worker", new InetSocketAddress(mWorkerNetAddress.getMHost(),
             webPort), mBlockDataManager, NetworkAddressUtils.getLocalWorkerAddress(mTachyonConf),
@@ -232,8 +232,7 @@ public class BlockWorker {
         mTachyonConf.getInt(Constants.WORKER_MIN_WORKER_THREADS, Runtime.getRuntime()
             .availableProcessors());
     int maxWorkerThreads =
-        mTachyonConf.getInt(Constants.WORKER_MAX_WORKER_THREADS,
-            Constants.DEFAULT_WORKER_MAX_WORKER_THREADS);
+        mTachyonConf.getInt(Constants.WORKER_MAX_WORKER_THREADS);
     WorkerService.Processor<BlockServiceHandler> processor =
         new WorkerService.Processor<BlockServiceHandler>(mServiceHandler);
     return new TThreadPoolServer(new TThreadPoolServer.Args(mThriftServerSocket)

--- a/servers/src/main/java/tachyon/worker/block/PinListSync.java
+++ b/servers/src/main/java/tachyon/worker/block/PinListSync.java
@@ -72,9 +72,9 @@ public class PinListSync implements Runnable {
         new MasterClient(NetworkAddressUtils.getMasterAddress(mTachyonConf),
             mMasterClientExecutorService, mTachyonConf);
     mSyncIntervalMs =
-        mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS, Constants.SECOND_MS);
+        mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
     mSyncTimeoutMs =
-        mTachyonConf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS, 10 * Constants.SECOND_MS);
+        mTachyonConf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS);
 
     mRunning = true;
   }

--- a/servers/src/main/java/tachyon/worker/block/UserCleaner.java
+++ b/servers/src/main/java/tachyon/worker/block/UserCleaner.java
@@ -49,7 +49,7 @@ public class UserCleaner implements Runnable {
     mBlockDataManager = blockDataManager;
     mTachyonConf = tachyonConf;
     mCheckIntervalMs =
-        mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS, Constants.SECOND_MS);
+        mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
 
     mRunning = true;
   }

--- a/servers/src/main/java/tachyon/worker/block/evictor/LRFUEvictor.java
+++ b/servers/src/main/java/tachyon/worker/block/evictor/LRFUEvictor.java
@@ -76,10 +76,9 @@ public class LRFUEvictor extends BlockStoreEventListenerBase implements Evictor 
     mManagerView = view;
     mTachyonConf = new TachyonConf();
     mStepFactor = mTachyonConf
-        .getDouble(Constants.WORKER_EVICT_STRATEGY_LRFU_STEP_FACTOR, DEFAULT_STEP_FACTOR);
+        .getDouble(Constants.WORKER_EVICT_STRATEGY_LRFU_STEP_FACTOR);
     mAttenuationFactor = mTachyonConf
-        .getDouble(Constants.WORKER_EVICT_STRATEGY_LRFU_ATTENUATION_FACTOR, 
-            DEFAULT_ATTENUATION_FACTOR);
+        .getDouble(Constants.WORKER_EVICT_STRATEGY_LRFU_ATTENUATION_FACTOR);
     Preconditions.checkArgument(mStepFactor >= 0.0 && mStepFactor <= 1.0, 
         "Step factor should be in the range of [0.0, 1.0]");
     Preconditions.checkArgument(mAttenuationFactor >= 2.0,

--- a/servers/src/main/java/tachyon/worker/netty/NettyDataServer.java
+++ b/servers/src/main/java/tachyon/worker/netty/NettyDataServer.java
@@ -122,9 +122,9 @@ public final class NettyDataServer implements DataServer {
    */
   private ServerBootstrap createBootstrapOfType(final ChannelType type) {
     final ServerBootstrap boot = new ServerBootstrap();
-    final int bossThreadCount = mTachyonConf.getInt(Constants.WORKER_NETTY_BOSS_THREADS, 1);
+    final int bossThreadCount = mTachyonConf.getInt(Constants.WORKER_NETTY_BOSS_THREADS);
     // If number of worker threads is 0, Netty creates (#processors * 2) threads by default.
-    final int workerThreadCount = mTachyonConf.getInt(Constants.WORKER_NETTY_WORKER_THREADS, 0);
+    final int workerThreadCount = mTachyonConf.getInt(Constants.WORKER_NETTY_WORKER_THREADS);
     final EventLoopGroup bossGroup =
         NettyUtils.createEventLoop(type, bossThreadCount, "data-server-boss-%d", false);
     final EventLoopGroup workerGroup =

--- a/servers/src/main/java/tachyon/worker/netty/NettyDataServer.java
+++ b/servers/src/main/java/tachyon/worker/netty/NettyDataServer.java
@@ -78,9 +78,9 @@ public final class NettyDataServer implements DataServer {
     // set write buffer
     // this is the default, but its recommended to set it in case of change in future netty.
     boot.childOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK,
-        (int) mTachyonConf.getBytes(Constants.WORKER_NETTY_WATERMARK_HIGH, 32 * 1024));
+        (int) mTachyonConf.getBytes(Constants.WORKER_NETTY_WATERMARK_HIGH));
     boot.childOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK,
-        (int) mTachyonConf.getBytes(Constants.WORKER_NETTY_WATERMARK_LOW, 8 * 1024));
+        (int) mTachyonConf.getBytes(Constants.WORKER_NETTY_WATERMARK_LOW));
 
     // more buffer settings
     final int optBacklog = mTachyonConf.getInt(Constants.WORKER_NETTY_BACKLOG, -1);

--- a/servers/src/test/java/tachyon/UserInfoTest.java
+++ b/servers/src/test/java/tachyon/UserInfoTest.java
@@ -36,8 +36,7 @@ public class UserInfoTest {
   @Before
   public final void before() {
     TachyonConf tachyonConf = new TachyonConf();
-    mUserTimeoutMs = tachyonConf.getInt(Constants.WORKER_USER_TIMEOUT_MS,
-        10 * Constants.SECOND_MS);
+    mUserTimeoutMs = tachyonConf.getInt(Constants.WORKER_USER_TIMEOUT_MS);
   }
 
   @Test

--- a/servers/src/test/java/tachyon/worker/block/evictor/LRFUEvictorTest.java
+++ b/servers/src/test/java/tachyon/worker/block/evictor/LRFUEvictorTest.java
@@ -66,9 +66,9 @@ public class LRFUEvictorTest {
             Collections.<Long>emptySet());
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.WORKER_EVICT_STRATEGY_CLASS, LRFUEvictor.class.getName());
-    mStepFactor = conf.getDouble(Constants.WORKER_EVICT_STRATEGY_LRFU_STEP_FACTOR, 0.25);
+    mStepFactor = conf.getDouble(Constants.WORKER_EVICT_STRATEGY_LRFU_STEP_FACTOR);
     mAttenuationFactor =
-        conf.getDouble(Constants.WORKER_EVICT_STRATEGY_LRFU_ATTENUATION_FACTOR, 2.0);
+        conf.getDouble(Constants.WORKER_EVICT_STRATEGY_LRFU_ATTENUATION_FACTOR);
     mEvictor = Evictor.Factory.createEvictor(conf, mManagerView);
   }
 

--- a/shell/src/main/java/tachyon/shell/TFsShellUtils.java
+++ b/shell/src/main/java/tachyon/shell/TFsShellUtils.java
@@ -67,7 +67,7 @@ public class TFsShellUtils {
       }
     } else {
       String hostname = tachyonConf.get(Constants.MASTER_HOSTNAME, "localhost");
-      int port =  tachyonConf.getInt(Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT);
+      int port =  tachyonConf.getInt(Constants.MASTER_PORT);
       if (tachyonConf.getBoolean(Constants.USE_ZOOKEEPER, false)) {
         return PathUtils.concatPath(Constants.HEADER_FT + hostname + ":" + port, path);
       }

--- a/underfs/glusterfs/src/main/java/tachyon/underfs/glusterfs/GlusterFSUnderFileSystem.java
+++ b/underfs/glusterfs/src/main/java/tachyon/underfs/glusterfs/GlusterFSUnderFileSystem.java
@@ -44,15 +44,14 @@ public class GlusterFSUnderFileSystem extends HdfsUnderFileSystem {
   protected void prepareConfiguration(String path, TachyonConf tachyonConf, Configuration config) {
     if (path.startsWith(SCHEME)) {
       // Configure for Gluster FS
-      config.set("fs.glusterfs.impl", tachyonConf.get(Constants.UNDERFS_GLUSTERFS_IMPL,
-          "org.apache.hadoop.fs.glusterfs.GlusterFileSystem"));
+      config.set("fs.glusterfs.impl", tachyonConf.get(Constants.UNDERFS_GLUSTERFS_IMPL));
       config.set("mapred.system.dir",
-          tachyonConf.get(Constants.UNDERFS_GLUSTERFS_MR_DIR, "glusterfs:///mapred/system"));
+          tachyonConf.get(Constants.UNDERFS_GLUSTERFS_MR_DIR));
       config
-          .set("fs.glusterfs.volumes", tachyonConf.get(Constants.UNDERFS_GLUSTERFS_VOLUMES, null));
+          .set("fs.glusterfs.volumes", tachyonConf.get(Constants.UNDERFS_GLUSTERFS_VOLUMES));
       config.set(
-          "fs.glusterfs.volume.fuse." + tachyonConf.get(Constants.UNDERFS_GLUSTERFS_VOLUMES, null),
-          tachyonConf.get(Constants.UNDERFS_GLUSTERFS_MOUNTS, null));
+          "fs.glusterfs.volume.fuse." + tachyonConf.get(Constants.UNDERFS_GLUSTERFS_VOLUMES),
+          tachyonConf.get(Constants.UNDERFS_GLUSTERFS_MOUNTS));
     } else {
       // If not Gluster FS fall back to default HDFS behaviour
       // This should only happen if someone creates an instance of this directly rather than via the

--- a/underfs/glusterfs/src/test/java/tachyon/underfs/glusterfs/GlusterFSUnderFileSystemFactoryTest.java
+++ b/underfs/glusterfs/src/test/java/tachyon/underfs/glusterfs/GlusterFSUnderFileSystemFactoryTest.java
@@ -41,9 +41,8 @@ public class GlusterFSUnderFileSystemFactoryTest {
   @Before
   public final void before() throws IOException {
     mTachyonConf = new TachyonConf();
-    mMount =  mTachyonConf.get(Constants.UNDERFS_GLUSTERFS_MR_DIR,
-        "glusterfs:///mapred/system");
-    mVolume = mTachyonConf.get(Constants.UNDERFS_GLUSTERFS_VOLUMES, null);
+    mMount =  mTachyonConf.get(Constants.UNDERFS_GLUSTERFS_MR_DIR);
+    mVolume = mTachyonConf.get(Constants.UNDERFS_GLUSTERFS_VOLUMES);
   }
 
   @Test

--- a/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java
@@ -95,7 +95,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
     // discover available file system implementations. However this configuration setting is
     // required for earlier Hadoop versions plus it is still honoured as an override even in 2.x so
     // if present propagate it to the Hadoop configuration
-    String ufsHdfsImpl = mTachyonConf.get(Constants.UNDERFS_HDFS_IMPL, null);
+    String ufsHdfsImpl = mTachyonConf.get(Constants.UNDERFS_HDFS_IMPL);
     if (!StringUtils.isEmpty(ufsHdfsImpl)) {
       config.set("fs.hdfs.impl", ufsHdfsImpl);
     }
@@ -302,8 +302,8 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
 
   @Override
   public void connectFromMaster(TachyonConf conf, String host) throws IOException {
-    String masterKeytab = conf.get(Constants.MASTER_KEYTAB_KEY, null);
-    String masterPrincipal = conf.get(Constants.MASTER_PRINCIPAL_KEY, null);
+    String masterKeytab = conf.get(Constants.MASTER_KEYTAB_KEY);
+    String masterPrincipal = conf.get(Constants.MASTER_PRINCIPAL_KEY);
     if (masterKeytab == null || masterPrincipal == null) {
       return;
     }
@@ -314,8 +314,8 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
 
   @Override
   public void connectFromWorker(TachyonConf conf, String host) throws IOException {
-    String workerKeytab = conf.get(Constants.WORKER_KEYTAB_KEY, null);
-    String workerPrincipal = conf.get(Constants.WORKER_PRINCIPAL_KEY, null);
+    String workerKeytab = conf.get(Constants.WORKER_KEYTAB_KEY);
+    String workerPrincipal = conf.get(Constants.WORKER_PRINCIPAL_KEY);
     if (workerKeytab == null || workerPrincipal == null) {
       return;
     }

--- a/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystemUtils.java
+++ b/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystemUtils.java
@@ -31,7 +31,7 @@ public class HdfsUnderFileSystemUtils {
     if (System.getProperty(key) != null && conf.get(key) == null) {
       conf.set(key, System.getProperty(key));
     } else if (tachyonConf.containsKey(key)) {
-      conf.set(key, tachyonConf.get(key, null));
+      conf.set(key, tachyonConf.get(key));
     }
   }
 

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -60,7 +60,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
   public S3UnderFileSystem(String bucketName, TachyonConf tachyonConf) throws ServiceException {
     super(tachyonConf);
     AWSCredentials awsCredentials =
-        new AWSCredentials(tachyonConf.get(Constants.S3_ACCESS_KEY, null), tachyonConf.get(
+        new AWSCredentials(tachyonConf.get(Constants.S3_ACCESS_KEY), tachyonConf.get(
             Constants.S3_SECRET_KEY, null));
     mBucketName = bucketName;
     mClient = new RestS3Service(awsCredentials);

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -70,14 +70,14 @@ public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
    */
   private boolean addAndCheckAWSCredentials(TachyonConf tachyonConf) {
     String accessKeyConf = Constants.S3_ACCESS_KEY;
-    if (System.getProperty(accessKeyConf) != null && tachyonConf.get(accessKeyConf, null) == null) {
+    if (System.getProperty(accessKeyConf) != null && tachyonConf.get(accessKeyConf) == null) {
       tachyonConf.set(accessKeyConf, System.getProperty(accessKeyConf));
     }
     String secretKeyConf = Constants.S3_SECRET_KEY;
-    if (System.getProperty(secretKeyConf) != null && tachyonConf.get(secretKeyConf, null) == null) {
+    if (System.getProperty(secretKeyConf) != null && tachyonConf.get(secretKeyConf) == null) {
       tachyonConf.set(secretKeyConf, System.getProperty(secretKeyConf));
     }
-    return tachyonConf.get(accessKeyConf, null) != null
-        && tachyonConf.get(secretKeyConf, null) != null;
+    return tachyonConf.get(accessKeyConf) != null
+        && tachyonConf.get(secretKeyConf) != null;
   }
 }

--- a/underfs/swift/src/main/java/tachyon/underfs/swift/SwiftUnderFileSystemUtils.java
+++ b/underfs/swift/src/main/java/tachyon/underfs/swift/SwiftUnderFileSystemUtils.java
@@ -30,7 +30,7 @@ public class SwiftUnderFileSystemUtils {
     if (System.getProperty(key) != null && conf.get(key) == null) {
       conf.set(key, System.getProperty(key));
     } else if (tachyonConf.containsKey(key)) {
-      conf.set(key, tachyonConf.get(key, null));
+      conf.set(key, tachyonConf.get(key));
     }
   }
 }


### PR DESCRIPTION
Currently the default value for TachyonConf getter(s) is provided as an argument which is error-prone. This PR tries to consolidate the source of default value, specifically for get(), getInt() and getBytes().
Note there are still some usages for get(key, %default_value%) left untouched, either because the default value was dynamically determined or I was uncertain about the context; and I also skipped getBoolean(), getList(), getEnum() and getClass() as they usage is either rare or default value likely to be intentional. Suggestion/comments are welcome since there could be cases where default value has implicit assumption which I might have overlooked.

JIRA: https://tachyon.atlassian.net/browse/TACHYON-470