### PR TITLE
[TACHYON-798] Enable simple authentication on TachyonWorker and WorkerClient

### DIFF
--- a/common/src/main/java/tachyon/worker/WorkerClient.java
+++ b/common/src/main/java/tachyon/worker/WorkerClient.java
@@ -36,6 +36,7 @@ import tachyon.HeartbeatExecutor;
 import tachyon.HeartbeatThread;
 import tachyon.conf.TachyonConf;
 import tachyon.master.MasterClient;
+import tachyon.security.authentication.AuthenticationFactory;
 import tachyon.thrift.BlockInfoException;
 import tachyon.thrift.FailedToCheckpointException;
 import tachyon.thrift.FileAlreadyExistException;
@@ -253,7 +254,8 @@ public class WorkerClient implements Closeable {
       mWorkerDataServerAddress = new InetSocketAddress(host, workerNetAddress.mSecondaryPort);
       LOG.info("Connecting " + (mIsLocal ? "local" : "remote") + " worker @ " + mWorkerAddress);
 
-      mProtocol = new TBinaryProtocol(new TFramedTransport(new TSocket(host, port)));
+      mProtocol = new TBinaryProtocol(new AuthenticationFactory(mTachyonConf).getClientTransport(
+          new InetSocketAddress(host, port)));
       mClient = new WorkerService.Client(mProtocol);
 
       mHeartbeatExecutor =

--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -226,6 +226,9 @@ public class BlockWorker {
   /**
    * Helper method to create a {@link org.apache.thrift.server.TThreadPoolServer} for handling
    * incoming RPC requests.
+   * The transport layer used for the thrift server is decided by {@link tachyon.security
+   * .authentication.AuthenticationFactory} based on the configuration. Different transports can
+   * support different security level and authentication methods.
    *
    * @return a thrift server
    */


### PR DESCRIPTION
JIRA: https://tachyon.atlassian.net/browse/TACHYON-798

Similar as the Master, we enable simple authentication on Worker by creating proper TTransport based on conf. 

This patch currently only contains change on code, and will be updated with tests, after #1297 merged (reuse the tests in #1297 and add worker part). 
