### PR TITLE
[SMALLFIX] Update the Tachyon - Spark dependency docs

### DIFF
--- a/docs/Running-Spark-on-Tachyon.md
+++ b/docs/Running-Spark-on-Tachyon.md
@@ -29,8 +29,12 @@ recompile Spark with the right version of tachyon-client by changing the version
   <td> v0.5.0 </td>
 </tr>
 <tr>
-  <td> 1.4.x and Above </td>
+  <td> 1.4.x </td>
   <td> v0.6.4 </td>
+</tr>
+<tr>
+  <td> 1.5.x </td>
+  <td> v0.7.1 </td>
 </tr>
 </table>
 

--- a/docs/Running-Spark-on-Tachyon.md
+++ b/docs/Running-Spark-on-Tachyon.md
@@ -33,7 +33,7 @@ recompile Spark with the right version of tachyon-client by changing the version
   <td> v0.6.4 </td>
 </tr>
 <tr>
-  <td> 1.5.x </td>
+  <td> 1.5.x and Above </td>
   <td> v0.7.1 </td>
 </tr>
 </table>


### PR DESCRIPTION
Spark 1.5+ will work out of the box with Tachyon 0.7.x.