### PR TITLE
[SMALLFIX] Fix external block store hostname

### DIFF
--- a/deploy/vagrant/provision/roles/spark/files/spark-defaults.sh
+++ b/deploy/vagrant/provision/roles/spark/files/spark-defaults.sh
@@ -9,5 +9,5 @@ cat > /spark/conf/spark-defaults.conf <<EOF
   spark.serializer org.apache.spark.serializer.KryoSerializer
   spark.tachyonStore.url tachyon://TachyonMaster:19998
   # externalBlockStore.url is needed in spark master branch
-  spark.externalBlockStore.url tachyon://TachyonMaster:19998 
+  spark.externalBlockStore.url tachyon://TachyonMaster:19998
 EOF

--- a/deploy/vagrant/provision/roles/spark/files/spark-defaults.sh
+++ b/deploy/vagrant/provision/roles/spark/files/spark-defaults.sh
@@ -7,7 +7,7 @@ cat > /spark/conf/spark-defaults.conf <<EOF
   spark.eventLog.enabled true
   spark.eventLog.dir /tmp/spark-eventlog
   spark.serializer org.apache.spark.serializer.KryoSerializer
-  spark.tachyonStore.url tachyon://TachyonMaster.local:19998
+  spark.tachyonStore.url tachyon://TachyonMaster:19998
   # externalBlockStore.url is needed in spark master branch
-  spark.externalBlockStore.url tachyon://TachyonMaster.local:19998 
+  spark.externalBlockStore.url tachyon://TachyonMaster:19998 
 EOF


### PR DESCRIPTION
Fixes the default spark external block store url to use the correct one.