### PR TITLE
[TACHYON-799] Organize the classes into proper packages under tachyon security

### DIFF
--- a/common/src/main/java/tachyon/security/LoginUser.java
+++ b/common/src/main/java/tachyon/security/LoginUser.java
@@ -24,6 +24,7 @@ import javax.security.auth.login.LoginException;
 
 import tachyon.conf.TachyonConf;
 import tachyon.security.authentication.AuthenticationFactory;
+import tachyon.security.login.TachyonJaasConfiguration;
 
 /**
  * A Singleton of LoginUser, which is an instance of {@link tachyon.security.User}. It represents

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationFactory.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.security.LoginUser;
-import tachyon.security.PlainSaslHelper;
 import tachyon.util.network.NetworkAddressUtils;
 
 /**

--- a/common/src/main/java/tachyon/security/authentication/PlainSaslHelper.java
+++ b/common/src/main/java/tachyon/security/authentication/PlainSaslHelper.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.authentication;
 
 import java.io.IOException;
 import java.security.Security;
@@ -33,8 +33,6 @@ import org.apache.thrift.transport.TTransportFactory;
 
 import tachyon.conf.TachyonConf;
 import tachyon.security.authentication.AuthenticationFactory.AuthType;
-import tachyon.security.authentication.AuthenticationProvider;
-import tachyon.security.authentication.AuthenticationProviderFactory;
 
 /**
  * Because the Java SunSASL provider doesn't support the server-side PLAIN mechanism.

--- a/common/src/main/java/tachyon/security/authentication/PlainSaslServer.java
+++ b/common/src/main/java/tachyon/security/authentication/PlainSaslServer.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.authentication;
 
 import java.io.IOException;
 
@@ -27,7 +27,7 @@ import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
 
-import tachyon.security.authentication.AuthenticationProvider;
+import tachyon.security.AuthorizedClientUser;
 
 /**
  * Because the Java SunSASL provider doesn't support the server-side PLAIN mechanism.

--- a/common/src/main/java/tachyon/security/authentication/PlainSaslServerProvider.java
+++ b/common/src/main/java/tachyon/security/authentication/PlainSaslServerProvider.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.authentication;
 
 import java.security.Provider;
 import java.util.Map;

--- a/common/src/main/java/tachyon/security/login/CustomLoginModule.java
+++ b/common/src/main/java/tachyon/security/login/CustomLoginModule.java
@@ -13,22 +13,26 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.login;
 
-import java.security.Principal;
 import java.util.Map;
-import java.util.Set;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.login.LoginException;
 import javax.security.auth.spi.LoginModule;
 
+import tachyon.Constants;
+import tachyon.security.User;
+
 /**
- * A login module that search the Kerberos or OS user from Subject, and then convert to a Tachyon
- * user. It does not really authenticate the user in its login method.
+ * A custom login module that creates a user based on the user name provided through application
+ * configuration. Specifically, through Java system property tachyon.security.username.
+ * This module is useful if multiple Tachyon clients running under same OS user name
+ * want to get different identifies (for resource and data management), or if Tachyon clients
+ * running under different OS user names want to get same identify.
  */
