### PR TITLE
[TACHYON-811] Trim trailing whitespace from exception message.

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -110,7 +110,7 @@ public class StorageDir {
   private void initializeMeta() throws AlreadyExistsException, IOException, OutOfSpaceException {
     // Create the storage directory path
     FileUtils.createStorageDirPath(mDirPath);
-    
+
     File dir = new File(mDirPath);
     File[] paths = dir.listFiles();
     if (paths == null) {
@@ -393,7 +393,7 @@ public class StorageDir {
 
   private void reserveSpace(long size, boolean committed) {
     Preconditions.checkState(size <= mAvailableBytes.get(),
-        "Available bytes should always be non-negative ");
+        "Available bytes should always be non-negative");
     mAvailableBytes.addAndGet(-size);
     if (committed) {
       mCommittedBytes.addAndGet(size);

--- a/servers/src/test/java/tachyon/worker/block/meta/StorageDirTest.java
+++ b/servers/src/test/java/tachyon/worker/block/meta/StorageDirTest.java
@@ -381,7 +381,7 @@ public class StorageDirTest {
     mDir.resizeTempBlockMeta(mTempBlockMeta, TEST_DIR_CAPACITY);
     Assert.assertEquals(TEST_DIR_CAPACITY, mTempBlockMeta.getBlockSize());
     mThrown.expect(IllegalStateException.class);
-    mThrown.expectMessage("Available bytes should always be non-negative ");
+    mThrown.expectMessage("Available bytes should always be non-negative");
     // resize again, now the newSize is more than available bytes, exception thrown
     mDir.resizeTempBlockMeta(mTempBlockMeta, TEST_DIR_CAPACITY + 1);
   }


### PR DESCRIPTION
Follow up to #1327 to clean up the error message.