### PR TITLE
[TACHYON-785] Move MasterClient into BlockWorker

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
@@ -53,8 +53,6 @@ public class BlockMasterSync implements Runnable {
 
   /** Block data manager responsible for interacting with Tachyon and UFS storage */
   private final BlockDataManager mBlockDataManager;
-  /** The executor service for the master client thread */
-  private final ExecutorService mMasterClientExecutorService;
   /** The net address of the worker */
   private final NetAddress mWorkerAddress;
   /** The configuration values */
@@ -76,16 +74,11 @@ public class BlockMasterSync implements Runnable {
           Executors.newFixedThreadPool(DEFAULT_BLOCK_REMOVER_POOL_SIZE);
 
   BlockMasterSync(BlockDataManager blockDataManager, TachyonConf tachyonConf,
-      NetAddress workerAddress) {
+      NetAddress workerAddress, MasterClient masterClient) {
     mBlockDataManager = blockDataManager;
     mWorkerAddress = workerAddress;
     mTachyonConf = tachyonConf;
-    mMasterClientExecutorService =
-        Executors.newFixedThreadPool(1,
-            ThreadFactoryUtils.build("worker-client-heartbeat-%d", true));
-    mMasterClient =
-        new MasterClient(NetworkAddressUtils.getMasterAddress(mTachyonConf),
-            mMasterClientExecutorService, mTachyonConf);
+    mMasterClient = masterClient;
     mHeartbeatIntervalMs =
         mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
     mHeartbeatTimeoutMs =
@@ -167,8 +160,6 @@ public class BlockMasterSync implements Runnable {
    */
   public void stop() {
     mRunning = false;
-    mMasterClient.close();
-    mMasterClientExecutorService.shutdown();
   }
 
   /**
@@ -212,13 +203,15 @@ public class BlockMasterSync implements Runnable {
   }
 
   /**
-   * Closes and creates a new master client, in case the master changes.
+   * Disconnect and reconnect the master client, in case the master changes.
    */
   private void resetMasterClient() {
-    mMasterClient.close();
-    mMasterClient =
-        new MasterClient(NetworkAddressUtils.getMasterAddress(mTachyonConf),
-            mMasterClientExecutorService, mTachyonConf);
+    mMasterClient.disconnect();
+    try {
+      mMasterClient.connect();
+    } catch (IOException e) {
+      LOG.error("Failed to connect to master.", e);
+    }
   }
 
   /**

--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -155,7 +155,7 @@ public class BlockWorker {
     mBlockMasterSync.registerWithMaster();
 
     // Setup PinListSyncer
-    mPinListSync = new PinListSync(mBlockDataManager, mTachyonConf,mMasterClient);
+    mPinListSync = new PinListSync(mBlockDataManager, mTachyonConf, mMasterClient);
 
     // Setup UserCleaner
     mUserCleanerThread = new UserCleaner(mBlockDataManager, mTachyonConf);

--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -35,6 +35,7 @@ import tachyon.Users;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.AlreadyExistsException;
 import tachyon.exception.OutOfSpaceException;
+import tachyon.master.MasterClient;
 import tachyon.metrics.MetricsSystem;
 import tachyon.thrift.NetAddress;
 import tachyon.thrift.WorkerService;
@@ -72,6 +73,10 @@ public class BlockWorker {
   private final BlockDataManager mBlockDataManager;
   /** Server for data requests and responses. */
   private final DataServer mDataServer;
+  /** Client for all master communication */
+  private final MasterClient mMasterClient;
+  /** The executor service for the master client thread */
+  private final ExecutorService mMasterClientExecutorService;
   /** Threadpool for the master sync */
   private final ExecutorService mSyncExecutorService;
   /** Net address of this worker */
@@ -98,9 +103,16 @@ public class BlockWorker {
     mTachyonConf = WorkerContext.getConf();
     mStartTimeMs = System.currentTimeMillis();
 
+    // Setup MasterClient along with its heartbeat ExecutorService
+    mMasterClientExecutorService =
+        Executors.newFixedThreadPool(1,
+            ThreadFactoryUtils.build("worker-client-heartbeat-%d", true));
+    mMasterClient = new MasterClient(NetworkAddressUtils.getMasterAddress(mTachyonConf),
+        mMasterClientExecutorService, mTachyonConf);
+
     // Set up BlockDataManager
     WorkerSource workerSource = new WorkerSource();
-    mBlockDataManager = new BlockDataManager(workerSource);
+    mBlockDataManager = new BlockDataManager(workerSource, mMasterClient);
 
     // Setup metrics collection
     mWorkerMetricsSystem = new MetricsSystem("worker", mTachyonConf);
@@ -136,11 +148,14 @@ public class BlockWorker {
     // mPinListSync and mUserCleanerThread
     mSyncExecutorService =
         Executors.newFixedThreadPool(3, ThreadFactoryUtils.build("worker-heartbeat-%d", true));
-    mBlockMasterSync = new BlockMasterSync(mBlockDataManager, mTachyonConf, mWorkerNetAddress);
+
+    mBlockMasterSync = new BlockMasterSync(mBlockDataManager, mTachyonConf, mWorkerNetAddress,
+        mMasterClient);
+    // In registerWithMaster mMasterClient tries to connect to master
     mBlockMasterSync.registerWithMaster();
 
     // Setup PinListSyncer
-    mPinListSync = new PinListSync(mBlockDataManager, mTachyonConf);
+    mPinListSync = new PinListSync(mBlockDataManager, mTachyonConf,mMasterClient);
 
     // Setup UserCleaner
     mUserCleanerThread = new UserCleaner(mBlockDataManager, mTachyonConf);
@@ -205,6 +220,8 @@ public class BlockWorker {
     mBlockMasterSync.stop();
     mPinListSync.stop();
     mUserCleanerThread.stop();
+    mMasterClient.close();
+    mMasterClientExecutorService.shutdown();
     mSyncExecutorService.shutdown();
     try {
       mWebServer.shutdownWebServer();


### PR DESCRIPTION
JIRA: https://tachyon.atlassian.net/browse/TACHYON-785

Current implementation creates three new MasterClient in BlockDataManager, BlockMasterSync, and PinListSync, which in turn creates three heartbeat threads inside MasterClient. A thread monitor on Worker can observe this behavior.

This PR moves MasterClient into BlockWorker and passes it to BlockManager, BlockMasterSync and PinListSync, avoiding redundant creation so the MasterClient heartbeat thread is limited to one.