-public class TachyonLoginModule implements LoginModule {
+public class CustomLoginModule implements LoginModule {
   private Subject mSubject;
   private User mUser;
 
@@ -39,15 +43,21 @@ public class TachyonLoginModule implements LoginModule {
   }
 
   /**
-   * Authenticate the user (first phase).
+   * Retrieve the user name by querying the property of Constants.TACHYON_SECURITY_USERNAME.
    *
-   * The implementation does not really authenticate the user here. Always return true.
-   * @return true in all cases
+   * @return true if customized user name is set and not empty.
    * @throws javax.security.auth.login.LoginException
    */
   @Override
   public boolean login() throws LoginException {
-    return true;
+    //TODO: after TachyonConf is refactored into Singleton, we will use TachyonConf
+    //instead of System.getProperty for retrieving user name.
+    String userName = System.getProperty(Constants.TACHYON_SECURITY_USERNAME, "");
+    if (!userName.isEmpty()) {
+      mUser = new User(userName);
+      return true;
+    }
+    return false;
   }
 
   /**
@@ -55,6 +65,7 @@ public class TachyonLoginModule implements LoginModule {
    *
    * This method is called if the LoginContext's overall authentication failed. (login failed)
    * It cleans up any state that was changed in the login and commit methods.
+   *
    * @return true in all cases
    * @throws LoginException
    */
@@ -68,12 +79,12 @@ public class TachyonLoginModule implements LoginModule {
   /**
    * Commit the authentication (second phase).
    *
-   * This method is called if the LoginContext's overall authentication succeeded. (login
-   * succeeded)
-   * The implementation searches the Kerberos or OS user in the Subject. If existed,
-   * convert it to a Tachyon user and add into the Subject.
-   * @return true in all cases
-   * @throws LoginException if the user extending a specific Principal is not found.
+   * This method is called if the LoginContext's overall authentication succeeded.
+   * The implementation first checks if there is already Tachyon user in the subject.
+   * If not, it adds the previously logged in Tachyon user into the subject.
+   *
+   * @return true if a Tachyon user if found or created.
+   * @throws LoginException not Tachyon user is found or created.
    */
   @Override
   public boolean commit() throws LoginException {
@@ -81,24 +92,12 @@ public class TachyonLoginModule implements LoginModule {
     if (!mSubject.getPrincipals(User.class).isEmpty()) {
       return true;
     }
-
-    Principal user = null;
-
-    // TODO: get a Kerberos user if we are using Kerberos.
-    // user = getKerberosUser();
-
-    // get a OS user
-    if (user == null) {
-      user = getPrincipalUser(TachyonJaasProperties.getOsPrincipalClassName());
-    }
-
-    // if a user is found, convert it to a Tachyon user and save it.
-    if (user != null) {
-      mUser = new User(user.getName());
+    // add the logged in user into subject
+    if (mUser != null) {
       mSubject.getPrincipals().add(mUser);
       return true;
     }
-
+    // throw exception if no Tachyon user is found or created.
     throw new LoginException("Cannot find a user");
   }
 
@@ -106,6 +105,7 @@ public class TachyonLoginModule implements LoginModule {
    * Logout the user
    *
    * The implementation removes the User associated with the Subject.
+   *
    * @return true in all cases
    * @throws LoginException if logout fails
    */
@@ -120,30 +120,5 @@ public class TachyonLoginModule implements LoginModule {
     }
 
     return true;
-  }
-
-  private Principal getPrincipalUser(String className) throws LoginException {
-    // load the principal class
-    ClassLoader loader = Thread.currentThread().getContextClassLoader();
-    if (loader == null) {
-      loader = ClassLoader.getSystemClassLoader();
-    }
-
-    Class<? extends Principal> clazz = null;
-    try {
-      clazz = (Class<? extends Principal>) loader.loadClass(className);
-    } catch (ClassNotFoundException e) {
-      throw new LoginException("Unable to find JAAS principal class:" + e.getMessage());
-    }
-
-    // find corresponding user based on the principal
-    Set<? extends Principal> userSet = mSubject.getPrincipals(clazz);
-    if (!userSet.isEmpty()) {
-      if (userSet.size() == 1) {
-        return userSet.iterator().next();
-      }
-      throw new LoginException("More than one instance of Principal " + className + " is found");
-    }
-    return null;
   }
 }

--- a/common/src/main/java/tachyon/security/login/TachyonJaasConfiguration.java
+++ b/common/src/main/java/tachyon/security/login/TachyonJaasConfiguration.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.login;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,6 +21,7 @@ import java.util.Map;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 
+import tachyon.security.User;
 import tachyon.security.authentication.AuthenticationFactory;
 
 /**
@@ -55,9 +56,9 @@ public class TachyonJaasConfiguration extends Configuration {
 
   /**
    * In SIMPLE mode, JAAS first tries to retrieve the user name set by the application with
-   * {@link tachyon.security.CustomLoginModule}. Upon failure, it use the OS specific login module
-   * to fetch the OS user, and then use the {@link tachyon.security.TachyonLoginModule} to convert
-   * it to a Tachyon user represented by {@link tachyon.security.User}.
+   * {@link tachyon.security.login.CustomLoginModule}. Upon failure, it use the OS specific login
+   * module to fetch the OS user, and then use the {@link tachyon.security.TachyonLoginModule} to
+   * convert it to a Tachyon user represented by {@link tachyon.security.User}.
    */
   private static final AppConfigurationEntry[] SIMPLE = new
       AppConfigurationEntry[]{CUSTOM_LOGIN, OS_SPECIFIC_LOGIN, TACHYON_LOGIN};

--- a/common/src/main/java/tachyon/security/login/TachyonJaasConfiguration.java
+++ b/common/src/main/java/tachyon/security/login/TachyonJaasConfiguration.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 
-import tachyon.security.User;
 import tachyon.security.authentication.AuthenticationFactory;
 
 /**

--- a/common/src/main/java/tachyon/security/login/TachyonJaasProperties.java
+++ b/common/src/main/java/tachyon/security/login/TachyonJaasProperties.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.login;
 
 import tachyon.util.PlatformUtils;
 

--- a/common/src/test/java/tachyon/security/authentication/AuthenticationFactoryTest.java
+++ b/common/src/test/java/tachyon/security/authentication/AuthenticationFactoryTest.java
@@ -34,7 +34,6 @@ import org.junit.rules.ExpectedException;
 
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
-import tachyon.security.PlainSaslHelper;
 
 /**
  * Unit test for inner class {@link tachyon.security.authentication.AuthenticationFactory

--- a/common/src/test/java/tachyon/security/authentication/PlainClientCallbackHandlerTest.java
+++ b/common/src/test/java/tachyon/security/authentication/PlainClientCallbackHandlerTest.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.authentication;
 
 import java.io.IOException;
 import javax.security.auth.callback.Callback;
@@ -27,6 +27,8 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import tachyon.security.authentication.PlainSaslHelper;
 
 public class PlainClientCallbackHandlerTest {
 

--- a/common/src/test/java/tachyon/security/authentication/PlainSaslServerProviderTest.java
+++ b/common/src/test/java/tachyon/security/authentication/PlainSaslServerProviderTest.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.authentication;
 
 import java.util.HashMap;
 
@@ -23,7 +23,8 @@ import javax.security.sasl.SaslServer;
 import org.junit.Assert;
 import org.junit.Test;
 
-import tachyon.security.PlainSaslHelper;
+import tachyon.security.authentication.PlainSaslHelper;
+import tachyon.security.authentication.PlainSaslServerProvider;
 
 public class PlainSaslServerProviderTest {
 

--- a/common/src/test/java/tachyon/security/authentication/PlainSaslServerTest.java
+++ b/common/src/test/java/tachyon/security/authentication/PlainSaslServerTest.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.authentication;
 
 import java.io.IOException;
 
@@ -28,6 +28,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import tachyon.security.authentication.PlainSaslServer;
 
 public class PlainSaslServerTest{
   private static byte sSEPARATOR = 0x00; // US-ASCII <NUL>

--- a/common/src/test/java/tachyon/security/authentication/PlainServerCallbackHandlerTest.java
+++ b/common/src/test/java/tachyon/security/authentication/PlainServerCallbackHandlerTest.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.authentication;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -32,6 +32,7 @@ import tachyon.conf.TachyonConf;
 import tachyon.security.authentication.AuthenticationFactory.AuthType;
 import tachyon.security.authentication.AuthenticationProvider;
 import tachyon.security.authentication.AuthenticationProviderFactory;
+import tachyon.security.authentication.PlainSaslServer;
 
 public class PlainServerCallbackHandlerTest {
   private TachyonConf mConf;

--- a/common/src/test/java/tachyon/security/login/LoginModuleTest.java
+++ b/common/src/test/java/tachyon/security/login/LoginModuleTest.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package tachyon.security;
+package tachyon.security.login;
 
 import java.security.Principal;
 
@@ -23,9 +23,13 @@ import javax.security.auth.login.LoginContext;
 import org.junit.Assert;
 import org.junit.Test;
 
+import tachyon.security.User;
+import tachyon.security.login.TachyonJaasConfiguration;
+import tachyon.security.login.TachyonJaasProperties;
+
 /**
- * Unit test for the login modules defined in {@link tachyon.security.TachyonLoginModule} and
- * used in {@link tachyon.security.TachyonJaasConfiguration}
+ * Unit test for the login modules defined in {@link tachyon.security.login.TachyonLoginModule} and
+ * used in {@link tachyon.security.login.TachyonJaasConfiguration}
  */
 public class LoginModuleTest {
 


### PR DESCRIPTION
Currently most of classes are under tachyon.security package. In order to organize them based on functionality, let's do below changes:
1. move PlainSaslXXX classes to tachyon.security.authentication
2. create a package tachyon.security.login and move TachyonJaasXXX or TachyonLoginXXX to it. These classes serves for login purpose.

jira: https://tachyon.atlassian.net/browse/TACHYON-799