### PR TITLE
[SMALLFIX] Fix the truncated usage message of vagrant create script

### DIFF
--- a/deploy/vagrant/create
+++ b/deploy/vagrant/create
@@ -6,6 +6,7 @@ BOLD_RED='\033[1;31m'
 GREEN='\033[32m'
 BOLD_PURPLE='\033[1;35m'
 NO_COLOR='\033[0m'
+
 error() {
  echo -e "${BOLD_RED}>>> $1${NO_COLOR}"
 }
@@ -17,8 +18,13 @@ error_exit() {
  error "$1"
  exit 1
 }
+
 PROVIDERS=("aws" "vb")
-[ "$#" -ne 2 ] && error_exit "usage: start <number of machines> <provider(${PROVIDERS[@]})>"
+
+if [ "$#" -ne 2 ]; then
+  MSG="Usage start <number of machines> <provider(${PROVIDERS[@]})>"
+  error_exit "$MSG"
+fi
 
 TOTAL="$1"
 PROVIDER="$2"


### PR DESCRIPTION
Before the fix ./create will print "usage: start <number of machines> <provider(aws" in bash. 

But ">>> Usage start <number of machines> <provider(aws vb)>" is expected.
