### PR TITLE
[SMALLFIX] rename ByteUtilsTest.java to BufferUtilsTest.java

### DIFF
--- a/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
+++ b/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class ByteUtilsTest {
+public class BufferUtilsTest {
   @Test
   public void cloneByteBufferTest() {
     final int bufferSize = 10;


### PR DESCRIPTION
it's more natural to match the test class name with the source class name