### PR TITLE
[TACHYON-754] Enable MapReduce FileSystem Counter information in AbstractTFS

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -504,6 +504,10 @@ abstract class AbstractTFS extends FileSystem {
   @Override
   public boolean rename(Path src, Path dst) throws IOException {
     LOG.info("rename(" + src + ", " + dst + ")");
+    if (mStatistics != null) {
+      mStatistics.incrementWriteOps(1);
+    }
+
     TachyonURI srcPath = new TachyonURI(Utils.getPathWithoutScheme(src));
     TachyonURI dstPath = new TachyonURI(Utils.getPathWithoutScheme(dst));
     ClientFileInfo info = mTFS.getFileStatus(-1, dstPath);

--- a/clients/unshaded/src/main/java/tachyon/hadoop/HdfsFileInputStream.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/HdfsFileInputStream.java
@@ -23,6 +23,7 @@ import com.google.common.primitives.Ints;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
@@ -45,7 +46,7 @@ public class HdfsFileInputStream extends InputStream implements Seekable, Positi
   private Path mHdfsPath;
   private Configuration mHadoopConf;
   private int mHadoopBufferSize;
-  private FileSystem.Statistics mStatistics;
+  private Statistics mStatistics;
   private TachyonFile mTachyonFile;
 
   private FSDataInputStream mHdfsInputStream = null;

--- a/integration-tests/src/test/java/tachyon/hadoop/HdfsFileInputStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/HdfsFileInputStreamIntegrationTest.java
@@ -79,12 +79,12 @@ public class HdfsFileInputStreamIntegrationTest {
   public final void before() throws IOException {
     ClientFileInfo fileInfo = sTFS.getFileStatus(-1, new TachyonURI("/testFile1"));
     mInMemInputStream = new HdfsFileInputStream(sTFS, fileInfo.getId(),
-        new Path(fileInfo.getUfsPath()), new Configuration(), BUFFER_SIZE,
+        new Path(fileInfo.getUfsPath()), new Configuration(), BUFFER_SIZE, null,
         sLocalTachyonCluster.getMasterTachyonConf());
 
     fileInfo = sTFS.getFileStatus(-1, new TachyonURI("/testFile2"));
     mUfsInputStream = new HdfsFileInputStream(sTFS, fileInfo.getId(),
-        new Path(fileInfo.getUfsPath()), new Configuration(), BUFFER_SIZE,
+        new Path(fileInfo.getUfsPath()), new Configuration(), BUFFER_SIZE, null,
         sLocalTachyonCluster.getMasterTachyonConf());
   }
 

--- a/integration-tests/src/test/java/tachyon/hadoop/TFSStatisticsTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/TFSStatisticsTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.hadoop;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import tachyon.client.TachyonFS;
+import tachyon.client.TachyonFSTestUtils;
+import tachyon.client.WriteType;
+import tachyon.master.LocalTachyonCluster;
+
+/**
+ * Integration tests for statistics in TFS.
+ */
+public class TFSStatisticsTest {
+
+  private static final int BLOCK_SIZE = 128;
+  private static final int FILE_LEN = BLOCK_SIZE * 2 + 1;
+  private static LocalTachyonCluster sLocalTachyonCluster;
+  private static FileSystem.Statistics sStatistics;
+  private static FileSystem sTFS;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    // Disable hdfs client caching to avoid file system close() affecting other clients
+    System.setProperty("fs.hdfs.impl.disable.cache", "true");
+
+    Configuration conf = new Configuration();
+    conf.set("fs.tachyon.impl", TFS.class.getName());
+
+    // Start local Tachyon cluster
+    sLocalTachyonCluster = new LocalTachyonCluster(10000, 1000, BLOCK_SIZE);
+    sLocalTachyonCluster.start();
+
+    TachyonFS tachyonFS = sLocalTachyonCluster.getClient();
+    TachyonFSTestUtils.createByteFile(tachyonFS, "/testFile-read", WriteType.CACHE_THROUGH,
+        FILE_LEN);
+    tachyonFS.close();
+
+    URI uri = URI.create(sLocalTachyonCluster.getMasterUri());
+    sTFS = FileSystem.get(uri, conf);
+    sStatistics = FileSystem.getStatistics(uri.getScheme(), sTFS.getClass());
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    sLocalTachyonCluster.stop();
+    System.clearProperty("fs.hdfs.impl.disable.cache");
+  }
+
+  /**
+   * Test the number of bytes read.
+   */
+  @Test
+  public void bytesReadStatisticsTest() throws Exception {
+    long originStat = sStatistics.getBytesRead();
+    InputStream is = sTFS.open(new Path("/testFile-read"));
+    while (is.read() != -1) {}
+    is.close();
+    Assert.assertEquals(originStat + FILE_LEN, sStatistics.getBytesRead());
+  }
+
+  /**
+   * Test the number of bytes written.
+   */
+  @Test
+  public void bytesWrittenStatisticsTest() throws Exception {
+    long originStat = sStatistics.getBytesWritten();
+    OutputStream os = sTFS.create(new Path("/testFile-write"));
+    for (int i = 0; i < FILE_LEN; i ++) {
+      os.write(1);
+    }
+    os.close();
+    Assert.assertEquals(originStat + FILE_LEN, sStatistics.getBytesWritten());
+  }
+
+  /**
+   * Test the number of read/write operations.
+   */
+  @Test
+  public void readWriteOperationsStatisticsTest() throws Exception {
+    int exceptedReadOps = sStatistics.getReadOps();
+    int exceptedWriteOps = sStatistics.getWriteOps();
+
+    // Call all the overridden methods and check the statistics.
+    sTFS.create(new Path("/testFile-create")).close();
+    exceptedWriteOps ++;
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.delete(new Path("/testFile-create"), true);
+    exceptedWriteOps ++;
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.getDefaultBlockSize();
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.getDefaultReplication();
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    FileStatus fStatus = sTFS.getFileStatus(new Path("/testFile-read"));
+    exceptedReadOps ++;
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.getFileBlockLocations(fStatus, 0, FILE_LEN);
+    exceptedReadOps ++;
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.getUri();
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.getWorkingDirectory();
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.listStatus(new Path("/"));
+    exceptedReadOps ++;
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.mkdirs(new Path("/testDir"));
+    exceptedWriteOps ++;
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.open(new Path("/testFile-read")).close();
+    exceptedReadOps ++;
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.rename(new Path("/testDir"), new Path("/testDir-rename"));
+    exceptedWriteOps ++;
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+
+    sTFS.setWorkingDirectory(new Path("/testDir-rename"));
+    Assert.assertEquals(exceptedReadOps, sStatistics.getReadOps());
+    Assert.assertEquals(exceptedWriteOps, sStatistics.getWriteOps());
+  }
+}


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-754

Also run a simple WordCount on both hdfs:// and tachyon://. (Hadoop-2.6.0, Tachyon-master)

**Run on hdfs://** File System Counters
		FILE: Number of bytes read=545224
		FILE: Number of bytes written=1060941
		FILE: Number of read operations=0
		FILE: Number of large read operations=0
		FILE: Number of write operations=0
		HDFS: Number of bytes read=3428
		HDFS: Number of bytes written=1765
		HDFS: Number of read operations=13
		HDFS: Number of large read operations=0
		HDFS: Number of write operations=4

**Run on tachyon://** File System Counters
		FILE: Number of bytes read=545258
		FILE: Number of bytes written=1060059
		FILE: Number of read operations=0
		FILE: Number of large read operations=0
		FILE: Number of write operations=0
		HDFS: Number of bytes read=0
		HDFS: Number of bytes written=1765
		HDFS: Number of read operations=6
		HDFS: Number of large read operations=0
		HDFS: Number of write operations=3
		TACHYON: Number of bytes read=3428
		TACHYON: Number of bytes written=1765
		TACHYON: Number of read operations=13
		TACHYON: Number of large read operations=0
		TACHYON: Number of write operations=3