### PR TITLE
[TACHYON-639] Check buffer returned from reading a dummy stream is null.

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
@@ -458,13 +458,15 @@ public class TachyonFile implements Comparable<TachyonFile> {
     // Using the dummy stream to read remote buffer.
     ByteBuffer inBuf = dummyStream.readRemoteByteBuffer(mTachyonFS, blockInfo, 0,
         blockInfo.length, mTachyonConf);
+    // Close the stream object.
+    dummyStream.close();
+    if (inBuf == null) {
+      return null;
+    }
     // Copy data in network buffer into client buffer.
     ByteBuffer outBuf = ByteBuffer.allocate((int) inBuf.capacity());
     outBuf.put(inBuf);
-    // Close the stream object.
-    dummyStream.close();
-    return (outBuf == null)
-        ? null : new TachyonByteBuffer(mTachyonFS, outBuf, blockInfo.blockId, -1);
+    return new TachyonByteBuffer(mTachyonFS, outBuf, blockInfo.blockId, -1);
   }
 
   // TODO remove this method. do streaming cache. This is not a right API.

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
@@ -458,14 +458,16 @@ public class TachyonFile implements Comparable<TachyonFile> {
     // Using the dummy stream to read remote buffer.
     ByteBuffer inBuf = dummyStream.readRemoteByteBuffer(mTachyonFS, blockInfo, 0,
         blockInfo.length, mTachyonConf);
-    // Close the stream object.
-    dummyStream.close();
     if (inBuf == null) {
+      // Close the stream object.
+      dummyStream.close();
       return null;
     }
     // Copy data in network buffer into client buffer.
     ByteBuffer outBuf = ByteBuffer.allocate((int) inBuf.capacity());
     outBuf.put(inBuf);
+    // Close the stream object (must be called after buffer is copied)
+    dummyStream.close();
     return new TachyonByteBuffer(mTachyonFS, outBuf, blockInfo.blockId, -1);
   }
 


### PR DESCRIPTION
JIRA: [TACHYON-639](https://tachyon.atlassian.net/browse/TACHYON-639)

This PR fixes bug reported by Pengfei Xuan on JIRA TACHYON-639. The bug causes basic THROUGH test to fail as no null-check is performed for the buffer returned from reading a dummy stream, before copying the data to another buffer.