### PR TITLE
[SMALLFIX] Let IndexedSet implement Iterable

### DIFF
--- a/servers/src/main/java/tachyon/master/next/IndexedSet.java
+++ b/servers/src/main/java/tachyon/master/next/IndexedSet.java
@@ -16,12 +16,12 @@
 package tachyon.master.next;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Set;
-import java.util.HashSet;
-import java.lang.reflect.Field;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +39,7 @@ import tachyon.Constants;
  *
  * This class is thread safe.
  */
-public class IndexedSet<T> {
+public class IndexedSet<T> implements Iterable<T> {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /** All objects in the set */
@@ -112,16 +112,16 @@ public class IndexedSet<T> {
   }
 
   /**
-   * Return the set of all objects, the returned set is backed up by the internal set, any changes
-   * to the internal set are reflected in the returned set, and vice-versa.
+   * Returns an iterator over the elements in this set. The elements are returned in no particular
+   * order. It is to implement {@link Iterable} so that users can foreach the IndexedSet directly.
+   * The traversal may reflect any modifications subsequent to the construction of the iterator.
    *
-   * @return a set of all objects
+   * @return an iterator over the elements in this IndexedSet
    */
-  // TODO(cc) Let this class implement Iterable to avoid this method, all use cases are to foreach
-  // this set.
-  public Set<T> all() {
+  @Override
+  public Iterator<T> iterator() {
     synchronized (mLock) {
-      return mObjects;
+      return mObjects.iterator();
     }
   }
 

--- a/servers/src/main/java/tachyon/master/next/block/BlockMaster.java
+++ b/servers/src/main/java/tachyon/master/next/block/BlockMaster.java
@@ -96,7 +96,7 @@ public class BlockMaster implements Master, ContainerIdGenerator {
   public List<WorkerInfo> getWorkerInfoList() {
     List<WorkerInfo> workerInfoList = new ArrayList<WorkerInfo>(mWorkers.size());
     synchronized (mWorkers) {
-      for (MasterWorkerInfo masterWorkerInfo : mWorkers.all()) {
+      for (MasterWorkerInfo masterWorkerInfo : mWorkers) {
         workerInfoList.add(masterWorkerInfo.generateClientWorkerInfo());
       }
     }
@@ -106,7 +106,7 @@ public class BlockMaster implements Master, ContainerIdGenerator {
   public long getCapacityBytes() {
     long ret = 0;
     synchronized (mWorkers) {
-      for (MasterWorkerInfo worker : mWorkers.all()) {
+      for (MasterWorkerInfo worker : mWorkers) {
         ret += worker.getCapacityBytes();
       }
     }
@@ -116,7 +116,7 @@ public class BlockMaster implements Master, ContainerIdGenerator {
   public long getUsedBytes() {
     long ret = 0;
     synchronized (mWorkers) {
-      for (MasterWorkerInfo worker : mWorkers.all()) {
+      for (MasterWorkerInfo worker : mWorkers) {
         ret += worker.getUsedBytes();
       }
     }

--- a/servers/src/main/java/tachyon/master/next/filesystem/meta/InodeDirectory.java
+++ b/servers/src/main/java/tachyon/master/next/filesystem/meta/InodeDirectory.java
@@ -133,7 +133,7 @@ public final class InodeDirectory extends Inode {
    * @return an unmodifiable set of the children inodes.
    */
   public synchronized Set<Inode> getChildren() {
-    return ImmutableSet.copyOf(mChildren.all());
+    return ImmutableSet.copyOf(mChildren.iterator());
   }
 
   /**
@@ -142,10 +142,9 @@ public final class InodeDirectory extends Inode {
    * @return the ids of the children
    */
   public synchronized List<Long> getChildrenIds() {
-    Set<Inode> children = mChildren.all();
-    List<Long> ret = new ArrayList<Long>(children.size());
-    for (Inode inode : children) {
-      ret.add(inode.getId());
+    List<Long> ret = new ArrayList<Long>(mChildren.size());
+    for (Inode child : mChildren) {
+      ret.add(child.getId());
     }
     return ret;
   }
@@ -182,7 +181,7 @@ public final class InodeDirectory extends Inode {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("InodeFolder(");
-    sb.append(super.toString()).append(",").append(mChildren.all()).append(")");
+    sb.append(super.toString()).append(",").append(getChildren()).append(")");
     return sb.toString();
   }
 }

--- a/servers/src/test/java/tachyon/master/next/IndexedSetTest.java
+++ b/servers/src/test/java/tachyon/master/next/IndexedSetTest.java
@@ -110,7 +110,7 @@ public class IndexedSetTest {
 
   @Test
   public void removeTest() {
-    Pair toRemove = mSet.all().iterator().next();
+    Pair toRemove = mSet.getFirstByField(mLongIndex, 1L);
     Assert.assertEquals(3, mSet.getByField(mLongIndex, toRemove.longValue()).size());
     Assert.assertEquals(9, mSet.size());
     Assert.assertTrue(mSet.remove(toRemove));


### PR DESCRIPTION
The common use case for `all()` in `IndexedSet` is to iterate over all elements, so it is an `Iterable`. 