### PR TITLE
[SMALLFIX] Mark async through as experimental in 0.7.

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/WriteType.java
+++ b/clients/unshaded/src/main/java/tachyon/client/WriteType.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -36,7 +36,8 @@ public enum WriteType {
    */
   THROUGH(4),
   /**
-   * Write the file asynchronously to the under fs (either must cache or must through).
+   * [Experimental] Write the file asynchronously to the under fs (either must cache or must
+   * through).
    */
   ASYNC_THROUGH(5);
 
@@ -48,7 +49,7 @@ public enum WriteType {
 
   /**
    * Return the value of the write type
-   * 
+   *
    * @return the value of the write type
    */
   public int getValue() {

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -351,8 +351,8 @@ The user configuration specifies values regarding file system access.
   <td>Default write type for Tachyon files in CLI copyFromLocal and Hadoop compatitable interface.
     Valid options are MUST_CACHE (write must cache), TRY_CACHE (write will try to cache),
     CACHE_THROUGH (try to cache, write to UnderFS synchronously), THROUGH (no cache, write to
-    UnderFS synchronously), ASYNC_THROUGH (must cache and write to UnderFS asynchronously, or
-    synchronous write to UnderFS).</td>
+    UnderFS synchronously), ASYNC_THROUGH (Experimental, must cache and write to UnderFS asynchronously,
+    or synchronous write to UnderFS).</td>
 </tr>
 <tr>
   <td>tachyon.user.quota.unit.bytes</td>


### PR DESCRIPTION
Notes async_through as an experimental write type, since the feature will likely be modified in future versions.