### PR TITLE
[TACHYON-787] add test for BufferUtils#cleanDirectBuffer

### DIFF
--- a/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
+++ b/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
@@ -48,10 +48,13 @@ public class BufferUtilsTest {
   @Test
   public void cleanDirectBufferTest() {
     final int MAX_ITERATIONS = 1024;
+    final int BUFFER_SIZE = 16 * 1024 * 1024;
+    // bufferArray keeps reference to each buffer to avoid auto GC
+    ByteBuffer[] bufferArray = new ByteBuffer[MAX_ITERATIONS];
     try {
       for (int i = 0; i < MAX_ITERATIONS; ++i) {
-        final int bufferSize = 16 * 1024 * 1024;
-        ByteBuffer buf = ByteBuffer.allocateDirect(bufferSize);
+        ByteBuffer buf = ByteBuffer.allocateDirect(BUFFER_SIZE);
+        bufferArray[i] = buf;
         BufferUtils.cleanDirectBuffer(buf);
       }
     } catch (OutOfMemoryError ooe) {

--- a/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
+++ b/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
@@ -45,6 +45,13 @@ public class BufferUtilsTest {
     Assert.assertTrue(bufClone.equals(bufDirect));
   }
 
+  /**
+   *{@link BufferUtils#cleanDirectBuffer(ByteBuffer)} } forces to unmap an unused direct buffer.
+   * This test repeated allocates and de-allocates a direct buffer of size 16MB to make sure
+   * cleanDirectBuffer is doing its job. The bufferArray is used to store references to the direct
+   * buffers so that they won't get garbage collected automatically. It has been tested that if the
+   * call to cleanDirectBuffer is removed, this test will fail
+   */
   @Test
   public void cleanDirectBufferTest() {
     final int MAX_ITERATIONS = 1024;
@@ -52,7 +59,7 @@ public class BufferUtilsTest {
     // bufferArray keeps reference to each buffer to avoid auto GC
     ByteBuffer[] bufferArray = new ByteBuffer[MAX_ITERATIONS];
     try {
-      for (int i = 0; i < MAX_ITERATIONS; ++i) {
+      for (int i = 0; i < MAX_ITERATIONS; i ++) {
         ByteBuffer buf = ByteBuffer.allocateDirect(BUFFER_SIZE);
         bufferArray[i] = buf;
         BufferUtils.cleanDirectBuffer(buf);

--- a/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
+++ b/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
@@ -44,4 +44,18 @@ public class BufferUtilsTest {
     bufClone = BufferUtils.cloneByteBuffer(bufDirect);
     Assert.assertTrue(bufClone.equals(bufDirect));
   }
+
+  @Test
+  public void cleanDirectBufferTest() {
+    final int MAX_ITERATIONS = 1024;
+    try {
+      for (int i = 0; i < MAX_ITERATIONS; ++i) {
+        final int bufferSize = 16 * 1024 * 1024;
+        ByteBuffer buf = ByteBuffer.allocateDirect(bufferSize);
+        BufferUtils.cleanDirectBuffer(buf);
+      }
+    } catch (OutOfMemoryError ooe) {
+      Assert.fail("cleanDirectBuffer is causing memory leak." + ooe.getMessage());
+    }
+  }
 }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-787

As suggested by @apc999 , allocate & free 16 MB of memory for 1024 times, make sure there is no OOM