### PR TITLE
[TACHYON-725] fix vagrant deploy script string matching regexp

### DIFF
--- a/deploy/vagrant/create
+++ b/deploy/vagrant/create
@@ -23,7 +23,7 @@ PROVIDERS=("aws" "vb")
 TOTAL="$1"
 PROVIDER="$2"
 [ "$TOTAL" -lt 2 ] && error_exit "number of machines should at least be 2"
-[[ $PROVIDERS =~ (^| )$PROVIDER($| ) ]] || error_exit "provider $PROVIDER not supported yet"
+[[ "${PROVIDERS[*]}" =~ (^| )$PROVIDER( |$) ]] || error_exit "provider $PROVIDER not supported yet"
 
 HERE=`dirname "$0"`
 cd $HERE


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-725

Honestly I don't know much about bash regexp test, but I found an example here: http://stackoverflow.com/questions/11396740/how-can-i-check-if-a-string-is-in-an-array-without-iterating-over-the-elements and it seems to work here, :wink: 