### PR TITLE
[TACHYON-772] Enable Master Server PLAIN Authentication

### DIFF
--- a/common/src/main/java/tachyon/security/LoginUser.java
+++ b/common/src/main/java/tachyon/security/LoginUser.java
@@ -101,9 +101,11 @@ public class LoginUser {
    * @param authType the authentication type in configuration
    */
   private static void checkSecurityEnabled(AuthenticationFactory.AuthType authType) {
-    //TODO: add Kerberos and Custom condition check.
-    if (authType != AuthenticationFactory.AuthType.SIMPLE) {
-      throw new UnsupportedOperationException("User is only supported in SIMPLE mode");
+    //TODO: add Kerberos condition check.
+    if (authType != AuthenticationFactory.AuthType.SIMPLE
+        && authType != AuthenticationFactory.AuthType.CUSTOM) {
+      throw new UnsupportedOperationException("User is not supported in " + authType.getAuthName()
+          + " mode");
     }
   }
 }

--- a/common/src/main/java/tachyon/security/TachyonJaasConfiguration.java
+++ b/common/src/main/java/tachyon/security/TachyonJaasConfiguration.java
@@ -58,6 +58,7 @@ public class TachyonJaasConfiguration extends Configuration {
    * {@link tachyon.security.CustomLoginModule}. Upon failure, it use the OS specific login module
    * to fetch the OS user, and then use the {@link tachyon.security.TachyonLoginModule} to convert
    * it to a Tachyon user represented by {@link tachyon.security.User}.
+   * In CUSTOM mode, we also use this configuration.
    */
   private static final AppConfigurationEntry[] SIMPLE = new
       AppConfigurationEntry[]{CUSTOM_LOGIN, OS_SPECIFIC_LOGIN, TACHYON_LOGIN};
@@ -67,8 +68,8 @@ public class TachyonJaasConfiguration extends Configuration {
 
   @Override
   public AppConfigurationEntry[] getAppConfigurationEntry(String appName) {
-    if (appName.equalsIgnoreCase(AuthenticationFactory.AuthType.SIMPLE.getAuthName())) {
-      // TODO: also return SIMPLE for AuthenticationFactory.AuthType.CUSTOM
+    if (appName.equalsIgnoreCase(AuthenticationFactory.AuthType.SIMPLE.getAuthName())
+        || appName.equalsIgnoreCase(AuthenticationFactory.AuthType.CUSTOM.getAuthName())) {
       return SIMPLE;
     } else if (appName.equalsIgnoreCase(AuthenticationFactory.AuthType.KERBEROS.getAuthName())) {
       // TODO: return KERBEROS;

--- a/common/src/test/java/tachyon/security/LoginUserTest.java
+++ b/common/src/test/java/tachyon/security/LoginUserTest.java
@@ -94,6 +94,21 @@ public class LoginUserTest {
     Assert.assertEquals(loginUser.getName(), System.getProperty("user.name"));
   }
 
+  /**
+   * Test whether we can get login user with conf in CUSTOM mode.
+   * @throws Exception
+   */
+  @Test
+  public void getLoginUserInCustomModeTest() throws Exception {
+    TachyonConf conf = new TachyonConf();
+    conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "CUSTOM");
+
+    User loginUser = LoginUser.get(conf);
+
+    Assert.assertNotNull(loginUser);
+    Assert.assertEquals(loginUser.getName(), System.getProperty("user.name"));
+  }
+
   // TODO: getKerberosLoginUserTest()
 
   /**
@@ -102,13 +117,13 @@ public class LoginUserTest {
    */
   @Test
   public void securityEnabledTest() throws Throwable {
-    // TODO: add Kerberos/Custom in the white list when it is supported.
-    // throw exception when AuthType is not "SIMPLE"
+    // TODO: add Kerberos in the white list when it is supported.
+    // throw exception when AuthType is not "SIMPLE", or "CUSTOM"
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "NOSASL");
 
     mThrown.expect(UnsupportedOperationException.class);
-    mThrown.expectMessage("User is only supported in SIMPLE mode");
+    mThrown.expectMessage("User is not supported in NOSASL mode");
     LoginUser.get(conf);
   }
 }

--- a/integration-tests/src/test/java/tachyon/master/MasterClientAuthenticationIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/MasterClientAuthenticationIntegrationTest.java
@@ -32,8 +32,8 @@ import org.junit.rules.ExpectedException;
 
 import tachyon.Constants;
 import tachyon.security.LoginUser;
-import tachyon.security.authentication.AuthenticationProvider;
 import tachyon.security.authentication.AuthenticationFactory.AuthType;
+import tachyon.security.authentication.AuthenticationProvider;
 
 /**
  * Though its name indicates that it provides the tests for Tachyon authentication.
@@ -52,10 +52,7 @@ public class MasterClientAuthenticationIntegrationTest {
   public void before() throws Exception {
     mLocalTachyonCluster = new LocalTachyonCluster(1000, 1000, Constants.GB);
     mExecutorService = Executors.newFixedThreadPool(2);
-    // User reflection to reset the private static member sLoginUser in LoginUser.
-    Field field = LoginUser.class.getDeclaredField("sLoginUser");
-    field.setAccessible(true);
-    field.set(null, null);
+    clearLoginUser();
   }
 
   @After
@@ -135,6 +132,7 @@ public class MasterClientAuthenticationIntegrationTest {
 
     mMasterInfo = mLocalTachyonCluster.getMasterInfo();
     // Using no-tachyon as loginUser to connect to Master, the IOException will be thrown
+    clearLoginUser();
     mThrown.expect(IOException.class);
     System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "no-tachyon");
     MasterClient masterClient =
@@ -162,6 +160,13 @@ public class MasterClientAuthenticationIntegrationTest {
     Assert.assertNotNull(masterClient.getFileStatus(-1, filename));
     masterClient.disconnect();
     masterClient.close();
+  }
+
+  private void clearLoginUser() throws Exception {
+    // User reflection to reset the private static member sLoginUser in LoginUser.
+    Field field = LoginUser.class.getDeclaredField("sLoginUser");
+    field.setAccessible(true);
+    field.set(null, null);
   }
 
   @Test

--- a/integration-tests/src/test/java/tachyon/master/MasterClientAuthenticationIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/MasterClientAuthenticationIntegrationTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.master;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.security.sasl.AuthenticationException;
+import javax.security.sasl.SaslException;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import tachyon.Constants;
+import tachyon.security.LoginUser;
+import tachyon.security.authentication.AuthenticationProvider;
+import tachyon.security.authentication.AuthenticationFactory.AuthType;
+
+/**
+ * Though its name indicates that it provides the tests for Tachyon authentication.
+ * This class is likely to test four authentication modes: NOSASL, SIMPLE, CUSTOM, KERBEROS.
+ *
+ */
+public class MasterClientAuthenticationIntegrationTest {
+  private LocalTachyonCluster mLocalTachyonCluster = null;
+  private ExecutorService mExecutorService = null;
+  private MasterInfo mMasterInfo = null;
+
+  @Rule
+  public ExpectedException mThrown = ExpectedException.none();
+
+  @Before
+  public void before() throws Exception {
+    mLocalTachyonCluster = new LocalTachyonCluster(1000, 1000, Constants.GB);
+    mExecutorService = Executors.newFixedThreadPool(2);
+    // User reflection to reset the private static member sLoginUser in LoginUser.
+    Field field = LoginUser.class.getDeclaredField("sLoginUser");
+    field.setAccessible(true);
+    field.set(null, null);
+  }
+
+  @After
+  public void after() throws Exception {
+    System.clearProperty(Constants.TACHYON_SECURITY_AUTHENTICATION);
+    System.clearProperty(Constants.TACHYON_AUTHENTICATION_PROVIDER_CUSTOM_CLASS);
+    System.clearProperty(Constants.TACHYON_SECURITY_USERNAME);
+  }
+
+  @Test
+  public void noAuthenticationOpenCloseTest() throws Exception {
+    //no authentication configure
+    System.setProperty(Constants.TACHYON_SECURITY_AUTHENTICATION,
+        AuthType.NOSASL.getAuthName());
+    //start cluster
+    mLocalTachyonCluster.start();
+
+    authenticationOperationTest("/file-nosasl");
+
+    //stop cluster
+    mLocalTachyonCluster.stop();
+  }
+
+  @Test
+  public void simpleAuthenticationOpenCloseTest() throws Exception {
+    //simple authentication configure
+    System.setProperty(Constants.TACHYON_SECURITY_AUTHENTICATION,
+        AuthType.SIMPLE.getAuthName());
+    //start cluster
+    mLocalTachyonCluster.start();
+
+    authenticationOperationTest("/file-simple");
+
+    //stop cluster
+    mLocalTachyonCluster.stop();
+  }
+
+  @Test
+  public void customAuthenticationOpenCloseTest() throws Exception {
+    //custom authentication configure
+    System.setProperty(Constants.TACHYON_SECURITY_AUTHENTICATION,
+        AuthType.CUSTOM.getAuthName());
+    //custom authenticationProvider configure
+    System.setProperty(Constants.TACHYON_AUTHENTICATION_PROVIDER_CUSTOM_CLASS,
+        NameMatchAuthenticationProvider.class.getName());
+
+    /**
+     * Using tachyon as loginUser for unit testing, only tachyon user is allowed to connect to
+     * Tachyon Master.
+     */
+    System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "tachyon");
+
+    //start cluster
+    mLocalTachyonCluster.start();
+
+    authenticationOperationTest("/file-custom");
+
+    //stop cluster
+    mLocalTachyonCluster.stop();
+  }
+
+  @Test
+  public void customAuthenticationDenyConnectTest() throws Exception {
+    //custom authentication configure
+    System.setProperty(Constants.TACHYON_SECURITY_AUTHENTICATION,
+        AuthType.CUSTOM.getAuthName());
+    //custom authenticationProvider configure
+    System.setProperty(Constants.TACHYON_AUTHENTICATION_PROVIDER_CUSTOM_CLASS,
+        NameMatchAuthenticationProvider.class.getName());
+    /**
+     * Using tachyon as loginUser for unit testing, only tachyon user is allowed to connect to
+     * Tachyon Master.
+     */
+    System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "tachyon");
+    //start cluster
+    mLocalTachyonCluster.start();
+
+    mMasterInfo = mLocalTachyonCluster.getMasterInfo();
+    // Using no-tachyon as loginUser to connect to Master, the IOException will be thrown
+    mThrown.expect(IOException.class);
+    System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "no-tachyon");
+    MasterClient masterClient =
+        new MasterClient(mMasterInfo.getMasterAddress(),
+            mExecutorService, mLocalTachyonCluster.getMasterTachyonConf());
+    Assert.assertFalse(masterClient.isConnected());
+    masterClient.connect();
+  }
+
+  /**
+   * Test Tachyon client connects or disconnects to the Master. When the client connects
+   * successfully to the Master, it can successfully create file or not.
+   * @param filename
+   * @throws Exception
+   */
+  private void authenticationOperationTest(String filename) throws Exception {
+    mMasterInfo = mLocalTachyonCluster.getMasterInfo();
+    MasterClient masterClient =
+        new MasterClient(mMasterInfo.getMasterAddress(),
+            mExecutorService, mLocalTachyonCluster.getMasterTachyonConf());
+    Assert.assertFalse(masterClient.isConnected());
+    masterClient.connect();
+    Assert.assertTrue(masterClient.isConnected());
+    masterClient.user_createFile(filename, "", Constants.DEFAULT_BLOCK_SIZE_BYTE, true);
+    Assert.assertNotNull(masterClient.getFileStatus(-1, filename));
+    masterClient.disconnect();
+    masterClient.close();
+  }
+
+  @Test
+  public void kerberosAuthenticationNotSupportTest() throws Exception {
+    //kerberos authentication configure
+    System.setProperty(Constants.TACHYON_SECURITY_AUTHENTICATION,
+        AuthType.KERBEROS.getAuthName());
+    //Currently the kerberos authentication doesn't support
+    mThrown.expect(SaslException.class);
+    mThrown.expectMessage("Kerberos is not supported currently");
+    //start cluster
+    mLocalTachyonCluster.start();
+  }
+
+  public static class NameMatchAuthenticationProvider implements AuthenticationProvider {
+    @Override
+    public void authenticate(String user, String password) throws AuthenticationException {
+      if (!user.equals("tachyon")) {
+        throw new AuthenticationException("Only allow the user tachyon to connect");
+      }
+    }
+  }
+}

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -23,9 +23,9 @@ import java.util.concurrent.Executors;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TServer;
 import org.apache.thrift.server.TThreadPoolServer;
