### PR TITLE
[SMALLFIX] Use Amazon Linux AMI

### DIFF
--- a/deploy/vagrant/conf/ec2.yml
+++ b/deploy/vagrant/conf/ec2.yml
@@ -69,9 +69,9 @@ Block_Device_Mapping: []
 # Some Instance Type must need PV/HVM:
 #   http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/
 # PV
-AMI: "ami-b06a98d8"
+AMI: "ami-1ccae774"
 # HVM
-# AMI: "ami-5b697332"
+# AMI: "ami-1ecae776"
 
 # EC2 network security groups and subnet id
 # Ensure ports used by Tachyon are on


### PR DESCRIPTION
Updates the AMI to be compatible with the java and maven upgrade. This is the same AMI used in master.