### PR TITLE
[TACHYON-726] Add methods of creating TTransport

### DIFF
--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -33,7 +33,7 @@ import tachyon.security.authentication.AuthenticationProviderFactory;
  * There is a new provider {@link PlainSaslServerProvider} needed to support server-side
  * PLAIN mechanism.
  * PlainSaslHelper is used to register this provider.
- * It also provide methods to generate PLAIN transport for server and client.
+ * It also provides methods to generate PLAIN transport for server and client.
  */
 public class PlainSaslHelper {
   static {

--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -15,13 +15,25 @@
 
 package tachyon.security;
 
+import java.util.HashMap;
+
+import javax.security.sasl.SaslException;
 import java.security.Security;
+
+import org.apache.thrift.transport.TSaslServerTransport;
+import org.apache.thrift.transport.TTransportFactory;
+
+import tachyon.conf.TachyonConf;
+import tachyon.security.authentication.AuthenticationFactory.AuthType;
+import tachyon.security.authentication.AuthenticationProvider;
+import tachyon.security.authentication.AuthenticationProviderFactory;
 
 /**
  * Because the Java SunSASL provider doesn't support the server-side PLAIN mechanism.
  * There is a new provider {@link PlainSaslServerProvider} needed to support server-side
  * PLAIN mechanism.
  * PlainSaslHelper is used to register this provider.
+ * It also provide methods to generate PLAIN transport for server and client.
  */
 public class PlainSaslHelper {
   static {
@@ -35,4 +47,27 @@ public class PlainSaslHelper {
   public static boolean isPlainSaslProviderAdded() {
     return Security.getProvider(PlainSaslServerProvider.PROVIDER) != null;
   }
+
+  /**
+   * For server side, get a PLAIN mechanism TTransportFactory. A callback handler is hooked for
+   * specific authentication methods.
+   * @param authType the authentication type
+   * @param conf TachyonConf
+   * @return a corresponding TTransportFactory, which is PLAIN mechanism
+   * @throws SaslException if an AuthenticationProvider is not found
+   */
+  public static TTransportFactory getPlainServerTransportFactory(AuthType authType,
+      TachyonConf conf) throws SaslException {
+    TSaslServerTransport.Factory saslFactory = new TSaslServerTransport.Factory();
+    AuthenticationProvider provider = AuthenticationProviderFactory
+        .getAuthenticationProvider(authType, conf);
+    saslFactory.addServerDefinition("PLAIN", null, null, new HashMap<String, String>(),
+        new PlainSaslServer.PlainServerCallbackHandler(provider));
+
+    return saslFactory;
+  }
+
+  // TODO: get client side PLAIN TTransport
+//  public static TTransport getPlainClientTransport(String username, String password,
+//      TTransport wrappedTransport) throws SaslException {}
 }

--- a/common/src/main/java/tachyon/security/PlainSaslServer.java
+++ b/common/src/main/java/tachyon/security/PlainSaslServer.java
@@ -100,8 +100,7 @@ public class PlainSaslServer implements SaslServer {
         throw new SaslException("AuthorizeCallback authorized failure");
       }
     } catch (AuthenticationException ae) {
-      throw new SaslException("AuthenticationProvider authenticate failed: " + ae.getMessage(),
-          ae);
+      throw new SaslException("AuthenticationProvider authenticate failed: " + ae.getMessage(), ae);
     } catch (IOException ioe) {
       throw new SaslException("Error validating the response", ioe);
     } catch (UnsupportedCallbackException uce) {

--- a/common/src/main/java/tachyon/security/PlainSaslServer.java
+++ b/common/src/main/java/tachyon/security/PlainSaslServer.java
@@ -100,7 +100,8 @@ public class PlainSaslServer implements SaslServer {
         throw new SaslException("AuthorizeCallback authorized failure");
       }
     } catch (AuthenticationException ae) {
-      throw new SaslException("AuthenticationProvider authenticate failed:" + ae.getMessage(), ae);
+      throw new SaslException("AuthenticationProvider authenticate failed: " + ae.getMessage(),
+          ae);
     } catch (IOException ioe) {
       throw new SaslException("Error validating the response", ioe);
     } catch (UnsupportedCallbackException uce) {

--- a/common/src/main/java/tachyon/security/PlainSaslServer.java
+++ b/common/src/main/java/tachyon/security/PlainSaslServer.java
@@ -99,12 +99,8 @@ public class PlainSaslServer implements SaslServer {
       if (!authCallback.isAuthorized()) {
         throw new SaslException("AuthorizeCallback authorized failure");
       }
-    } catch (AuthenticationException ae) {
-      throw new SaslException("AuthenticationProvider authenticate failed: " + ae.getMessage(), ae);
-    } catch (IOException ioe) {
-      throw new SaslException("Error validating the response", ioe);
-    } catch (UnsupportedCallbackException uce) {
-      throw new SaslException("Error validating the response", uce);
+    } catch (Exception e) {
+      throw new SaslException("Plain authentication failed: " + e.getMessage(), e);
     }
     mCompleted = true;
     return null;

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
@@ -117,15 +117,16 @@ public class AuthenticationFactory {
   /**
    * For server side, this method return a TTransportFactory based on the auth type. It is used as
    * one argument to build a Thrift TServer.
+   * If the auth type is not supported or recognized, an UnsupportedOperationException is thrown.
    * @return a corresponding TTransportFactory
    * @throws SaslException if building a TransportFactory fails
-   * @throws UnsupportedOperationException if the auth type is not supported or recognized.
    */
   public TTransportFactory getServerTransportFactory() throws SaslException {
     switch (mAuthType) {
       case NOSASL:
         return new TFramedTransport.Factory();
       case SIMPLE:
+        // intent to fall through
       case CUSTOM:
         return PlainSaslHelper.getPlainServerTransportFactory(mAuthType, mTachyonConf);
       case KERBEROS:

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
@@ -98,7 +98,7 @@ public class AuthenticationFactory {
     mAuthType = getAuthTypeFromConf(tachyonConf);
   }
 
-  AuthType getAuthType() {
+  public AuthType getAuthType() {
     return mAuthType;
   }
 

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
@@ -119,6 +119,7 @@ public class AuthenticationFactory {
    * one argument to build a Thrift TServer.
    * @return a corresponding TTransportFactory
    * @throws SaslException if building a TransportFactory fails
+   * @throws UnsupportedOperationException if the auth type is not supported or recognized.
    */
   public TTransportFactory getServerTransportFactory() throws SaslException {
     switch (mAuthType) {

--- a/common/src/test/java/tachyon/security/PlainSaslServerTest.java
+++ b/common/src/test/java/tachyon/security/PlainSaslServerTest.java
@@ -21,6 +21,7 @@ import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.AuthorizeCallback;
+import javax.security.sasl.SaslException;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,15 +64,15 @@ public class PlainSaslServerTest{
 
   @Test
   public void userIsNotSetTest() throws Exception {
-    mThrown.expect(IllegalStateException.class);
-    mThrown.expectMessage("No authentication identity provided");
+    mThrown.expect(SaslException.class);
+    mThrown.expectMessage("Plain authentication failed: No authentication identity provided");
     mPlainSaslServer.evaluateResponse(getUserInfo("", "anonymous"));
   }
 
   @Test
   public void passwordIsNotSetTest() throws Exception {
-    mThrown.expect(IllegalStateException.class);
-    mThrown.expectMessage("No password provided");
+    mThrown.expect(SaslException.class);
+    mThrown.expectMessage("Plain authentication failed: No password provided");
     mPlainSaslServer.evaluateResponse(getUserInfo("tachyon", ""));
   }
 

--- a/common/src/test/java/tachyon/security/PlainServerCallbackHandlerTest.java
+++ b/common/src/test/java/tachyon/security/PlainServerCallbackHandlerTest.java
@@ -66,7 +66,7 @@ public class PlainServerCallbackHandlerTest {
   @Test
   public void authenticateNameNotMatchTest() throws Exception {
     mThrown.expect(AuthenticationException.class);
-    mThrown.expectMessage("Only allow the user startWith tachyon");
+    mThrown.expectMessage("Only allow the user starting with tachyon");
 
     String authenticateId = "not-tachyon-1";
     NameCallback ncb = new NameCallback(" authentication id: ");
@@ -84,7 +84,7 @@ public class PlainServerCallbackHandlerTest {
     @Override
     public void authenticate(String user, String password) throws AuthenticationException {
       if (!user.matches("^tachyon.*")) {
-        throw new AuthenticationException("Only allow the user startWith tachyon");
+        throw new AuthenticationException("Only allow the user starting with tachyon");
       }
     }
   }

--- a/common/src/test/java/tachyon/security/authentication/AuthenticationFactoryTest.java
+++ b/common/src/test/java/tachyon/security/authentication/AuthenticationFactoryTest.java
@@ -15,6 +15,25 @@
 
 package tachyon.security.authentication;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.transport.TFramedTransport;
+import org.apache.thrift.transport.TSaslClientTransport;
+import org.apache.thrift.transport.TServerSocket;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.transport.TTransportFactory;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,49 +41,218 @@ import org.junit.rules.ExpectedException;
 
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
+import tachyon.security.PlainServerCallbackHandlerTest;
+import tachyon.util.network.NetworkAddressUtils;
 
 /**
  * Unit test for inner class {@link tachyon.security.authentication.AuthenticationFactory
  * .AuthType} and methods of {@link tachyon.security.authentication.AuthenticationFactory}
+ *
+ * In order to test methods that return kinds of TTransport for connection in different mode,
+ * we build Thrift servers and clients with specific TTransport, and let them connect.
  */
 public class AuthenticationFactoryTest {
+
+  TThreadPoolServer mServer;
+  TachyonConf mTachyonConf = new TachyonConf();
+  InetSocketAddress mServerAddress = new InetSocketAddress("localhost",
+      Constants.DEFAULT_MASTER_PORT);
 
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
 
   @Test
   public void authenticationFactoryConstructorTest() {
-    TachyonConf tachyonConf = new TachyonConf();
-    tachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
+    mTachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
 
-    AuthenticationFactory authenticationFactory = new AuthenticationFactory(tachyonConf);
+    AuthenticationFactory authenticationFactory = new AuthenticationFactory(mTachyonConf);
 
-    Assert.assertEquals(AuthenticationFactory.AuthType.SIMPLE.getAuthName(),
-        authenticationFactory.getAuthTypeStr());
+    Assert.assertEquals(AuthenticationFactory.AuthType.SIMPLE, authenticationFactory.getAuthType());
   }
 
   @Test
   public void getAuthTypeFromConfTest() {
-    TachyonConf tachyonConf = new TachyonConf();
     AuthenticationFactory.AuthType authType;
 
     // should return a SIMPLE AuthType with conf "SIMPLE"
-    tachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
-    authType = AuthenticationFactory.getAuthTypeFromConf(tachyonConf);
+    mTachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
+    authType = AuthenticationFactory.getAuthTypeFromConf(mTachyonConf);
     Assert.assertEquals(AuthenticationFactory.AuthType.SIMPLE, authType);
 
     // should return a SIMPLE AuthType with conf "simple"
-    tachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "simple");
-    authType = AuthenticationFactory.getAuthTypeFromConf(tachyonConf);
+    mTachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "simple");
+    authType = AuthenticationFactory.getAuthTypeFromConf(mTachyonConf);
     Assert.assertEquals(AuthenticationFactory.AuthType.SIMPLE, authType);
 
     // should throw exception with conf "wrong"
-    tachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "wrong");
+    mTachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "wrong");
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("wrong is not a valid authentication type. Check the configuration "
         + "parameter " + Constants.TACHYON_SECURITY_AUTHENTICATION);
-    authType = AuthenticationFactory.getAuthTypeFromConf(tachyonConf);
+    authType = AuthenticationFactory.getAuthTypeFromConf(mTachyonConf);
   }
 
-  // TODO: add more tests for methods of AuthenticationFactory
+  /**
+   * In NOSASL mode, the TTransport used should be the same as Tachyon original code.
+   */
+  @Test
+  public void nosaslAuthenticationTest() throws Exception {
+    mTachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "NOSASL");
+
+    // start server
+    startServerThread(mTachyonConf);
+
+    // create client and connect to server
+    TTransport client = createClient(null);
+    client.open();
+    Assert.assertTrue(client.isOpen());
+
+    // clean up
+    client.close();
+    mServer.stop();
+  }
+
+  /**
+   * In SIMPLE mode, the TTransport mechanism is PLAIN. When server authenticate the connected
+   * client user, it use {@link tachyon.security.authentication.SimpleAuthenticationProviderImpl}.
+   */
+  @Test
+  public void simpleAuthenticationTest() throws Exception {
+    mTachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
+
+    // start server
+    startServerThread(mTachyonConf);
+
+    // when connecting, authentication happens. It is a no-op in Simple mode.
+    TTransport client = createClient("anyone");
+    client.open();
+    Assert.assertTrue(client.isOpen());
+
+    // clean up
+    client.close();
+    mServer.stop();
+  }
+
+  /**
+   * In CUSTOM mode, the TTransport mechanism is PLAIN. When server authenticate the connected
+   * client user, it use configured AuthenticationProvider.
+   */
+  @Test
+  public void customAuthenticationTest() throws Exception {
+    mTachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "CUSTOM");
+    mTachyonConf.set(Constants.TACHYON_AUTHENTICATION_PROVIDER_CUSTOM_CLASS,
+        PlainServerCallbackHandlerTest.NameMatchAuthenticationProvider.class.getName());
+
+    // start server
+    startServerThread(mTachyonConf);
+
+    // when connecting, authentication happens. Users starting with "tachyon" can pass.
+    TTransport client = createClient("tachyon");
+    client.open();
+    Assert.assertTrue(client.isOpen());
+
+    // Users not starting with "tachyon" can not pass, and throw exception.
+    TTransport wrongClient = createClient("not-tachyon");
+    mThrown.expect(TTransportException.class);
+    mThrown.expectMessage("Peer indicated failure: AuthenticationProvider authenticate failed: "
+        + "Only allow the user starting with tachyon");
+    try {
+      wrongClient.open();
+    } catch (TTransportException e) {
+      // clean up and re-throw the expected exception
+      client.close();
+      mServer.stop();
+      throw e;
+    }
+  }
+
+  /**
+   * TODO: In KERBEROS mode, ...
+   */
+  @Test
+  public void kerberosAuthenticationTest() throws Exception {
+    mTachyonConf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "KERBEROS");
+
+    // throw unsupported exception currently
+    mThrown.expect(UnsupportedOperationException.class);
+    mThrown.expectMessage("Kerberos is not supported currently.");
+    startServerThread(mTachyonConf);
+  }
+
+  private void startServerThread(TachyonConf conf) throws Exception {
+    // create args and use them to build a Thrift TServer
+    AuthenticationFactory factory = new AuthenticationFactory(conf);
+    TTransportFactory tTransportFactory = factory.getServerTransportFactory();
+
+    TServerSocket wrappedServerSocket = new TServerSocket(mServerAddress);
+
+    mServer = new TThreadPoolServer(new TThreadPoolServer.Args(wrappedServerSocket)
+        .maxWorkerThreads(2).minWorkerThreads(1)
+        .processor(null).transportFactory(tTransportFactory)
+        .protocolFactory(new TBinaryProtocol.Factory(true, true)));
+
+    // start the server in a new thread
+    Thread serverThread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        mServer.serve();
+      }
+    });
+
+    serverThread.start();
+
+    // ensure server is running
+    while (!mServer.isServing() && serverThread.isAlive()) {
+      Thread.sleep(50);
+    }
+  }
+
+  // FIXME: API for creating client transport is on-going in TACHYON-621.
+  // This code is temporarily used to simulate a client transport. Use the API when it's done.
+  private TTransport createClient(String user) throws Exception {
+    // the underlining client socket for connecting to server
+    TTransport tTransport = new TSocket(NetworkAddressUtils.getFqdnHost(mServerAddress),
+        mServerAddress.getPort());
+
+    // wrap above socket.
+    if (user != null) {
+      // Simple and Custom mode
+      return new TSaslClientTransport("PLAIN", null, null, null, new HashMap<String,
+          String>(), new PlainCallbackHandler(user, "noPassword"), tTransport);
+    } else {
+      // NOSASL mode. The original Tachyon logic
+      return new TFramedTransport(tTransport);
+    }
+  }
+
+  // FIXME: This client side Callback Handler is on-going in TACHYON-621.
+  // This code is temporarily used for test and should be deleted after TACHYON-621 merged.
+  /**
+   * A client side callback to put application provided username/pwd into SASL transport.
+   */
+  private static class PlainCallbackHandler implements CallbackHandler {
+
+    private final String mUserName;
+    private final String mPassword;
+
+    public PlainCallbackHandler(String mUserName, String mPassword) {
+      this.mUserName = mUserName;
+      this.mPassword = mPassword;
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+      for (Callback callback : callbacks) {
+        if (callback instanceof NameCallback) {
+          NameCallback nameCallback = (NameCallback) callback;
+          nameCallback.setName(mUserName);
+        } else if (callback instanceof PasswordCallback) {
+          PasswordCallback passCallback = (PasswordCallback) callback;
+          passCallback.setPassword(mPassword.toCharArray());
+        } else {
+          throw new UnsupportedCallbackException(callback);
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
JIRA: https://tachyon.atlassian.net/browse/TACHYON-726

This patch adds a method in AuthenticationFactory for creating server side TTransportFactory, which is used to build a Thrift TServer.

In original code, `TachyonMaster` build a `TThreadPoolServer` with transport `TFramedTransport.Factory`. This method increase options of transport, so enhance the server.