### PR TITLE
[SMALLFIX] Fix Table of Contents for Project Docs

### DIFF
--- a/docs/js/scrollspy.js
+++ b/docs/js/scrollspy.js
@@ -55,7 +55,7 @@ if (toc !== null) { // checks to see if table of contents exists in page
                 }
             }
 
-            if (tocEl[active].children[1] !== null && tocEl[active].children[1].nodeName == "UL") {
+            if (tocEl[active].children[1] != null && tocEl[active].children[1].nodeName == "UL") {
                 // this list item has a nested list so a sublist has been entered
                 sublist = active;
                 sublistChildren = tocEl[active].children[1].childElementCount;


### PR DESCRIPTION
There was a comparator in the if statement that was using !== instead of != so undefined and null were not resulting in equal values, causing the scrollspy plugin to fail.