### PR TITLE
[SMALLFIX] Change IOException to NotFoundException

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import tachyon.Constants;
 import tachyon.Users;
 import tachyon.conf.TachyonConf;
+import tachyon.exception.NotFoundException;
 import tachyon.master.MasterClient;
 import tachyon.thrift.BlockInfoException;
 import tachyon.thrift.Command;
@@ -187,7 +188,9 @@ public class BlockMasterSync implements Runnable {
         for (long block : cmd.mData) {
           try {
             mBlockDataManager.removeBlock(Users.MASTER_COMMAND_USER_ID, block);
-          } catch (IOException ioe) {
+          } catch (NotFoundException nfe) {
+            // TODO: Throw a better exception here
+            // NotFoundException will be thrown if the block is unable to be locked.
             LOG.warn("Failed master free block cmd for: " + block + " due to concurrent read.");
           }
         }


### PR DESCRIPTION
In the master branch, failing to lock now throws NotFoundException, so we should catch that instead.