### PR TITLE
[SMALLFIX] Using a newer java and maven to build Tachyon in vagrant/deploy

### DIFF
--- a/deploy/vagrant/provision/roles/common/files/java.sh
+++ b/deploy/vagrant/provision/roles/common/files/java.sh
@@ -3,6 +3,6 @@
 #set -x
 
 # install java
-sudo yum install -y -q java-1.6.0-openjdk-devel.x86_64
-jvm="/usr/lib/jvm/java-1.6.0-openjdk.x86_64"
+sudo yum install -y -q java-1.7.0-openjdk-devel.x86_64
+jvm="/usr/lib/jvm/java-1.7.0-openjdk.x86_64"
 echo "export JAVA_HOME=${jvm}" >> ~/.bashrc

--- a/deploy/vagrant/provision/roles/lib/files/maven.sh
+++ b/deploy/vagrant/provision/roles/lib/files/maven.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
 
-REPO=/etc/yum.repos.d/epel-apache-maven.repo
-
-if [ -f "$REPO" ]; then exit 0; fi
+MAVEN_LOC=http://apache.arvixe.com/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz
 
 mkdir -p /vagrant/shared
 cd /vagrant/shared
 
 # install maven
-if [ ! -f epel-apache-maven.repo ]; then
- sudo yum install -y -q wget
- wget -q http://repos.fedorapeople.org/repos/dchen/apache-maven/epel-apache-maven.repo
-fi
+wget -q $MAVEN_LOC
+filename=$(basename "$MAVEN_LOC")
+tar xzvf $filename
 
-sudo cp epel-apache-maven.repo $REPO
-sudo yum install -q -y apache-maven
-sudo ln -f -s /usr/share/apache-maven/bin/mvn /usr/bin/mvn
+IFS='-' read -a array <<< "$filename"
+sudo ln -f -s "/vagrant/shared/${array[0]}-${array[1]}-${array[2]}/bin/mvn" /usr/bin/mvn
+
 # relocate local repo to shared folder
 mkdir -p ~/.m2
 cat > ~/.m2/settings.xml <<EOF


### PR DESCRIPTION
Old script point to an outdated maven repo that is not working anymore.
Instead we fetch a specific version of maven that is known to work, and
a java version that is required of that maven version.