### PR TITLE
[SMALLFIX] remove vbox/shared directory from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ deploy/vagrant/files/
 deploy/vagrant/shared/
 deploy/vagrant/vbox/.vagrant/
 deploy/vagrant/vbox/tachyon-dev.box
-deploy/vagrant/vbox/shared/
 deploy/vagrant/conf/init.yml
 deploy/vagrant/spot/roles/create_ec2/vars/
 deploy/vagrant/spot/roles/tag_ec2/vars/


### PR DESCRIPTION
vbox/shared will not be generated anymore.