### PR TITLE
[TACHYON-813] RemoteBlockInstream read should only cache locally

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -256,7 +256,8 @@ public class RemoteBlockInStream extends BlockInStream {
     while (bytesLeft > 0 && mAttemptReadFromWorkers && updateCurrentBuffer()) {
       int bytesToRead = Math.min(bytesLeft, mCurrentBuffer.remaining());
       mCurrentBuffer.get(b, off, bytesToRead);
-      if (mRecache) {
+      // TACHYON-813: Only cache locally
+      if (mRecache && mBlockOutStream instanceof LocalBlockOutStream) {
         mBlockOutStream.write(b, off, bytesToRead);
       }
       off += bytesToRead;
@@ -283,7 +284,8 @@ public class RemoteBlockInStream extends BlockInStream {
           LOG.error("Checkpoint stream read 0 bytes, which shouldn't ever happen");
           return len - bytesLeft;
         }
-        if (mRecache) {
+        // TACHYON-813: Only cache locally
+        if (mRecache && mBlockOutStream instanceof LocalBlockOutStream) {
           mBlockOutStream.write(b, off, readBytes);
         }
         off += readBytes;

--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -245,13 +245,13 @@ public class RemoteBlockInStream extends BlockInStream {
     if (bytesLeft > 0 && mBlockOutStream == null && mRecache) {
       try {
         mBlockOutStream = BlockOutStream.get(mFile, WriteType.TRY_CACHE, mBlockIndex, mTachyonConf);
+        // We should only cache when we are writing to a local worker
+        if (mBlockOutStream instanceof RemoteBlockOutStream) {
+          LOG.info("Cannot find a local worker to write to, recache attempt cancelled.");
+          cancelRecache();
+        }
       } catch (IOException ioe) {
         LOG.warn("Recache attempt failed.", ioe);
-        cancelRecache();
-      }
-      // TACHYON-813: Only cache locally
-      if (mBlockOutStream instanceof RemoteBlockOutStream) {
-        LOG.info("Cannot find a local worker to write to, recache attempt cancelled.");
         cancelRecache();
       }
     }

--- a/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
@@ -569,16 +569,18 @@ public class RemoteBlockInStreamIntegrationTest {
     int len = 2;
     int fileId = TachyonFSTestUtils.createByteFile(mTfs, uniqPath, WriteType.THROUGH, len);
     TachyonConf conf = mLocalTachyonCluster.getWorkerTachyonConf();
+    // Turn on localwrite so that local worker can be found
     conf.set(Constants.USER_ENABLE_LOCAL_WRITE, Boolean.toString(true));
     TachyonFS fs = TachyonFS.get(conf);
     TachyonFile file = fs.getFile(fileId);
     InStream is = file.getInStream(ReadType.CACHE);
     Assert.assertFalse(file.isInMemory());
     Assert.assertTrue(is instanceof RemoteBlockInStream);
-    for (int i = 0; i < len; ++ i) {
+    for (int i = 0; i < len; i ++) {
       Assert.assertEquals(i, is.read());
     }
     is.close();
+    // reading the whole file cause it to recache
     Assert.assertTrue(file.isInMemory());
     is = file.getInStream(ReadType.NO_CACHE);
     Assert.assertTrue(is instanceof LocalBlockInStream);
@@ -586,16 +588,19 @@ public class RemoteBlockInStreamIntegrationTest {
 
     String uniqPath2 = PathUtils.uniqPath();
     int fileId2 = TachyonFSTestUtils.createByteFile(mTfs, uniqPath2, WriteType.THROUGH, len);
+    // Turn off localwrite so that only remote worker can be found
     conf.set(Constants.USER_ENABLE_LOCAL_WRITE, Boolean.toString(false));
     TachyonFS fs2 = TachyonFS.get(conf);
     TachyonFile file2 = fs2.getFile(fileId2);
     InStream is2 = new RemoteBlockInStream(file2, ReadType.CACHE, 0, conf);
     Assert.assertFalse(file2.isInMemory());
     Assert.assertTrue(is2 instanceof RemoteBlockInStream);
-    for (int i = 0; i < len; ++ i) {
+    for (int i = 0; i < len; i ++) {
       Assert.assertEquals(i, is2.read());
     }
     is2.close();
+    // even though the whole file was read, recache was cancelled because no local worker is
+    // available
     Assert.assertFalse(file2.isInMemory());
     is2 = file2.getInStream(ReadType.NO_CACHE);
     Assert.assertTrue(is2 instanceof RemoteBlockInStream);

--- a/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
@@ -559,6 +559,49 @@ public class RemoteBlockInStreamIntegrationTest {
     is.close();
   }
 
+  /*
+   * Tests that reading a remote block with CACHE ReadType will only cache if it is writing with a
+   * local stream.
+   */
+  @Test
+  public void remoteStreamCancelsRecache() throws IOException {
+    String uniqPath = PathUtils.uniqPath();
+    int len = 2;
+    int fileId = TachyonFSTestUtils.createByteFile(mTfs, uniqPath, WriteType.THROUGH, len);
+    TachyonConf conf = mLocalTachyonCluster.getWorkerTachyonConf();
+    conf.set(Constants.USER_ENABLE_LOCAL_WRITE, Boolean.toString(true));
+    TachyonFS fs = TachyonFS.get(conf);
+    TachyonFile file = fs.getFile(fileId);
+    InStream is = file.getInStream(ReadType.CACHE);
+    Assert.assertFalse(file.isInMemory());
+    Assert.assertTrue(is instanceof RemoteBlockInStream);
+    for (int i = 0; i < len; ++ i) {
+      Assert.assertEquals(i, is.read());
+    }
+    is.close();
+    Assert.assertTrue(file.isInMemory());
+    is = file.getInStream(ReadType.NO_CACHE);
+    Assert.assertTrue(is instanceof LocalBlockInStream);
+    is.close();
+
+    String uniqPath2 = PathUtils.uniqPath();
+    int fileId2 = TachyonFSTestUtils.createByteFile(mTfs, uniqPath2, WriteType.THROUGH, len);
+    conf.set(Constants.USER_ENABLE_LOCAL_WRITE, Boolean.toString(false));
+    TachyonFS fs2 = TachyonFS.get(conf);
+    TachyonFile file2 = fs2.getFile(fileId2);
+    InStream is2 = new RemoteBlockInStream(file2, ReadType.CACHE, 0, conf);
+    Assert.assertFalse(file2.isInMemory());
+    Assert.assertTrue(is2 instanceof RemoteBlockInStream);
+    for (int i = 0; i < len; ++ i) {
+      Assert.assertEquals(i, is2.read());
+    }
+    is2.close();
+    Assert.assertFalse(file2.isInMemory());
+    is2 = file2.getInStream(ReadType.NO_CACHE);
+    Assert.assertTrue(is2 instanceof RemoteBlockInStream);
+    is2.close();
+  }
+
   /**
    * Tests that reading a file consisting of more than one block from the underfs works
    */


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-813

@gpang Is this what you have in mind? Maybe we could also check the type of mBlockOutStream upon creation at line 247 and reset it to null if it's remote?