### PR TITLE
[TACHYON-796] Remove the map entry from `mAddedBlocks` when the block list is empty

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockHeartbeatReporter.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockHeartbeatReporter.java
@@ -17,8 +17,10 @@ package tachyon.worker.block;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import com.google.common.collect.Lists;
 
@@ -130,9 +132,17 @@ public class BlockHeartbeatReporter extends BlockStoreEventListenerBase {
    * @param blockId The block to remove
    */
   private void removeBlockFromAddedBlocks(long blockId) {
-    for (List<Long> blockList : mAddedBlocks.values()) {
+    Iterator<Entry<Long, List<Long>>> iterator = mAddedBlocks.entrySet().iterator();
+    while (iterator.hasNext()) {
+      Entry<Long, List<Long>> entry = iterator.next();
+      List<Long> blockList = entry.getValue();
       if (blockList.contains(blockId)) {
         blockList.remove(blockId);
+        if (blockList.isEmpty()) {
+          iterator.remove();
+        }
+        // exit the loop when already find and remove blockId from mAddedBlocks
+        break;
       }
     }
   }

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -42,7 +42,7 @@ import tachyon.worker.block.BlockStoreLocation;
 
 /**
  * Represents a directory in a storage tier. It has a fixed capacity allocated to it on
- * instantiation. It contains the set of blocks currently in the storage directory
+ * instantiation. It contains the set of blocks currently in the storage directory.
  * <p>
  * This class does not guarantee thread safety.
  */
@@ -74,7 +74,7 @@ public class StorageDir {
   }
 
   /**
-   * Factory method to create {@link StorageDir}
+   * Factory method to create {@link StorageDir}.
    *
    * It will load meta data of existing committed blocks in the dirPath specified. Only files with
    * directory depth 1 under dirPath and whose file name can be parsed into {@code long} will be
@@ -87,6 +87,7 @@ public class StorageDir {
    * @param dirPath filesystem path of this dir for actual storage
    * @return the new created StorageDir
    * @throws AlreadyExistsException when meta data of existing committed blocks already exists
+   * @throws IOException if the storage directory cannot be created with the appropriate permissions
    * @throws OutOfSpaceException when meta data can not be added due to limited left space
    */
   public static StorageDir newStorageDir(StorageTier tier, int dirIndex, long capacityBytes,
@@ -97,7 +98,7 @@ public class StorageDir {
   }
 
   /**
-   * Initialize meta data for existing blocks in this StorageDir
+   * Initialize meta data for existing blocks in this StorageDir.
    *
    * Only paths satisfying the contract defined in {@link BlockMetaBase#commitPath} are legal,
    * should be in format like {dir}/{blockId}. other paths will be deleted.
@@ -238,7 +239,7 @@ public class StorageDir {
   }
 
   /**
-   * Gets the BlockMeta from this storage dir by its block ID or throws NotFoundException.
+   * Gets the BlockMeta from this storage dir by its block ID.
    *
    * @param blockId the block ID
    * @return BlockMeta of the given block or null
@@ -254,7 +255,7 @@ public class StorageDir {
   }
 
   /**
-   * Gets the BlockMeta from this storage dir by its block ID or throws NotFoundException.
+   * Gets the BlockMeta from this storage dir by its block ID.
    *
    * @param blockId the block ID
    * @return TempBlockMeta of the given block or null
@@ -270,7 +271,7 @@ public class StorageDir {
   }
 
   /**
-   * Adds the metadata of a new block into this storage dir or throws Exception.
+   * Adds the metadata of a new block into this storage dir.
    *
    * @param blockMeta the meta data of the block
    * @throws AlreadyExistsException if blockId already exists
@@ -293,7 +294,7 @@ public class StorageDir {
   }
 
   /**
-   * Adds the metadata of a new block into this storage dir or throws Exception.
+   * Adds the metadata of a new block into this storage dir.
    *
    * @param tempBlockMeta the meta data of a temp block to add
    * @throws AlreadyExistsException if blockId already exists
@@ -326,7 +327,7 @@ public class StorageDir {
   }
 
   /**
-   * Removes a block from this storage dir or throws Exception.
+   * Removes a block from this storage dir.
    *
    * @param blockMeta the meta data of the block
    * @throws NotFoundException if no block is found
@@ -342,7 +343,7 @@ public class StorageDir {
   }
 
   /**
-   * Removes a temp block from this storage dir or throws Exception.
+   * Removes a temp block from this storage dir.
    *
    * @param tempBlockMeta the meta data of the temp block to remove
    * @throws NotFoundException if no temp block is found
@@ -373,7 +374,7 @@ public class StorageDir {
   }
 
   /**
-   * Changes the size of a temp block or throws Exception.
+   * Changes the size of a temp block.
    *
    * @param tempBlockMeta the meta data of the temp block to resize
    * @param newSize the new size after change in bytes
@@ -409,7 +410,7 @@ public class StorageDir {
   }
 
   /**
-   * Cleans up the temp block meta data for each block id passed in
+   * Cleans up the temp block meta data for each block id passed in.
    *
    * @param userId the ID of the client associated with the temporary blocks
    * @param tempBlockIds the list of temporary blocks to clean up, non temporary blocks or

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -238,7 +238,7 @@ public class StorageDir {
   }
 
   /**
-   * Gets the BlockMeta from this storage dir by its block ID or throws IOException.
+   * Gets the BlockMeta from this storage dir by its block ID or throws NotFoundException.
    *
    * @param blockId the block ID
    * @return BlockMeta of the given block or null
@@ -254,7 +254,7 @@ public class StorageDir {
   }
 
   /**
-   * Gets the BlockMeta from this storage dir by its block ID or throws IOException.
+   * Gets the BlockMeta from this storage dir by its block ID or throws NotFoundException.
    *
    * @param blockId the block ID
    * @return TempBlockMeta of the given block or null
@@ -270,7 +270,7 @@ public class StorageDir {
   }
 
   /**
-   * Adds the metadata of a new block into this storage dir or throws IOException.
+   * Adds the metadata of a new block into this storage dir or throws Exception.
    *
    * @param blockMeta the meta data of the block
    * @throws AlreadyExistsException if blockId already exists
@@ -293,7 +293,7 @@ public class StorageDir {
   }
 
   /**
-   * Adds the metadata of a new block into this storage dir or throws IOException.
+   * Adds the metadata of a new block into this storage dir or throws Exception.
    *
    * @param tempBlockMeta the meta data of a temp block to add
    * @throws AlreadyExistsException if blockId already exists
@@ -326,7 +326,7 @@ public class StorageDir {
   }
 
   /**
-   * Removes a block from this storage dir or throws IOException.
+   * Removes a block from this storage dir or throws Exception.
    *
    * @param blockMeta the meta data of the block
    * @throws NotFoundException if no block is found
@@ -342,7 +342,7 @@ public class StorageDir {
   }
 
   /**
-   * Removes a temp block from this storage dir or throws IOException.
+   * Removes a temp block from this storage dir or throws Exception.
    *
    * @param tempBlockMeta the meta data of the temp block to remove
    * @throws NotFoundException if no temp block is found
@@ -373,7 +373,7 @@ public class StorageDir {
   }
 
   /**
-   * Changes the size of a temp block or throws IOException.
+   * Changes the size of a temp block or throws Exception.
    *
    * @param tempBlockMeta the meta data of the temp block to resize
    * @param newSize the new size after change in bytes

--- a/servers/src/test/java/tachyon/worker/block/BlockHeartbeatReporterTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockHeartbeatReporterTest.java
@@ -127,7 +127,7 @@ public class BlockHeartbeatReporterTest {
 
     // The block should not be in the added blocks list
     BlockHeartbeatReport report = mReporter.generateReport();
-    Assert.assertTrue(report.getAddedBlocks().get(MEM_LOC.getStorageDirId()).isEmpty());
+    Assert.assertEquals(null, report.getAddedBlocks().get(MEM_LOC.getStorageDirId()));
 
     // The block should be in the removed blocks list
     List<Long> removedBlocks = report.getRemovedBlocks();


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-796

Remove the map entry from `mAddedBlocks` when the block list added under corresponding dir becomes empty. 
Also, compared with the code before, exit the loop directly when already find and remove blockId from `mAddedBlocks`.
