### PR TITLE
[TACHYON-612] BlockStoreLocation Visitor

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/allocator/Allocator.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/Allocator.java
@@ -64,6 +64,6 @@ public interface Allocator {
    * @return a temp block meta if success, null otherwise
    * @throws IllegalArgumentException if block location is invalid
    */
-  TempBlockMeta allocateBlockWithView(long userId, long blockId, long blockSize,
-      BlockStoreLocation location, BlockMetadataManagerView view);
+  TempBlockMeta allocateBlockWithView(final long userId, final long blockId, final long blockSize,
+      final BlockStoreLocation location, final BlockMetadataManagerView view);
 }

--- a/servers/src/main/java/tachyon/worker/block/evictor/Evictor.java
+++ b/servers/src/main/java/tachyon/worker/block/evictor/Evictor.java
@@ -67,6 +67,6 @@ public interface Evictor {
    *         is feasible
    * @throws IllegalArgumentException if given block location is invalid
    */
-  EvictionPlan freeSpaceWithView(long availableBytes, BlockStoreLocation location,
-      BlockMetadataManagerView view);
+  EvictionPlan freeSpaceWithView(final long availableBytes, final BlockStoreLocation location,
+      final BlockMetadataManagerView view);
 }

--- a/servers/src/main/java/tachyon/worker/block/evictor/PartialLRUEvictor.java
+++ b/servers/src/main/java/tachyon/worker/block/evictor/PartialLRUEvictor.java
@@ -15,13 +15,10 @@
 
 package tachyon.worker.block.evictor;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import com.google.common.base.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,9 +29,7 @@ import tachyon.exception.NotFoundException;
 import tachyon.worker.block.BlockMetadataManagerView;
 import tachyon.worker.block.BlockStoreLocation;
 import tachyon.worker.block.meta.BlockMeta;
-import tachyon.worker.block.meta.StorageDir;
 import tachyon.worker.block.meta.StorageDirView;
-import tachyon.worker.block.meta.StorageTier;
 import tachyon.worker.block.meta.StorageTierView;
 
 /**
@@ -53,9 +48,8 @@ public class PartialLRUEvictor extends LRUEvictor {
   }
 
   @Override
-  protected StorageDirView cascadingEvict(long bytesToBeAvailable, BlockStoreLocation location,
-      EvictionPlan plan) {
-
+  protected StorageDirView cascadingEvict(final long bytesToBeAvailable,
+      final BlockStoreLocation location, final EvictionPlan plan) {
     // 1. Get StorageDir with max free space. If no such StorageDir, return null. If
     // bytesToBeAvailable can already be satisfied without eviction, return emtpy plan
     StorageDirView candidateDirView = getDirWithMaxFreeSpace(bytesToBeAvailable, location);
@@ -121,43 +115,30 @@ public class PartialLRUEvictor extends LRUEvictor {
    * @param availableBytes space size to be requested
    * @param location location that the space will be allocated in
    * @return the StorageDirView selected
-   * @throws IOException
    */
-  private StorageDirView getDirWithMaxFreeSpace(long availableBytes, BlockStoreLocation location) {
-    long maxFreeSize = -1;
-    StorageDirView selectedDirView = null;
+  private StorageDirView getDirWithMaxFreeSpace(final long availableBytes,
+      final BlockStoreLocation location) {
+    BlockMetadataManagerView.DirVisitor visitor = new BlockMetadataManagerView.DirVisitor() {
+      private long mMaxFreeSize = -1;
+      private StorageDirView mDir = null;
 
-    if (location.equals(BlockStoreLocation.anyTier())) {
-      for (StorageTierView tierView : mManagerView.getTierViews()) {
-        for (StorageDirView dirView : tierView.getDirViews()) {
-          if (dirView.getCommittedBytes() + dirView.getAvailableBytes() >= availableBytes
-              && dirView.getAvailableBytes() > maxFreeSize) {
-            selectedDirView = dirView;
-            maxFreeSize = dirView.getAvailableBytes();
-          }
-        }
-      }
-    } else {
-      int tierAlias = location.tierAlias();
-      StorageTierView tierView = mManagerView.getTierView(tierAlias);
-      if (location.equals(BlockStoreLocation.anyDirInTier(tierAlias))) {
-        for (StorageDirView dirView : tierView.getDirViews()) {
-          if (dirView.getCommittedBytes() + dirView.getAvailableBytes() >= availableBytes
-              && dirView.getAvailableBytes() > maxFreeSize) {
-            selectedDirView = dirView;
-            maxFreeSize = dirView.getAvailableBytes();
-          }
-        }
-      } else {
-        int dirIndex = location.dir();
-        StorageDirView dirView = tierView.getDirView(dirIndex);
+      @Override
+      public boolean visit(StorageDirView dirView) {
         if (dirView.getCommittedBytes() + dirView.getAvailableBytes() >= availableBytes
-            && dirView.getAvailableBytes() > maxFreeSize) {
-          selectedDirView = dirView;
-          maxFreeSize = dirView.getAvailableBytes();
+            && dirView.getAvailableBytes() > mMaxFreeSize) {
+          mDir = dirView;
+          mMaxFreeSize = dirView.getAvailableBytes();
         }
+        return false;
       }
-    }
-    return selectedDirView;
+
+      @Override
+      public StorageDirView getDir() {
+        return mDir;
+      }
+    };
+
+    mManagerView.visitDirs(location, visitor);
+    return visitor.getDir();
   }
 }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-612

A visitor interface to abstract the logic of looping through StorageDirViews contained in a BlockStoreLocation so that the logic does not need to be duplicated in Evictors and Allocators.