### PR TITLE
[TACHYON-786] Login Mechanism: Add CUSTOM_LOGIN (by JAAS framework)

### DIFF
--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -240,6 +240,7 @@ public class Constants {
   public static final int BYTES_WRITTEN_UFS_INDEX = 10;
 
   /** Security */
+  public static final String TACHYON_SECURITY_USERNAME = "tachyon.security.username";
   // Authentication
   public static final String TACHYON_SECURITY_AUTHENTICATION = "tachyon.security.authentication";
   public static final String TACHYON_AUTHENTICATION_PROVIDER_CUSTOM_CLASS =

--- a/common/src/main/java/tachyon/security/CustomLoginModule.java
+++ b/common/src/main/java/tachyon/security/CustomLoginModule.java
@@ -26,7 +26,10 @@ import tachyon.Constants;
 
 /**
  * A custom login module that creates a user based on the user name provided through application
- * configuration.
+ * configuration. Specifically, through Java system property tachyon.security.username.
+ * This module is useful if multiple Tachyon clients running under same OS user name
+ * want to get different identifies (for resource and data management), or if Tachyon clients
+ * running under different OS user names want to get same identify.
  */
 public class CustomLoginModule implements LoginModule {
   private Subject mSubject;
@@ -41,7 +44,7 @@ public class CustomLoginModule implements LoginModule {
   /**
    * Retrieve the user name by querying the property of Constants.TACHYON_SECURITY_USERNAME.
    *
-   * @return true if customized user name is not null or empty
+   * @return true if customized user name is set and not empty.
    * @throws javax.security.auth.login.LoginException
    */
   @Override
@@ -49,7 +52,7 @@ public class CustomLoginModule implements LoginModule {
     //TODO: after TachyonConf is refactored into Singleton, we will use TachyonConf
     //instead of System.getProperty for retrieving user name.
     String userName = System.getProperty(Constants.TACHYON_SECURITY_USERNAME, "");
-    if (userName != "") {
+    if (!userName.isEmpty()) {
       mUser = new User(userName);
       return true;
     }

--- a/common/src/main/java/tachyon/security/CustomLoginModule.java
+++ b/common/src/main/java/tachyon/security/CustomLoginModule.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.security;
+
+import java.util.Map;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+import tachyon.Constants;
+
+/**
+ * A custom login module that creates a user based on the user name provided through application
+ * configuration.
+ */
+public class CustomLoginModule implements LoginModule {
+  private Subject mSubject;
+  private User mUser;
+
+  @Override
+  public void initialize(Subject subject, CallbackHandler callbackHandler,
+      Map<String, ?> sharedState, Map<String, ?> options) {
+    mSubject = subject;
+  }
+
+  /**
+   * Retrieve the user name by querying the property of Constants.TACHYON_SECURITY_USERNAME.
+   *
+   * @return true if customized user name is not null or empty
+   * @throws javax.security.auth.login.LoginException
+   */
+  @Override
+  public boolean login() throws LoginException {
+    String userName = System.getProperty(Constants.TACHYON_SECURITY_USERNAME, "");
+    if (userName != "") {
+      mUser = new User(userName);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Abort the authentication (second phase).
+   *
+   * This method is called if the LoginContext's overall authentication failed. (login failed)
+   * It cleans up any state that was changed in the login and commit methods.
+   *
+   * @return true in all cases
+   * @throws LoginException
+   */
+  @Override
+  public boolean abort() throws LoginException {
+    logout();
+    mUser = null;
+    return true;
+  }
+
+  /**
+   * Commit the authentication (second phase).
+   *
+   * This method is called if the LoginContext's overall authentication succeeded.
+   * The implementation first checks if there is already Tachyon user in the subject.
+   * If not, it adds the previously logged in Tachyon user into the subject.
+   *
+   * @return true if a Tachyon user if found or created.
+   * @throws LoginException not Tachyon user is found or created.
+   */
+  @Override
+  public boolean commit() throws LoginException {
+    // if there is already a Tachyon user, it's done.
+    if (!mSubject.getPrincipals(User.class).isEmpty()) {
+      return true;
+    }
+    // add the logged in user into subject
+    if (mUser != null) {
+      mSubject.getPrincipals().add(mUser);
+      return true;
+    }
+    // throw exception if no Tachyon user is found or created.
+    throw new LoginException("Cannot find a user");
+  }
+
+  /**
+   * Logout the user
+   *
+   * The implementation removes the User associated with the Subject.
+   *
+   * @return true in all cases
+   * @throws LoginException if logout fails
+   */
+  @Override
+  public boolean logout() throws LoginException {
+    if (mSubject.isReadOnly()) {
+      throw new LoginException("logout Failed: Subject is Readonly.");
+    }
+
+    if (mUser != null) {
+      mSubject.getPrincipals().remove(mUser);
+    }
+
+    return true;
+  }
+}

--- a/common/src/main/java/tachyon/security/CustomLoginModule.java
+++ b/common/src/main/java/tachyon/security/CustomLoginModule.java
@@ -46,6 +46,8 @@ public class CustomLoginModule implements LoginModule {
    */
   @Override
   public boolean login() throws LoginException {
+    //TODO: after TachyonConf is refactored into Singleton, we will use TachyonConf
+    //instead of System.getProperty for retrieving user name.
     String userName = System.getProperty(Constants.TACHYON_SECURITY_USERNAME, "");
     if (userName != "") {
       mUser = new User(userName);

--- a/common/src/main/java/tachyon/security/TachyonJaasConfiguration.java
+++ b/common/src/main/java/tachyon/security/TachyonJaasConfiguration.java
@@ -39,6 +39,12 @@ public class TachyonJaasConfiguration extends Configuration {
   private static final AppConfigurationEntry OS_SPECIFIC_LOGIN =
       new AppConfigurationEntry(TachyonJaasProperties.getOsLoginModuleName(),
           AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, BASIC_JAAS_OPTIONS);
+  /**
+   * This custom login module allows an customized user name to be specified.
+   */
+  private static final AppConfigurationEntry CUSTOM_LOGIN =
+      new AppConfigurationEntry(CustomLoginModule.class.getName(),
+          AppConfigurationEntry.LoginModuleControlFlag.SUFFICIENT, BASIC_JAAS_OPTIONS);
 
   private static final AppConfigurationEntry TACHYON_LOGIN =
       new AppConfigurationEntry(TachyonLoginModule.class.getName(),
@@ -48,12 +54,13 @@ public class TachyonJaasConfiguration extends Configuration {
   // private static final AppConfigurationEntry KERBEROS_LOGIN = ...
 
   /**
-   * In SIMPLE mode, JAAS use the OS specific login module to fetch the OS user,
-   * and then use the {@link tachyon.security.TachyonLoginModule} to convert it to a Tachyon user
-   * represented by {@link tachyon.security.User}
+   * In SIMPLE mode, JAAS first tries to retrieve the user name set by the application with
+   * {@link tachyon.security.CustomLoginModule}. Upon failure, it use the OS specific login module
+   * to fetch the OS user, and then use the {@link tachyon.security.TachyonLoginModule} to convert
+   * it to a Tachyon user represented by {@link tachyon.security.User}.
    */
   private static final AppConfigurationEntry[] SIMPLE = new
-      AppConfigurationEntry[]{OS_SPECIFIC_LOGIN, TACHYON_LOGIN};
+      AppConfigurationEntry[]{CUSTOM_LOGIN, OS_SPECIFIC_LOGIN, TACHYON_LOGIN};
 
   // TODO: add Kerberos mode
   // private static final AppConfigurationEntry[] KERBEROS = ...

--- a/common/src/test/java/tachyon/security/LoginUserTest.java
+++ b/common/src/test/java/tachyon/security/LoginUserTest.java
@@ -65,6 +65,8 @@ public class LoginUserTest {
   public void getCustomLoginUserTest() throws Exception {
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
+    //TODO: after TachyonConf is refactored into Singleton, we will use TachyonConf
+    //instead of System.getProperty for retrieving user name.
     System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "tachyon-user");
 
     User loginUser = LoginUser.get(conf);
@@ -82,12 +84,14 @@ public class LoginUserTest {
   public void getLoginUserWhenCustomIsEmpty() throws Exception {
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
+    //TODO: after TachyonConf is refactored into Singleton, we will use TachyonConf
+    //instead of System.getProperty for retrieving user name.
     System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "");
 
     User loginUser = LoginUser.get(conf);
 
     Assert.assertNotNull(loginUser);
-    Assert.assertFalse(loginUser.getName().isEmpty());
+    Assert.assertEquals(loginUser.getName(), System.getProperty("user.name"));
   }
 
   // TODO: getKerberosLoginUserTest()

--- a/common/src/test/java/tachyon/security/LoginUserTest.java
+++ b/common/src/test/java/tachyon/security/LoginUserTest.java
@@ -57,6 +57,39 @@ public class LoginUserTest {
     Assert.assertFalse(loginUser.getName().isEmpty());
   }
 
+  /**
+   * Test whether we can get login user with conf in SIMPLE mode, when custom name is provided.
+   * @throws Exception
+   */
+  @Test
+  public void getCustomLoginUserTest() throws Exception {
+    TachyonConf conf = new TachyonConf();
+    conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
+    System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "tachyon-user");
+
+    User loginUser = LoginUser.get(conf);
+
+    Assert.assertNotNull(loginUser);
+    Assert.assertEquals(loginUser.getName(), "tachyon-user");
+  }
+
+  /**
+   * Test whether we can get login user with conf in SIMPLE mode, when custom name is set to an
+   * empty string. In this case, login should return the OS user instead of empty string.
+   * @throws Exception
+   */
+  @Test
+  public void getLoginUserWhenCustomIsEmpty() throws Exception {
+    TachyonConf conf = new TachyonConf();
+    conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
+    System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "");
+
+    User loginUser = LoginUser.get(conf);
+
+    Assert.assertNotNull(loginUser);
+    Assert.assertFalse(loginUser.getName().isEmpty());
+  }
+
   // TODO: getKerberosLoginUserTest()
 
   /**


### PR DESCRIPTION
JIRA: [TACHYON-786](https://tachyon.atlassian.net/browse/TACHYON-786)

In production use of Tachyon, we want different applications to have separate user identities, even if they are running under same operating system user. We should allow this by letting the application to specify their username, through Java configuration parameter. This JIRA enables that in the SIMPLE login mechanism. If tachyon.security.username is specified by the application and is not empty, the login modules uses tachyon.security.username as the username; otherwise, we fall back to OS_SPECIFIC_LOGIN.