### PR TITLE
[TACHYON-782] Disable flakey delete during eviction test.

### DIFF
--- a/integration-tests/src/test/java/tachyon/worker/block/meta/CapacityUsageIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/block/meta/CapacityUsageIntegrationTest.java
@@ -110,7 +110,8 @@ public class CapacityUsageIntegrationTest {
     mTFS.delete(new TachyonURI(fileName2), false);
   }
 
-  @Test
+  // TODO: Rethink the approach of this test and what it should be testing
+  //@Test
   public void deleteDuringEvictionTest() throws IOException {
     // This test may not trigger eviction each time, repeat it 20 times.
     for (int i = 0; i < 20; i ++) {


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-782

This is a temporary bandaid for ticket 782. The long term solution should be to repurpose the test to the new worker delete and eviction logic.