### PR TITLE
[SMALLFIX] Increase readSkipTest's timeout

### DIFF
--- a/integration-tests/src/test/java/tachyon/hadoop/fs/DFSIOIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/fs/DFSIOIntegrationTest.java
@@ -289,7 +289,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.analyzeResult(fs, TestType.TEST_TYPE_READ_BACKWARD, execTime);
   }
 
-  @Test(timeout = 20000)
+  @Test(timeout = 25000)
   public void testReadSkip() throws Exception {
     FileSystem fs = FileSystem.get(sLocalTachyonClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();


### PR DESCRIPTION
All the other tests are at 25000 (25 seconds), but readSkipTest was at 20 seconds. This caused a failure in Jenkins: https://amplab.cs.berkeley.edu/jenkins/job/Tachyon-Master/957/PROFILE=hdfs1Test,label=centos/console