### PR TITLE
[TACHYON-621] Enable Client PLAIN Authentication

### DIFF
--- a/common/src/main/java/tachyon/master/MasterClient.java
+++ b/common/src/main/java/tachyon/master/MasterClient.java
@@ -26,12 +26,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import javax.security.sasl.SaslException;
 
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TFramedTransport;
-import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,9 @@ import tachyon.Version;
 import tachyon.conf.TachyonConf;
 import tachyon.retry.ExponentialBackoffRetry;
 import tachyon.retry.RetryPolicy;
+import tachyon.security.LoginUser;
+import tachyon.security.authentication.AuthenticationFactory;
+import tachyon.security.authentication.AuthenticationFactory.AuthType;
 import tachyon.thrift.BlockInfoException;
 import tachyon.thrift.ClientBlockInfo;
 import tachyon.thrift.ClientDependencyInfo;
@@ -182,9 +186,7 @@ public final class MasterClient implements Closeable {
       LOG.info("Tachyon client (version " + Version.VERSION + ") is trying to connect with master"
           + " @ " + mMasterAddress);
 
-      mProtocol =
-          new TBinaryProtocol(new TFramedTransport(new TSocket(
-              NetworkAddressUtils.getFqdnHost(mMasterAddress), mMasterAddress.getPort())));
+      mProtocol = new TBinaryProtocol(createTransport());
       mClient = new MasterService.Client(mProtocol);
       try {
         mProtocol.getTransport().open();
@@ -222,6 +224,28 @@ public final class MasterClient implements Closeable {
     // Reaching here indicates that we did not successfully connect.
     throw new IOException("Failed to connect with master @ " + mMasterAddress + " after "
         + (retry.getRetryCount()) + " attempts", lastException);
+  }
+
+  /**
+   * Create transport per the connection options Supported transport options are: NOSASL, SIMPLE,
+   * CUSTOM, KERBEROS
+   * @throws TTransportException
+   */
+  private TTransport createTransport() throws IOException {
+    TTransport tTransport = AuthenticationFactory.createTSocket(mMasterAddress);
+    AuthType authType = AuthenticationFactory.getAuthTypeFromConf(mTachyonConf);
+    switch (authType) {
+      case NOSASL:
+        return new TFramedTransport(tTransport);
+      case SIMPLE:
+      case CUSTOM:
+        String username = LoginUser.get(mTachyonConf).getName();
+        return AuthenticationFactory.createPlainClientTransport(username, "noPassword", tTransport);
+      case KERBEROS:
+        throw new SaslException("Kerberos is not supported currently.");
+      default:
+        throw new SaslException("Unsupported authentication type: " + authType.getAuthName());
+    }
   }
 
   /**

--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -88,30 +88,31 @@ public class PlainSaslHelper {
         new PlainClientCallbackHandler(username, password), wrappedTransport);
   }
 
+  /**
+   * A client side callback to put application provided username/password into SASL transport.
+   */
   public static class PlainClientCallbackHandler implements CallbackHandler {
 
     private final String mUserName;
     private final String mPassword;
 
     public PlainClientCallbackHandler(String userName, String password) {
-      this.mUserName = userName;
-      this.mPassword = password;
+      mUserName = userName;
+      mPassword = password;
     }
 
     @Override
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
       for (Callback callback : callbacks) {
-        if (callback != null) {
-          if (callback instanceof NameCallback) {
-            NameCallback nameCallback = (NameCallback) callback;
-            nameCallback.setName(mUserName);
-          } else if (callback instanceof PasswordCallback) {
-            PasswordCallback passCallback = (PasswordCallback) callback;
-            passCallback.setPassword(mPassword == null ? null : mPassword.toCharArray());
-          } else {
-            throw new UnsupportedCallbackException(callback, callback.getClass()
-                + " is unsupported.");
-          }
+        if (callback instanceof NameCallback) {
+          NameCallback nameCallback = (NameCallback) callback;
+          nameCallback.setName(mUserName);
+        } else if (callback instanceof PasswordCallback) {
+          PasswordCallback passCallback = (PasswordCallback) callback;
+          passCallback.setPassword(mPassword == null ? null : mPassword.toCharArray());
+        } else {
+          Class<?> callbackClass = (callback == null) ? null : callback.getClass();
+          throw new UnsupportedCallbackException(callback, callbackClass + " is unsupported.");
         }
       }
     }

--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -75,11 +75,11 @@ public class PlainSaslHelper {
   }
 
   /**
-   * Get a ClientTransport for Plain
+   * Get a PLAIN mechanism transport for client side.
    * @param username User Name of PlainClient
    * @param password Password of PlainClient
    * @param wrappedTransport The original Transport
-   * @return Wrapped Transport with Plain
+   * @return Wrapped transport with PLAIN mechanism
    * @throws SaslException if an AuthenticationProvider is not found
    */
   public static TTransport getPlainClientTransport(String username, String password,

--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -85,7 +85,7 @@ public class PlainSaslHelper {
    * @return Wrapped Transport with Plain
    * @throws SaslException
    */
-  public static TTransport getPlainTransport(String username, String password,
+  public static TTransport getPlainClientTransport(String username, String password,
       TTransport wrappedTransport) throws SaslException {
     return new TSaslClientTransport("PLAIN", null, null, null, new HashMap<String, String>(),
         new PlainCallbackHandler(username, password), wrappedTransport);
@@ -96,9 +96,9 @@ public class PlainSaslHelper {
     private final String mUserName;
     private final String mPassword;
 
-    public PlainCallbackHandler(String mUserName, String mPassword) {
-      this.mUserName = mUserName;
-      this.mPassword = mPassword;
+    public PlainCallbackHandler(String userName, String password) {
+      this.mUserName = userName;
+      this.mPassword = password;
     }
 
     @Override

--- a/common/src/main/java/tachyon/security/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/PlainSaslHelper.java
@@ -15,12 +15,20 @@
 
 package tachyon.security;
 
+import java.io.IOException;
+import java.security.Security;
 import java.util.HashMap;
 
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.SaslException;
-import java.security.Security;
 
+import org.apache.thrift.transport.TSaslClientTransport;
 import org.apache.thrift.transport.TSaslServerTransport;
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportFactory;
 
 import tachyon.conf.TachyonConf;
@@ -41,7 +49,6 @@ public class PlainSaslHelper {
   }
 
   /**
-   * @param name the name of the provider
    * @return true if the provider was registered
    */
   public static boolean isPlainSaslProviderAdded() {
@@ -70,4 +77,44 @@ public class PlainSaslHelper {
   // TODO: get client side PLAIN TTransport
 //  public static TTransport getPlainClientTransport(String username, String password,
 //      TTransport wrappedTransport) throws SaslException {}
+  /**
+   * Get a ClientTransport for Plain
+   * @param username User Name of PlainClient
+   * @param password Password of PlainClient
+   * @param wrappedTransport The original Transport
+   * @return Wrapped Transport with Plain
+   * @throws SaslException
+   */
+  public static TTransport getPlainTransport(String username, String password,
+      TTransport wrappedTransport) throws SaslException {
+    return new TSaslClientTransport("PLAIN", null, null, null, new HashMap<String, String>(),
+        new PlainCallbackHandler(username, password), wrappedTransport);
+  }
+
+  public static class PlainCallbackHandler implements CallbackHandler {
+
+    private final String mUserName;
+    private final String mPassword;
+
+    public PlainCallbackHandler(String mUserName, String mPassword) {
+      this.mUserName = mUserName;
+      this.mPassword = mPassword;
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+      for (Callback callback : callbacks) {
+        if (callback instanceof NameCallback) {
+          NameCallback nameCallback = (NameCallback) callback;
+          nameCallback.setName(mUserName);
+        } else if (callback instanceof PasswordCallback) {
+          PasswordCallback passCallback = (PasswordCallback) callback;
+          passCallback.setPassword(mPassword.toCharArray());
+        } else {
+          throw new UnsupportedCallbackException(callback, callback.getClass()
+              + " is unsupported.");
+        }
+      }
+    }
+  }
 }

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
@@ -163,7 +163,7 @@ public class AuthenticationFactory {
    */
   public static TTransport createPlainClientTransport(String username, String password,
       TTransport tTransport) throws SaslException {
-    return PlainSaslHelper.getPlainTransport(username, password, tTransport);
+    return PlainSaslHelper.getPlainClientTransport(username, password, tTransport);
   }
 
   // TODO: add methods of getting different Thrift class in follow-up PR.

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
@@ -176,5 +176,4 @@ public class AuthenticationFactory {
     return new TSocket(NetworkAddressUtils.getFqdnHost(address), address.getPort());
   }
 
-  // TODO: add methods of getting different Thrift class in follow-up PR.
 }

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
@@ -144,8 +144,11 @@ public class AuthenticationFactory {
   }
 
   /**
-   * Create a transport per the connection options. Supported transport options are: NOSASL,
-   * SIMPLE, CUSTOM, KERBEROS
+   * Create a transport per the connection options. Supported transport options are: NOSASL, SIMPLE,
+   * CUSTOM, KERBEROS. With NOSASL as input, an unmodified TTransport is returned; with
+   * SIMPLE/CUSTOM as input, a PlainCLientTransport is returned; KERBEROS is not supported
+   * currently. If the auth type is not supported or recognized, an UnsupportedOperationException is
+   * thrown.
    * 
    * @param serverAddress the server address which clients will connect to
    * @return a TTransport for client
@@ -157,6 +160,7 @@ public class AuthenticationFactory {
       case NOSASL:
         return new TFramedTransport(tTransport);
       case SIMPLE:
+        // indent to fall through after case SIMPLE
       case CUSTOM:
         String username = LoginUser.get(mTachyonConf).getName();
         return PlainSaslHelper.getPlainClientTransport(username, "noPassword", tTransport);

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
@@ -15,11 +15,14 @@
 
 package tachyon.security.authentication;
 
+import java.net.InetSocketAddress;
 import java.util.Locale;
 
 import javax.security.sasl.SaslException;
 
 import org.apache.thrift.transport.TFramedTransport;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.security.PlainSaslHelper;
+import tachyon.util.network.NetworkAddressUtils;
 
 /**
  * This class is the main entry for Tachyon authentication.
@@ -139,4 +143,28 @@ public class AuthenticationFactory {
 
   // TODO: get client side TTransport based on auth type
   // public TTransport getClientTransport(InetSocketAddress serverAddress) throws SaslException {}
+
+  /**
+   * Create a new Thrift socket what will connect to the given address
+   * @param address The given address to connect
+   * @return An unconnected socket
+   */
+  public static TSocket createTSocket(InetSocketAddress address) {
+    return new TSocket(NetworkAddressUtils.getFqdnHost(address), address.getPort());
+  }
+
+  /**
+   * Create a ClientTransport for Plain
+   * @param username User Name of PlainClient
+   * @param password Password of PlainClient
+   * @param tTransport The original Transport
+   * @return Wrapped Transport with Plain
+   * @throws SaslException
+   */
+  public static TTransport createPlainClientTransport(String username, String password,
+      TTransport tTransport) throws SaslException {
+    return PlainSaslHelper.getPlainTransport(username, password, tTransport);
+  }
+
+  // TODO: add methods of getting different Thrift class in follow-up PR.
 }

--- a/common/src/test/java/tachyon/security/PlainClientCallbackHandlerTest.java
+++ b/common/src/test/java/tachyon/security/PlainClientCallbackHandlerTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -43,7 +43,8 @@ public class PlainClientCallbackHandlerTest {
     String user = "tachyon-user-1";
     String password = "tachyon-user-1-password";
 
-    CallbackHandler clientCBHandler = new PlainSaslHelper.PlainCallbackHandler(user, password);
+    CallbackHandler clientCBHandler =
+        new PlainSaslHelper.PlainClientCallbackHandler(user, password);
     clientCBHandler.handle(callbacks);
 
     validateCallbacks(user, password, callbacks);
@@ -62,7 +63,42 @@ public class PlainClientCallbackHandlerTest {
 
     String user = "tachyon-user-2";
     String password = "tachyon-user-2-password";
-    CallbackHandler clientCBHandler = new PlainSaslHelper.PlainCallbackHandler(user, password);
+    CallbackHandler clientCBHandler =
+        new PlainSaslHelper.PlainClientCallbackHandler(user, password);
+    clientCBHandler.handle(callbacks);
+
+    validateCallbacks(user, password, callbacks);
+  }
+
+
+  @Test
+  public void nullPasswordCallbackTest() throws Exception {
+
+    Callback[] callbacks = new Callback[2];
+    callbacks[0] = new NameCallback("Username:");
+    callbacks[1] = new PasswordCallback("Password:", true);
+
+    String user = "tachyon-user-3";
+    String password = null;
+    CallbackHandler clientCBHandler =
+        new PlainSaslHelper.PlainClientCallbackHandler(user, password);
+    clientCBHandler.handle(callbacks);
+
+    validateCallbacks(user, password, callbacks);
+  }
+
+  @Test
+  public void nullCallbackTest() throws Exception {
+
+    Callback[] callbacks = new Callback[3];
+    callbacks[0] = new NameCallback("Username:");
+    callbacks[1] = new PasswordCallback("Password:", true);
+    callbacks[2] = null;
+
+    String user = "tachyon-user-4";
+    String password = "tachyon-user-4-password";
+    CallbackHandler clientCBHandler =
+        new PlainSaslHelper.PlainClientCallbackHandler(user, password);
     clientCBHandler.handle(callbacks);
 
     validateCallbacks(user, password, callbacks);
@@ -75,7 +111,7 @@ public class PlainClientCallbackHandlerTest {
         Assert.assertEquals(user, ((NameCallback) cb).getName());
       } else if (cb instanceof PasswordCallback) {
         char[] passwordChar = ((PasswordCallback) cb).getPassword();
-        Assert.assertEquals(passwd, String.copyValueOf(passwordChar));
+        Assert.assertEquals(passwd, passwordChar == null ? null : String.copyValueOf(passwordChar));
       }
     }
   }

--- a/common/src/test/java/tachyon/security/PlainClientCallbackHandlerTest.java
+++ b/common/src/test/java/tachyon/security/PlainClientCallbackHandlerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.security;
+
+import java.io.IOException;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PlainClientCallbackHandlerTest {
+
+  @Rule
+  public ExpectedException mThrown = ExpectedException.none();
+
+  @Test
+  public void clientCallbackHandlerTest() throws Exception {
+
+    Callback[] callbacks = new Callback[2];
+    callbacks[0] = new NameCallback("Username:");
+    callbacks[1] = new PasswordCallback("Password:", true);
+
+    String user = "tachyon-user-1";
+    String password = "tachyon-user-1-password";
+
+    CallbackHandler clientCBHandler = new PlainSaslHelper.PlainCallbackHandler(user, password);
+    clientCBHandler.handle(callbacks);
+
+    validateCallbacks(user, password, callbacks);
+  }
+
+  @Test
+  public void unsupportCallbackTest() throws Exception {
+
+    mThrown.expect(UnsupportedCallbackException.class);
+    mThrown.expectMessage(RealmCallback.class + " is unsupported.");
+
+    Callback[] callbacks = new Callback[3];
+    callbacks[0] = new NameCallback("Username:");
+    callbacks[1] = new PasswordCallback("Password:", true);
+    callbacks[2] = new RealmCallback("Realm:");
+
+    String user = "tachyon-user-2";
+    String password = "tachyon-user-2-password";
+    CallbackHandler clientCBHandler = new PlainSaslHelper.PlainCallbackHandler(user, password);
+    clientCBHandler.handle(callbacks);
+
+    validateCallbacks(user, password, callbacks);
+  }
+
+  private void validateCallbacks(String user, String passwd, Callback[] callbacks)
+      throws IOException, UnsupportedCallbackException {
+    for (Callback cb : callbacks) {
+      if (cb instanceof NameCallback) {
+        Assert.assertEquals(user, ((NameCallback) cb).getName());
+      } else if (cb instanceof PasswordCallback) {
+        char[] passwordChar = ((PasswordCallback) cb).getPassword();
+        Assert.assertEquals(passwd, String.copyValueOf(passwordChar));
+      }
+    }
+  }
+}

--- a/common/src/test/java/tachyon/security/PlainClientCallbackHandlerTest.java
+++ b/common/src/test/java/tachyon/security/PlainClientCallbackHandlerTest.java
@@ -70,7 +70,6 @@ public class PlainClientCallbackHandlerTest {
     validateCallbacks(user, password, callbacks);
   }
 
-
   @Test
   public void nullPasswordCallbackTest() throws Exception {
 
@@ -89,6 +88,9 @@ public class PlainClientCallbackHandlerTest {
 
   @Test
   public void nullCallbackTest() throws Exception {
+
+    mThrown.expect(UnsupportedCallbackException.class);
+    mThrown.expectMessage(null + " is unsupported.");
 
     Callback[] callbacks = new Callback[3];
     callbacks[0] = new NameCallback("Username:");

--- a/common/src/test/java/tachyon/security/PlainClientCallbackHandlerTest.java
+++ b/common/src/test/java/tachyon/security/PlainClientCallbackHandlerTest.java
@@ -66,6 +66,20 @@ public class PlainClientCallbackHandlerTest {
     CallbackHandler clientCBHandler =
         new PlainSaslHelper.PlainClientCallbackHandler(user, password);
     clientCBHandler.handle(callbacks);
+  }
+
+  @Test
+  public void nullNameCallbackTest() throws Exception {
+
+    Callback[] callbacks = new Callback[2];
+    callbacks[0] = new NameCallback("Username:");
+    callbacks[1] = new PasswordCallback("Password:", true);
+
+    String user = null;
+    String password = "tachyon-user-3-password";
+    CallbackHandler clientCBHandler =
+        new PlainSaslHelper.PlainClientCallbackHandler(user, password);
+    clientCBHandler.handle(callbacks);
 
     validateCallbacks(user, password, callbacks);
   }
@@ -77,7 +91,7 @@ public class PlainClientCallbackHandlerTest {
     callbacks[0] = new NameCallback("Username:");
     callbacks[1] = new PasswordCallback("Password:", true);
 
-    String user = "tachyon-user-3";
+    String user = "tachyon-user-4";
     String password = null;
     CallbackHandler clientCBHandler =
         new PlainSaslHelper.PlainClientCallbackHandler(user, password);
@@ -97,13 +111,11 @@ public class PlainClientCallbackHandlerTest {
     callbacks[1] = new PasswordCallback("Password:", true);
     callbacks[2] = null;
 
-    String user = "tachyon-user-4";
-    String password = "tachyon-user-4-password";
+    String user = "tachyon-user-5";
+    String password = "tachyon-user-5-password";
     CallbackHandler clientCBHandler =
         new PlainSaslHelper.PlainClientCallbackHandler(user, password);
     clientCBHandler.handle(callbacks);
-
-    validateCallbacks(user, password, callbacks);
   }
 
   private void validateCallbacks(String user, String passwd, Callback[] callbacks)

--- a/common/src/test/java/tachyon/security/authentication/AuthenticationFactoryTest.java
+++ b/common/src/test/java/tachyon/security/authentication/AuthenticationFactoryTest.java
@@ -23,6 +23,7 @@ import javax.security.sasl.SaslException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TThreadPoolServer;
 import org.apache.thrift.transport.TServerSocket;
+import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.TTransportFactory;
@@ -48,6 +49,7 @@ public class AuthenticationFactoryTest {
   TachyonConf mTachyonConf = new TachyonConf();
   InetSocketAddress mServerAddress = new InetSocketAddress("localhost",
       Constants.DEFAULT_MASTER_PORT);
+  TSocket mServerTSocket = AuthenticationFactory.createTSocket(mServerAddress);
 
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
@@ -122,8 +124,7 @@ public class AuthenticationFactoryTest {
 
     // when connecting, authentication happens. It is a no-op in Simple mode.
     TTransport client =
-        PlainSaslHelper.getPlainClientTransport("anyone", "whatever",
-            AuthenticationFactory.createTSocket(mServerAddress));
+        PlainSaslHelper.getPlainClientTransport("anyone", "whatever", mServerTSocket);
     client.open();
     Assert.assertTrue(client.isOpen());
 
@@ -142,9 +143,7 @@ public class AuthenticationFactoryTest {
     // check case that user is null
     mThrown.expect(SaslException.class);
     mThrown.expectMessage("PLAIN: authorization ID and password must be specified");
-    TTransport client =
-        PlainSaslHelper.getPlainClientTransport(null, "whatever",
-            AuthenticationFactory.createTSocket(mServerAddress));
+    TTransport client = PlainSaslHelper.getPlainClientTransport(null, "whatever", mServerTSocket);
   }
 
   /**
@@ -157,9 +156,7 @@ public class AuthenticationFactoryTest {
     // check case that password is null
     mThrown.expect(SaslException.class);
     mThrown.expectMessage("PLAIN: authorization ID and password must be specified");
-    TTransport client =
-        PlainSaslHelper.getPlainClientTransport("anyone", null,
-            AuthenticationFactory.createTSocket(mServerAddress));
+    TTransport client = PlainSaslHelper.getPlainClientTransport("anyone", null, mServerTSocket);
   }
 
   /**
@@ -176,9 +173,7 @@ public class AuthenticationFactoryTest {
     mThrown.expect(TTransportException.class);
     mThrown.expectMessage("Peer indicated failure: Plain authentication failed: No authentication"
         + " identity provided");
-    TTransport client =
-        PlainSaslHelper.getPlainClientTransport("", "whatever",
-            AuthenticationFactory.createTSocket(mServerAddress));
+    TTransport client = PlainSaslHelper.getPlainClientTransport("", "whatever", mServerTSocket);
     try {
       client.open();
     } finally {
@@ -202,9 +197,7 @@ public class AuthenticationFactoryTest {
     mThrown.expect(TTransportException.class);
     mThrown.expectMessage("Peer indicated failure: Plain authentication failed: No password "
         + "provided");
-    TTransport client =
-        PlainSaslHelper.getPlainClientTransport("anyone", "",
-            AuthenticationFactory.createTSocket(mServerAddress));
+    TTransport client = PlainSaslHelper.getPlainClientTransport("anyone", "", mServerTSocket);
     try {
       client.open();
     } finally {
@@ -228,8 +221,7 @@ public class AuthenticationFactoryTest {
 
     // when connecting, authentication happens. User's name:pwd pair matches and auth pass.
     TTransport client =
-        PlainSaslHelper.getPlainClientTransport("tachyon", "correct-password",
-            AuthenticationFactory.createTSocket(mServerAddress));
+        PlainSaslHelper.getPlainClientTransport("tachyon", "correct-password", mServerTSocket);
     client.open();
     Assert.assertTrue(client.isOpen());
 
@@ -253,8 +245,7 @@ public class AuthenticationFactoryTest {
 
     // User with wrong password can not pass auth, and throw exception.
     TTransport wrongClient =
-        PlainSaslHelper.getPlainClientTransport("tachyon", "wrong-password",
-            AuthenticationFactory.createTSocket(mServerAddress));
+        PlainSaslHelper.getPlainClientTransport("tachyon", "wrong-password", mServerTSocket);
     mThrown.expect(TTransportException.class);
     mThrown.expectMessage("Peer indicated failure: Plain authentication failed: "
         + "User authentication fails");
@@ -276,8 +267,7 @@ public class AuthenticationFactoryTest {
     mThrown.expect(SaslException.class);
     mThrown.expectMessage("PLAIN: authorization ID and password must be specified");
     TTransport client =
-        PlainSaslHelper.getPlainClientTransport(null, "correct-password",
-            AuthenticationFactory.createTSocket(mServerAddress));
+        PlainSaslHelper.getPlainClientTransport(null, "correct-password", mServerTSocket);
   }
 
   /**
@@ -290,9 +280,7 @@ public class AuthenticationFactoryTest {
     // check case that password is null
     mThrown.expect(SaslException.class);
     mThrown.expectMessage("PLAIN: authorization ID and password must be specified");
-    TTransport client =
-        PlainSaslHelper.getPlainClientTransport("tachyon", null,
-            AuthenticationFactory.createTSocket(mServerAddress));
+    TTransport client = PlainSaslHelper.getPlainClientTransport("tachyon", null, mServerTSocket);
   }
 
   /**
@@ -312,8 +300,7 @@ public class AuthenticationFactoryTest {
     mThrown.expectMessage("Peer indicated failure: Plain authentication failed: No authentication"
         + " identity provided");
     TTransport client =
-        PlainSaslHelper.getPlainClientTransport("", "correct-password",
-            AuthenticationFactory.createTSocket(mServerAddress));
+        PlainSaslHelper.getPlainClientTransport("", "correct-password", mServerTSocket);
     try {
       client.open();
     } finally {
@@ -337,9 +324,7 @@ public class AuthenticationFactoryTest {
     mThrown.expect(TTransportException.class);
     mThrown.expectMessage("Peer indicated failure: Plain authentication failed: No password "
         + "provided");
-    TTransport client =
-        PlainSaslHelper.getPlainClientTransport("tachyon", "",
-            AuthenticationFactory.createTSocket(mServerAddress));
+    TTransport client = PlainSaslHelper.getPlainClientTransport("tachyon", "", mServerTSocket);
     try {
       client.open();
     } finally {

--- a/common/src/test/java/tachyon/security/authentication/AuthenticationFactoryTest.java
+++ b/common/src/test/java/tachyon/security/authentication/AuthenticationFactoryTest.java
@@ -15,24 +15,14 @@
 
 package tachyon.security.authentication;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.HashMap;
 
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.AuthenticationException;
 import javax.security.sasl.SaslException;
 
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TThreadPoolServer;
-import org.apache.thrift.transport.TFramedTransport;
-import org.apache.thrift.transport.TSaslClientTransport;
 import org.apache.thrift.transport.TServerSocket;
-import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.TTransportFactory;
@@ -43,7 +33,7 @@ import org.junit.rules.ExpectedException;
 
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
-import tachyon.util.network.NetworkAddressUtils;
+import tachyon.security.PlainSaslHelper;
 
 /**
  * Unit test for inner class {@link tachyon.security.authentication.AuthenticationFactory
@@ -110,7 +100,7 @@ public class AuthenticationFactoryTest {
     startServerThread(mTachyonConf);
 
     // create client and connect to server
-    TTransport client = createClient(mTachyonConf, null, null);
+    TTransport client = new AuthenticationFactory(mTachyonConf).getClientTransport(mServerAddress);
     client.open();
     Assert.assertTrue(client.isOpen());
 
@@ -131,7 +121,9 @@ public class AuthenticationFactoryTest {
     startServerThread(mTachyonConf);
 
     // when connecting, authentication happens. It is a no-op in Simple mode.
-    TTransport client = createClient(mTachyonConf, "anyone", "whatever");
+    TTransport client =
+        PlainSaslHelper.getPlainClientTransport("anyone", "whatever",
+            AuthenticationFactory.createTSocket(mServerAddress));
     client.open();
     Assert.assertTrue(client.isOpen());
 
@@ -150,7 +142,9 @@ public class AuthenticationFactoryTest {
     // check case that user is null
     mThrown.expect(SaslException.class);
     mThrown.expectMessage("PLAIN: authorization ID and password must be specified");
-    TTransport client = createClient(mTachyonConf, null, "whatever");
+    TTransport client =
+        PlainSaslHelper.getPlainClientTransport(null, "whatever",
+            AuthenticationFactory.createTSocket(mServerAddress));
   }
 
   /**
@@ -163,7 +157,9 @@ public class AuthenticationFactoryTest {
     // check case that password is null
     mThrown.expect(SaslException.class);
     mThrown.expectMessage("PLAIN: authorization ID and password must be specified");
-    TTransport client = createClient(mTachyonConf, "anyone", null);
+    TTransport client =
+        PlainSaslHelper.getPlainClientTransport("anyone", null,
+            AuthenticationFactory.createTSocket(mServerAddress));
   }
 
   /**
@@ -180,7 +176,9 @@ public class AuthenticationFactoryTest {
     mThrown.expect(TTransportException.class);
     mThrown.expectMessage("Peer indicated failure: Plain authentication failed: No authentication"
         + " identity provided");
-    TTransport client = createClient(mTachyonConf, "", "whatever");
+    TTransport client =
+        PlainSaslHelper.getPlainClientTransport("", "whatever",
+            AuthenticationFactory.createTSocket(mServerAddress));
     try {
       client.open();
     } finally {
@@ -204,7 +202,9 @@ public class AuthenticationFactoryTest {
     mThrown.expect(TTransportException.class);
     mThrown.expectMessage("Peer indicated failure: Plain authentication failed: No password "
         + "provided");
-    TTransport client = createClient(mTachyonConf, "anyone", "");
+    TTransport client =
+        PlainSaslHelper.getPlainClientTransport("anyone", "",
+            AuthenticationFactory.createTSocket(mServerAddress));
     try {
       client.open();
     } finally {
@@ -227,7 +227,9 @@ public class AuthenticationFactoryTest {
     startServerThread(mTachyonConf);
 
     // when connecting, authentication happens. User's name:pwd pair matches and auth pass.
-    TTransport client = createClient(mTachyonConf, "tachyon", "correct-password");
+    TTransport client =
+        PlainSaslHelper.getPlainClientTransport("tachyon", "correct-password",
+            AuthenticationFactory.createTSocket(mServerAddress));
     client.open();
     Assert.assertTrue(client.isOpen());
 
@@ -250,7 +252,9 @@ public class AuthenticationFactoryTest {
     startServerThread(mTachyonConf);
 
     // User with wrong password can not pass auth, and throw exception.
-    TTransport wrongClient = createClient(mTachyonConf, "tachyon", "wrong-password");
+    TTransport wrongClient =
+        PlainSaslHelper.getPlainClientTransport("tachyon", "wrong-password",
+            AuthenticationFactory.createTSocket(mServerAddress));
     mThrown.expect(TTransportException.class);
     mThrown.expectMessage("Peer indicated failure: Plain authentication failed: "
         + "User authentication fails");
@@ -271,7 +275,9 @@ public class AuthenticationFactoryTest {
     // check case that user is null
     mThrown.expect(SaslException.class);
     mThrown.expectMessage("PLAIN: authorization ID and password must be specified");
-    TTransport client = createClient(mTachyonConf, null, "correct-password");
+    TTransport client =
+        PlainSaslHelper.getPlainClientTransport(null, "correct-password",
+            AuthenticationFactory.createTSocket(mServerAddress));
   }
 
   /**
@@ -284,7 +290,9 @@ public class AuthenticationFactoryTest {
     // check case that password is null
     mThrown.expect(SaslException.class);
     mThrown.expectMessage("PLAIN: authorization ID and password must be specified");
-    TTransport client = createClient(mTachyonConf, "tachyon", null);
+    TTransport client =
+        PlainSaslHelper.getPlainClientTransport("tachyon", null,
+            AuthenticationFactory.createTSocket(mServerAddress));
   }
 
   /**
@@ -303,7 +311,9 @@ public class AuthenticationFactoryTest {
     mThrown.expect(TTransportException.class);
     mThrown.expectMessage("Peer indicated failure: Plain authentication failed: No authentication"
         + " identity provided");
-    TTransport client = createClient(mTachyonConf, "", "correct-password");
+    TTransport client =
+        PlainSaslHelper.getPlainClientTransport("", "correct-password",
+            AuthenticationFactory.createTSocket(mServerAddress));
     try {
       client.open();
     } finally {
@@ -327,7 +337,9 @@ public class AuthenticationFactoryTest {
     mThrown.expect(TTransportException.class);
     mThrown.expectMessage("Peer indicated failure: Plain authentication failed: No password "
         + "provided");
-    TTransport client = createClient(mTachyonConf, "tachyon", "");
+    TTransport client =
+        PlainSaslHelper.getPlainClientTransport("tachyon", "",
+            AuthenticationFactory.createTSocket(mServerAddress));
     try {
       client.open();
     } finally {
@@ -394,53 +406,4 @@ public class AuthenticationFactoryTest {
     }
   }
 
-  // FIXME: API for creating client transport is on-going in TACHYON-621.
-  // This code is temporarily used to simulate a client transport. Use the API when it's done.
-  private TTransport createClient(TachyonConf conf, String user, String password)
-      throws SaslException {
-    // the underlining client socket for connecting to server
-    TTransport tTransport = new TSocket(NetworkAddressUtils.getFqdnHost(mServerAddress),
-        mServerAddress.getPort());
-
-    // wrap above socket.
-    if (AuthenticationFactory.getAuthTypeFromConf(conf) != AuthenticationFactory.AuthType.NOSASL) {
-      // Simple and Custom mode
-      return new TSaslClientTransport("PLAIN", null, null, null, new HashMap<String,
-          String>(), new PlainClientCallbackHandler(user, password), tTransport);
-    } else {
-      // NOSASL mode. The original Tachyon logic
-      return new TFramedTransport(tTransport);
-    }
-  }
-
-  // FIXME: This client side Callback Handler is on-going in TACHYON-621.
-  // This code is temporarily used for test and should be deleted after TACHYON-621 merged.
-  /**
-   * A client side callback to put application provided username/pwd into SASL transport.
-   */
-  private static class PlainClientCallbackHandler implements CallbackHandler {
-
-    private final String mUserName;
-    private final String mPassword;
-
-    public PlainClientCallbackHandler(String mUserName, String mPassword) {
-      this.mUserName = mUserName;
-      this.mPassword = mPassword;
-    }
-
-    @Override
-    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-      for (Callback callback : callbacks) {
-        if (callback instanceof NameCallback) {
-          NameCallback nameCallback = (NameCallback) callback;
-          nameCallback.setName(mUserName);
-        } else if (callback instanceof PasswordCallback) {
-          PasswordCallback passCallback = (PasswordCallback) callback;
-          passCallback.setPassword(mPassword == null ? null : mPassword.toCharArray());
-        } else {
-          throw new UnsupportedCallbackException(callback);
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
Jira: https://tachyon.atlassian.net/browse/TACHYON-621

This patch is about Enable Client PLAIN Authentication, including adding Plain Client Transport and callback handler in client side.

Related jira: [TACHYON-726](https://tachyon.atlassian.net/browse/TACHYON-726) Add methods of creating TTransport