-import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.transport.TTransportFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +38,7 @@ import tachyon.TachyonURI;
 import tachyon.Version;
 import tachyon.conf.TachyonConf;
 import tachyon.metrics.MetricsSystem;
+import tachyon.security.authentication.AuthenticationFactory;
 import tachyon.thrift.MasterService;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.util.CommonUtils;
@@ -271,10 +272,16 @@ public class TachyonMaster {
     MasterService.Processor<MasterServiceHandler> masterServiceProcessor =
         new MasterService.Processor<MasterServiceHandler>(mMasterServiceHandler);
 
+    /**
+     * Return a TTransportFactory based on the authentication type
+     */
+    TTransportFactory transportFactory =
+        new AuthenticationFactory(mTachyonConf).getServerTransportFactory();
+
     mMasterServiceServer =
         new TThreadPoolServer(new TThreadPoolServer.Args(mServerTServerSocket)
             .maxWorkerThreads(mMaxWorkerThreads).minWorkerThreads(mMinWorkerThreads)
-            .processor(masterServiceProcessor).transportFactory(new TFramedTransport.Factory())
+            .processor(masterServiceProcessor).transportFactory(transportFactory)
             .protocolFactory(new TBinaryProtocol.Factory(true, true)));
 
     mIsStarted = true;


### PR DESCRIPTION
JIRA: https://tachyon.atlassian.net/browse/TACHYON-772.

Enable Master Server PLAIN Authentication. I have written some integration tests for all kinds of authentication mode, such as NOSASL, SIMPLE, CUSTOM and KERBEROS.　There has some code about create a test loginUser for uniting test. I know @ooq has sent a PR about custom loginmodule. I will use his feature when it has been committed. @apc999 @ooq  please help me to review this PR. Thanks.