### PR TITLE
[TACHYON-590] Utility functions for the wildcard support of Tachyon shell commands

### DIFF
--- a/shell/src/main/java/tachyon/shell/TFsShellUtils.java
+++ b/shell/src/main/java/tachyon/shell/TFsShellUtils.java
@@ -172,7 +172,7 @@ public class TFsShellUtils {
    * @param parent The directory in which we are searching matched files 
    * @return A list of files that matches the input path in the parent directory
    */
-  protected static List<File> getFiles(String inputPath, String parent) {
+  private static List<File> getFiles(String inputPath, String parent) {
     List<File> res = new LinkedList<File>();
     File pFile = new File(parent);
     if (!pFile.exists() || !pFile.isDirectory()) {
@@ -223,7 +223,7 @@ public class TFsShellUtils {
    * @param patternURI The URI that can contain wildcards
    * @return true if matches; false if not
    */
-  protected static boolean match(TachyonURI fileURI, TachyonURI patternURI) {
+  private static boolean match(TachyonURI fileURI, TachyonURI patternURI) {
     return escape(fileURI.getPath()).matches(replaceWildcards(patternURI.getPath()));
   }
   

--- a/shell/src/main/java/tachyon/shell/TFsShellUtils.java
+++ b/shell/src/main/java/tachyon/shell/TFsShellUtils.java
@@ -15,11 +15,17 @@
 
 package tachyon.shell;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Pattern;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
+import tachyon.client.TachyonFS;
 import tachyon.conf.TachyonConf;
+import tachyon.thrift.ClientFileInfo;
 import tachyon.util.io.PathUtils;
 
 /**
@@ -73,5 +79,164 @@ public class TFsShellUtils {
       }
       return PathUtils.concatPath(Constants.HEADER + hostname + ":" + port, path);
     }
+  }
+  
+  /**
+   * Get all the TachyonURIs that match inputURI. 
+   * If the path is an absolute path, the returned list only contains the corresponding URI;
+   * Else if the path contains wildcards, the returned list contains all the matched URIs
+   * It supports any number of wildcards in inputURI
+   * @param tachyonClient The client that fetches the paths
+   * @param inputURI the input URI (could contain wildcards)
+   * @return A list of TachyonURI that matches the inputURI
+   * @throws IOException
+   */
+  public static List<TachyonURI> getTachyonURIs(TachyonFS tachyonClient, TachyonURI inputURI)
+      throws IOException {    
+    if (inputURI.getPath().contains(TachyonURI.WILDCARD) == false) {
+      List<TachyonURI> res = new LinkedList<TachyonURI>();
+      if (tachyonClient.getFileId(inputURI) != -1) {
+        res.add(inputURI);
+      }
+      return res;
+    } else {
+      String inputPath = inputURI.getPath();
+      TachyonURI parentURI = 
+          new TachyonURI(inputURI.getScheme(), inputURI.getAuthority(),
+              inputPath.substring(0, inputPath.indexOf(TachyonURI.WILDCARD) + 1)).getParent();
+      return getTachyonURIs(tachyonClient, inputURI, parentURI);
+    }
+  }
+  
+  /**
+   * The utility function used to implement getTachyonURIs
+   * Basically, it recursively iterates through the directory from the parent directory 
+   * (e.g., for input "/a/b/*", it will start from "/a/b") until it finds all the matches;
+   * It does not go into a directory if the prefix mismatches
+   * (e.g., for input "/a/b/*", it won't go inside directory "/a/c")
+   * If a file path matches 
+   * @param tachyonClient
+   * @param inputURI
+   * @param parentDir
+   * @return
+   * @throws IOException
+   */
+  private static List<TachyonURI> getTachyonURIs(TachyonFS tachyonClient,
+      TachyonURI inputURI, TachyonURI parentDir) throws IOException {
+    List<TachyonURI> res = new LinkedList<TachyonURI>(); 
+    List<ClientFileInfo> files = tachyonClient.listStatus(parentDir);
+    for (ClientFileInfo file : files) {
+      TachyonURI fileURI = new TachyonURI(inputURI.getScheme(), 
+                                          inputURI.getAuthority(), 
+                                          file.getPath());
+      if (match(fileURI, inputURI)) { //if it matches
+        res.add(fileURI);
+      } else {
+        if (file.isFolder) { //if it is a folder, we do it recursively
+          TachyonURI dirURI = new TachyonURI(inputURI.getScheme(), 
+                                             inputURI.getAuthority(), 
+                                             file.getPath());
+          String prefix = inputURI.getLeadingPath(dirURI.getDepth());
+          if (prefix != null && match(dirURI, new TachyonURI(prefix)) == true) {
+            res.addAll(getTachyonURIs(tachyonClient, inputURI, dirURI));
+          }
+        }
+      }
+    }
+    return res;
+  }
+  
+  /**
+   * Get the Files (on the local filesystem) that matches input path. 
+   * Else if the path contains wildcards, the returned list contains all the matched Files
+   * @param path The input URI (could contain wildcards)
+   * @return A list of TachyonURI that matches the input path
+   */
+  public static List<File> getFiles(String path) {
+    File file = new File(path);
+    if (path.contains("*") == false) {
+      List<File> res = new LinkedList<File>();
+      if (file.exists()) {
+        res.add(file);
+      }
+      return res;
+    } else {
+      String prefix = path.substring(0, path.indexOf(TachyonURI.WILDCARD) + 1);
+      String parent = new File(prefix).getParent();
+      return getFiles(path, parent);
+    }
+  }
+  
+  /**
+   * The utility function used to implement getFiles
+   * It follows the same algorithm as getTachyonURIs
+   * @param inputPath
+   * @param parent
+   * @return
+   */
+  protected static List<File> getFiles(String inputPath, String parent) {
+    List<File> res = new LinkedList<File>();
+    File pFile = new File(parent);
+    if (pFile.exists() == false || pFile.isDirectory() == false) {
+      return res;
+    }
+    if (pFile.isDirectory() && pFile.canRead()) {
+      for (File file : pFile.listFiles()) {
+        if (match(file.getPath(), inputPath)) { //if it matches
+          res.add(file);
+        } else {
+          if (file.isDirectory()) { //if it is a folder, we do it recursively
+            TachyonURI dirURI = new TachyonURI(file.getPath());
+            String prefix = 
+                new TachyonURI(inputPath).getLeadingPath(dirURI.getDepth());     
+            if (prefix != null && match(dirURI, new TachyonURI(prefix)) == true) {
+              res.addAll(getFiles(inputPath, dirURI.getPath()));
+            }
+          }
+        }
+      }
+    }
+    return res;
+  }
+  
+  /**
+   * The characters that have special regex semantics
+   */
+  private static final Pattern SPECIAL_REGEX_CHARS = Pattern.compile("[{}()\\[\\].+*?^$\\\\|]");
+  
+  /**
+   * Escape the special characters in a given string
+   * @param str Input string
+   * @return the string with special characters escaped
+   */
+  private static String escape(String str) {
+    return SPECIAL_REGEX_CHARS.matcher(str).replaceAll("\\\\$0");
+  }
+  
+  /**
+   * Replace the wildcards with Java's regex semantics
+   */
+  private static String replaceWildcards(String text) {
+    return escape(text).replace("\\*", ".*");
+  }
+  
+  /**
+   * Return whether or not fileURI matches the patternURI
+   * @param fileURI The TachyonURI of a particular file
+   * @param patternURI The URI that can contain wildcards
+   * @return true if matches; false if not
+   */
+  protected static boolean match(TachyonURI fileURI, TachyonURI patternURI) {
+    return escape(fileURI.getPath()).matches(replaceWildcards(patternURI.getPath()));
+  }
+  
+  /**
+   * Return whether or not filePath matches patternPath
+   * @param filePath Path of a given file
+   * @param patternPath Path that can contain wildcards
+   * @return true if matches; false if not
+   */
+  protected static boolean match(String filePath, String patternPath) {
+    return match(new TachyonURI(filePath), new TachyonURI(patternPath));
   }
 }

--- a/shell/src/test/java/tachyon/shell/TFsShellUtilsTest.java
+++ b/shell/src/test/java/tachyon/shell/TFsShellUtilsTest.java
@@ -15,13 +15,25 @@
 
 package tachyon.shell;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import tachyon.Constants;
+import tachyon.TachyonURI;
+import tachyon.client.TachyonFS;
+import tachyon.client.TachyonFSTestUtils;
+import tachyon.client.WriteType;
 import tachyon.conf.TachyonConf;
+import tachyon.master.LocalTachyonCluster;
 
 /**
  * Unit tests on tachyon.command.Utils.
@@ -30,7 +42,22 @@ import tachyon.conf.TachyonConf;
  * getFilePathTest is specified.
  */
 public class TFsShellUtilsTest {
+  private static final int SIZE_BYTES = Constants.MB * 10;
+  private LocalTachyonCluster mLocalTachyonCluster = null;
+  private TachyonFS mTfs = null;
 
+  @After
+  public final void after() throws Exception {
+    mLocalTachyonCluster.stop();
+  }
+
+  @Before
+  public final void before() throws Exception {
+    mLocalTachyonCluster = new LocalTachyonCluster(SIZE_BYTES, 1000, Constants.GB);
+    mLocalTachyonCluster.start();
+    mTfs = mLocalTachyonCluster.getClient();
+  }
+  
   @Test
   public void getFilePathTest() throws IOException {
     String[] paths =
@@ -41,5 +68,176 @@ public class TFsShellUtilsTest {
       String result = TFsShellUtils.getFilePath(path, new TachyonConf());
       Assert.assertEquals(expected, result);
     }
+  }
+  
+  private void assertFilePath(File file, String path) {
+    Assert.assertEquals(file.getAbsolutePath().compareTo(path), 0);
+  }
+  
+  public static Comparator<File> createFilePathComparator() { 
+    return  new Comparator<File>() {
+      public int compare(File file1, File file2) {
+        // ascending order
+        return file1.getAbsoluteFile().compareTo(file2.getAbsoluteFile());
+      }
+    };
+  }
+  
+  public static Comparator<TachyonURI> createTachyonURIComparator() {
+    return  new Comparator<TachyonURI>() {
+      public int compare(TachyonURI tUri1, TachyonURI tUri2) {
+        // ascending order
+        return tUri1.getPath().compareTo(tUri2.getPath());
+      }
+    };
+  }
+  
+  public int[] resetTachyonFileHierarchy() throws IOException {
+    /**
+     * Generate such local structure
+     *  /testWildCards
+     *  ├── foo
+     *  |    ├── foobar1
+     *  |    └── foobar2
+     *  ├── bar
+     *  |    └── foobar3
+     *  └── foobar4
+     */
+    int[] fileIds = new int[4];
+    mTfs.delete(new TachyonURI("/testWildCards"), true);
+    mTfs.mkdir(new TachyonURI("/testWildCards"));
+    mTfs.mkdir(new TachyonURI("/testWildCards/foo"));
+    mTfs.mkdir(new TachyonURI("/testWildCards/bar"));
+    fileIds[0] = 
+        TachyonFSTestUtils.createByteFile(mTfs, "/testWildCards/foo/foobar1", 
+            WriteType.MUST_CACHE, 10);
+    fileIds[1] =
+        TachyonFSTestUtils.createByteFile(mTfs, "/testWildCards/foo/foobar2", 
+            WriteType.MUST_CACHE, 20);
+    fileIds[2] =
+        TachyonFSTestUtils.createByteFile(mTfs, "/testWildCards/bar/foobar3", 
+            WriteType.MUST_CACHE, 30);
+    fileIds[3] =
+        TachyonFSTestUtils.createByteFile(mTfs, "/testWildCards/foobar4", 
+            WriteType.MUST_CACHE, 40);
+    return fileIds;
+  }
+  
+  @Test
+  public void getTachyonURIsTest() throws IOException {
+    resetTachyonFileHierarchy();   
+    String rootDir = "/testWildCards";
+    
+    List<TachyonURI> tl1 = TFsShellUtils.getTachyonURIs(mTfs, new TachyonURI(rootDir + "/foo"));
+    Collections.sort(tl1, createTachyonURIComparator());
+    Assert.assertEquals(tl1.size(), 1);
+    Assert.assertEquals(tl1.get(0).getPath(), rootDir + "/foo");
+
+    // Trailing slash
+    List<TachyonURI> tl2 = TFsShellUtils.getTachyonURIs(mTfs, new TachyonURI(rootDir + "/foo/"));
+    Collections.sort(tl2, createTachyonURIComparator());
+    Assert.assertEquals(tl2.size(), 1);
+    Assert.assertEquals(tl2.get(0).getPath(), rootDir + "/foo");
+    
+    // Wildcard
+    List<TachyonURI> tl3 = TFsShellUtils.getTachyonURIs(mTfs, new TachyonURI(rootDir + "/foo/*"));
+    Collections.sort(tl3, createTachyonURIComparator());
+    Assert.assertEquals(tl3.size(), 2);
+    Assert.assertEquals(tl3.get(0).getPath(), rootDir + "/foo/foobar1");
+    Assert.assertEquals(tl3.get(1).getPath(), rootDir + "/foo/foobar2");
+
+    // Trailing slash + wildcard
+    List<TachyonURI> tl4 = TFsShellUtils.getTachyonURIs(mTfs, new TachyonURI(rootDir + "/foo/*/"));
+    Collections.sort(tl4, createTachyonURIComparator());
+    Assert.assertEquals(tl4.size(), 2);
+    Assert.assertEquals(tl4.get(0).getPath(), rootDir + "/foo/foobar1");
+    Assert.assertEquals(tl4.get(1).getPath(), rootDir + "/foo/foobar2");
+
+    // Multiple wildcards
+    List<TachyonURI> tl5 = TFsShellUtils.getTachyonURIs(mTfs, new TachyonURI(rootDir + "/*/foo*"));
+    Collections.sort(tl5, createTachyonURIComparator());
+    Assert.assertEquals(tl5.size(), 3);
+    Assert.assertEquals(tl5.get(0).getPath(), rootDir + "/bar/foobar3");
+    Assert.assertEquals(tl5.get(1).getPath(), rootDir + "/foo/foobar1");
+    Assert.assertEquals(tl5.get(2).getPath(), rootDir + "/foo/foobar2");
+  }
+  
+  public void resetLocalFileHierarchy() throws IOException {
+    /**
+     * Generate such local structure
+     *  /testWildCards
+     *  ├── foo
+     *  |    ├── foobar1
+     *  |    └── foobar2
+     *  ├── bar
+     *  |    └── foobar3
+     *  └── foobar4
+     */
+    FileUtils.deleteDirectory(new File(mLocalTachyonCluster.getTachyonHome() + "/testWildCards"));
+    new File(mLocalTachyonCluster.getTachyonHome() + "/testWildCards").mkdir();
+    new File(mLocalTachyonCluster.getTachyonHome() + "/testWildCards/foo").mkdir();
+    new File(mLocalTachyonCluster.getTachyonHome() + "/testWildCards/bar").mkdir();
+    
+    new File(mLocalTachyonCluster.getTachyonHome() + "/testWildCards/foo/foobar1").createNewFile();
+    new File(mLocalTachyonCluster.getTachyonHome() + "/testWildCards/foo/foobar2").createNewFile();
+    new File(mLocalTachyonCluster.getTachyonHome() + "/testWildCards/bar/foobar3").createNewFile();
+    new File(mLocalTachyonCluster.getTachyonHome() + "/testWildCards/foobar4").createNewFile();
+  }
+  
+  
+  @Test
+  public void getFilesTest() throws IOException {
+    resetLocalFileHierarchy();   
+    String rootDir = mLocalTachyonCluster.getTachyonHome() + "/testWildCards";
+    
+    List<File> fl1 = TFsShellUtils.getFiles(rootDir + "/foo");
+    Collections.sort(fl1, createFilePathComparator());
+    Assert.assertEquals(fl1.size(), 1);
+    assertFilePath(fl1.get(0), rootDir + "/foo");
+
+    // Trailing slash
+    List<File> fl2 = TFsShellUtils.getFiles(rootDir + "/foo/");
+    Collections.sort(fl2, createFilePathComparator());
+    Assert.assertEquals(fl2.size(), 1);
+    assertFilePath(fl2.get(0), rootDir + "/foo");
+    
+    // Wildcard
+    List<File> fl3 = TFsShellUtils.getFiles(rootDir + "/foo/*");
+    Collections.sort(fl3, createFilePathComparator());
+    Assert.assertEquals(fl3.size(), 2);
+    assertFilePath(fl3.get(0), rootDir + "/foo/foobar1");
+    assertFilePath(fl3.get(1), rootDir + "/foo/foobar2");
+
+    // Trailing slash + wildcard
+    List<File> fl4 = TFsShellUtils.getFiles(rootDir + "/foo/*/");
+    Collections.sort(fl4, createFilePathComparator());
+    Assert.assertEquals(fl4.size(), 2);
+    assertFilePath(fl4.get(0), rootDir + "/foo/foobar1");
+    assertFilePath(fl4.get(1), rootDir + "/foo/foobar2");
+
+    // Multiple wildcards
+    List<File> fl5 = TFsShellUtils.getFiles(rootDir + "/*/foo*");
+    Collections.sort(fl5, createFilePathComparator());
+    Assert.assertEquals(fl5.size(), 3);
+    assertFilePath(fl5.get(0), rootDir + "/bar/foobar3");
+    assertFilePath(fl5.get(1), rootDir + "/foo/foobar1");
+    assertFilePath(fl5.get(2), rootDir + "/foo/foobar2");
+  }
+  
+  @Test
+  public void matchTest() {
+    Assert.assertEquals(TFsShellUtils.match("/a/b/c",  "/a/*"),    true);
+    Assert.assertEquals(TFsShellUtils.match("/a/b/c",  "/a/*/"),   true);
+    Assert.assertEquals(TFsShellUtils.match("/a/b/c",  "/a/*/c"),  true);
+    Assert.assertEquals(TFsShellUtils.match("/a/b/c",  "/a/*/*"),  true);
+    Assert.assertEquals(TFsShellUtils.match("/a/b/c",  "/a/*/*/"), true);
+    Assert.assertEquals(TFsShellUtils.match("/a/b/c/", "/a/*/*/"), true);
+    Assert.assertEquals(TFsShellUtils.match("/a/b/c/", "/a/*/*"),  true);
+    
+    Assert.assertEquals(TFsShellUtils.match("/foo/bar/foobar/", "/foo*/*"), true);
+    Assert.assertEquals(TFsShellUtils.match("/foo/bar/foobar/", "/*/*/foobar"), true);
+    
+    Assert.assertEquals(TFsShellUtils.match("/a/b/c/", "/b/*"), false);
+    Assert.assertEquals(TFsShellUtils.match("/", "/*/*"), false);
   }
 }


### PR DESCRIPTION
There are two public methods, 
`getTachyonURIs` and `getFiles`
; the former is for Tachyon files and the latter is for files in the local fs.

Basically, the method takes a input path (could contain wildcards) and return the list of files that matches the input path (if the input path is an absolute path, it returns the path)