### PR TITLE
[TACHYON-814] Defined the exception messages in an enum and refactored existing exceptions

### DIFF
--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package tachyon.conf;
 
 import java.io.IOException;

--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package tachyon.conf;
 
 import java.io.IOException;

--- a/common/src/main/java/tachyon/exception/AbstractTachyonException.java
+++ b/common/src/main/java/tachyon/exception/AbstractTachyonException.java
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package tachyon.exception;
 
 /**

--- a/common/src/main/java/tachyon/exception/AbstractTachyonException.java
+++ b/common/src/main/java/tachyon/exception/AbstractTachyonException.java
@@ -19,19 +19,19 @@ package tachyon.exception;
  * Abstract class for Tachyon exceptions.
  *
  */
+@SuppressWarnings("serial")
 public abstract class AbstractTachyonException extends Exception {
-  private static final long serialVersionUID = -5227424702682358256L;
 
   public AbstractTachyonException(String message) {
     super(message);
   }
 
-  public AbstractTachyonException(ExceptionMessage message, Object... params) {
-    this(message.getMessage(params));
-  }
-
   public AbstractTachyonException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  public AbstractTachyonException(ExceptionMessage message, Object... params) {
+    this(message.getMessage(params));
   }
 
   public AbstractTachyonException(ExceptionMessage message, Throwable cause, Object... params) {

--- a/common/src/main/java/tachyon/exception/AbstractTachyonException.java
+++ b/common/src/main/java/tachyon/exception/AbstractTachyonException.java
@@ -12,11 +12,28 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package tachyon;
+package tachyon.exception;
 
 /**
- * Error messages used in Tachyon server project.
+ * Abstract class for Tachyon exceptions.
+ *
  */
-public enum ErrorMessage {
+public abstract class AbstractTachyonException extends Exception {
+  private static final long serialVersionUID = -5227424702682358256L;
 
+  public AbstractTachyonException(String message) {
+    super(message);
+  }
+
+  public AbstractTachyonException(ExceptionMessage message, Object... params) {
+    this(message.getMessage(params));
+  }
+
+  public AbstractTachyonException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public AbstractTachyonException(ExceptionMessage message, Throwable cause, Object... params) {
+    this(message.getMessage(params), cause);
+  }
 }

--- a/common/src/main/java/tachyon/exception/AlreadyExistsException.java
+++ b/common/src/main/java/tachyon/exception/AlreadyExistsException.java
@@ -19,12 +19,22 @@ package tachyon.exception;
  * Exception used when some entity that we attempted to create (e.g., block, file, directory or
  * lock) already exists.
  */
-public class AlreadyExistsException extends Exception {
+public final class AlreadyExistsException extends AbstractTachyonException {
+  private static final long serialVersionUID = -8538037207176988241L;
+
   public AlreadyExistsException(String message) {
     super(message);
   }
 
   public AlreadyExistsException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  public AlreadyExistsException(ExceptionMessage message, Object... params) {
+    super(message, params);
+  }
+
+  public AlreadyExistsException(ExceptionMessage message, Throwable cause, Object... params) {
+    super(message, cause, params);
   }
 }

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -22,6 +22,13 @@ import java.text.MessageFormat;
 public enum ExceptionMessage {
   // general
 
+  // block manager
+  LOCK_ID_FOR_DIFFERENT_BLOCK("lockId {0} is for block {1}, not {2}"),
+  LOCK_ID_FOR_DIFFERENT_USER("lockId {0} is owned by userId {1} not {2}"),
+  LOCK_NOT_FOUND_FOR_BLOCK_AND_USER("no lock is found for blockId {0} for userId {1}"),
+  LOCK_RECORD_NOT_FOUND("lockId {0} has no lock record"),
+
+
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;
 

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -12,6 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package tachyon.exception;
 
 import java.text.MessageFormat;
@@ -32,16 +33,16 @@ public enum ExceptionMessage {
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;
 
-  private final MessageFormat message;
+  private final MessageFormat mMessage;
 
   ExceptionMessage(String message) {
-    this.message = new MessageFormat(message);
+    this.mMessage = new MessageFormat(message);
   }
 
   public String getMessage(Object... params) {
     // MessageFormat is not thread-safe, so guard it
-    synchronized (message) {
-      return this.message.format(params);
+    synchronized (mMessage) {
+      return this.mMessage.format(params);
     }
   }
 }

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -19,6 +19,8 @@ import java.text.MessageFormat;
 
 /**
  * Exception messages used across Tachyon.
+ *
+ * Note: To minimize merge conflicts, please sort alphabetically in this section.
  */
 public enum ExceptionMessage {
   // general
@@ -26,8 +28,8 @@ public enum ExceptionMessage {
   // block manager
   LOCK_ID_FOR_DIFFERENT_BLOCK("lockId {0} is for block {1}, not {2}"),
   LOCK_ID_FOR_DIFFERENT_USER("lockId {0} is owned by userId {1} not {2}"),
-  LOCK_NOT_FOUND_FOR_BLOCK_AND_USER("no lock is found for blockId {0} for userId {1}"),
-  LOCK_RECORD_NOT_FOUND("lockId {0} has no lock record"),
+  LOCK_RECORD_NOT_FOUND_FOR_BLOCK_AND_USER("no lock is found for blockId {0} for userId {1}"),
+  LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID("lockId {0} has no lock record"),
 
 
   // SEMICOLON! minimize merge conflicts by putting it on its own line

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -38,6 +38,19 @@ public enum ExceptionMessage {
   TIER_ALIAS_NOT_FOUND("Tier with alias {0} not found"),
   TIER_VIEW_ALIAS_NOT_FOUND("Tier view with alias {0} not found"),
 
+  // tieredBlockStore
+  BLOCK_ID_FOR_DIFFERENT_USER("BlockId {0} is owned by userId {1} not {2}"),
+  MOVE_UNCOMMITTED_BLOCK("Cannot move uncommitted block {0}"),
+  NO_BLOCK_ID_FOUND("BlockId {0} not found"),
+  NO_EVICTION_PLAN_TO_FREE_SPACE("No eviction plan by evictor to free space"),
+  NO_SPACE_FOR_BLOCK_ALLOCATION("Failed to allocate {0} bytes after {1} retries for blockId {2}"),
+  NO_SPACE_FOR_BLOCK_MOVE("Failed to find space in {0} to move blockId {1} after {2} retries"),
+  REMOVE_UNCOMMITTED_BLOCK("Cannot remove uncommitted block {0}"),
+  TEMP_BLOCK_ID_COMMITTED("Temp blockId {0} is not available, because it is already committed"),
+  TEMP_BLOCK_ID_EXISTS("Temp blockId {0} is not available, because it already exists"),
+
+
+
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;
 

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -12,34 +12,29 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package tachyon.exception;
 
+import java.text.MessageFormat;
+
 /**
- * Exception used when the system is not in a state required for the operation.
- *
- * For example:
- * <ul>
- * <li>userId or blockId does not correspond to that in the record of lockId</li>
- * <li>user A wants to commit a temp block owned by user B</li>
- * </ul>
+ * Exception messages used across Tachyon.
  */
-public final class InvalidStateException extends AbstractTachyonException {
-  private static final long serialVersionUID = -7966393090688326795L;
+public enum ExceptionMessage {
+  // general
 
-  public InvalidStateException(String message) {
-    super(message);
+  // SEMICOLON! minimize merge conflicts by putting it on its own line
+  ;
+
+  private final MessageFormat message;
+
+  ExceptionMessage(String message) {
+    this.message = new MessageFormat(message);
   }
 
-  public InvalidStateException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public InvalidStateException(ExceptionMessage message, Object... params) {
-    super(message, params);
-  }
-
-  public InvalidStateException(ExceptionMessage message, Throwable cause, Object... params) {
-    super(message, cause, params);
+  public String getMessage(Object... params) {
+    // MessageFormat is not thread-safe, so guard it
+    synchronized (message) {
+      return this.message.format(params);
+    }
   }
 }

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -31,11 +31,12 @@ public enum ExceptionMessage {
   LOCK_RECORD_NOT_FOUND_FOR_BLOCK_AND_USER("no lock is found for blockId {0} for userId {1}"),
   LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID("lockId {0} has no lock record"),
 
-  // block metadata manager
+  // block metadata manager and view
   BLOCK_META_NOT_FOUND("BlockMeta not found for blockId {0}"),
   GET_DIR_FROM_NON_SPECIFIC_LOCATION("Cannot get path from non-specific dir {0}"),
   TEMP_BLOCK_META_NOT_FOUND("TempBlockMeta not found for blockId {0}"),
   TIER_ALIAS_NOT_FOUND("Tier with alias {0} not found"),
+  TIER_VIEW_ALIAS_NOT_FOUND("Tier view with alias {0} not found"),
 
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -31,6 +31,11 @@ public enum ExceptionMessage {
   LOCK_RECORD_NOT_FOUND_FOR_BLOCK_AND_USER("no lock is found for blockId {0} for userId {1}"),
   LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID("lockId {0} has no lock record"),
 
+  // block metadata manager
+  BLOCK_META_NOT_FOUND("BlockMeta not found for blockId {0}"),
+  GET_DIR_FROM_NON_SPECIFIC_LOCATION("Cannot get path from non-specific dir {0}"),
+  TEMP_BLOCK_META_NOT_FOUND("TempBlockMeta not found for blockId {0}"),
+  TIER_ALIAS_NOT_FOUND("Tier with alias {0} not found"),
 
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -17,6 +17,8 @@ package tachyon.exception;
 
 import java.text.MessageFormat;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Exception messages used across Tachyon.
  *
@@ -57,13 +59,14 @@ public enum ExceptionMessage {
   private final MessageFormat mMessage;
 
   ExceptionMessage(String message) {
-    this.mMessage = new MessageFormat(message);
+    mMessage = new MessageFormat(message);
   }
 
   public String getMessage(Object... params) {
+    Preconditions.checkArgument(mMessage.getFormats().length == params.length);
     // MessageFormat is not thread-safe, so guard it
     synchronized (mMessage) {
-      return this.mMessage.format(params);
+      return mMessage.format(params);
     }
   }
 }

--- a/common/src/main/java/tachyon/exception/NotFoundException.java
+++ b/common/src/main/java/tachyon/exception/NotFoundException.java
@@ -18,12 +18,22 @@ package tachyon.exception;
 /**
  * Exception used when some requested entity (e.g., block, file, directory or lock) was not found.
  */
-public class NotFoundException extends Exception {
+public final class NotFoundException extends AbstractTachyonException {
+  private static final long serialVersionUID = 6901397458237323517L;
+
   public NotFoundException(String message) {
     super(message);
   }
 
   public NotFoundException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  public NotFoundException(ExceptionMessage message, Object... params) {
+    super(message, params);
+  }
+
+  public NotFoundException(ExceptionMessage message, Throwable cause, Object... params) {
+    super(message, cause, params);
   }
 }

--- a/common/src/main/java/tachyon/exception/OutOfSpaceException.java
+++ b/common/src/main/java/tachyon/exception/OutOfSpaceException.java
@@ -24,12 +24,22 @@ package tachyon.exception;
  * <li>evictor cannot satisfy the space to be available after eviction</li>
  * </ul>
  */
-public class OutOfSpaceException extends Exception {
+public final class OutOfSpaceException extends AbstractTachyonException {
+  private static final long serialVersionUID = -5000240143940942071L;
+
   public OutOfSpaceException(String message) {
     super(message);
   }
 
   public OutOfSpaceException(String message, Throwable cause) {
     super(message, cause);
+  }
+
+  public OutOfSpaceException(ExceptionMessage message, Object... params) {
+    super(message, params);
+  }
+
+  public OutOfSpaceException(ExceptionMessage message, Throwable cause, Object... params) {
+    super(message, cause, params);
   }
 }

--- a/servers/src/main/java/tachyon/ErrorMessage.java
+++ b/servers/src/main/java/tachyon/ErrorMessage.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package tachyon;
+
+/**
+ * Error messages used in Tachyon server project.
+ */
+public enum ErrorMessage {
+
+}

--- a/servers/src/main/java/tachyon/worker/block/BlockLockManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockLockManager.java
@@ -120,7 +120,7 @@ public final class BlockLockManager {
     synchronized (mSharedMapsLock) {
       LockRecord record = mLockIdToRecordMap.get(lockId);
       if (record == null) {
-        throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND, lockId);
+        throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID, lockId);
       }
       long userId = record.userId();
       lock = record.lock();
@@ -141,7 +141,7 @@ public final class BlockLockManager {
       for (long lockId : userLockIds) {
         LockRecord record = mLockIdToRecordMap.get(lockId);
         if (null == record) {
-          throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND, lockId);
+          throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID, lockId);
         }
         if (blockId == record.blockId()) {
           mLockIdToRecordMap.remove(lockId);
@@ -154,7 +154,7 @@ public final class BlockLockManager {
           return;
         }
       }
-      throw new NotFoundException(ExceptionMessage.LOCK_NOT_FOUND_FOR_BLOCK_AND_USER, blockId,
+      throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_BLOCK_AND_USER, blockId,
           userId);
     }
   }
@@ -174,7 +174,7 @@ public final class BlockLockManager {
     synchronized (mSharedMapsLock) {
       LockRecord record = mLockIdToRecordMap.get(lockId);
       if (null == record) {
-        throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND, lockId);
+        throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID, lockId);
       }
       if (userId != record.userId()) {
         throw new InvalidStateException(ExceptionMessage.LOCK_ID_FOR_DIFFERENT_USER, lockId,
@@ -201,7 +201,7 @@ public final class BlockLockManager {
       for (long lockId : userLockIds) {
         LockRecord record = mLockIdToRecordMap.get(lockId);
         if (null == record) {
-          LOG.error(ExceptionMessage.LOCK_RECORD_NOT_FOUND.getMessage(lockId));
+          LOG.error(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID.getMessage(lockId));
           continue;
         }
         Lock lock = record.lock();

--- a/servers/src/main/java/tachyon/worker/block/BlockLockManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockLockManager.java
@@ -30,6 +30,7 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 
 import tachyon.Constants;
+import tachyon.exception.ExceptionMessage;
 import tachyon.exception.InvalidStateException;
 import tachyon.exception.NotFoundException;
 
@@ -119,8 +120,7 @@ public final class BlockLockManager {
     synchronized (mSharedMapsLock) {
       LockRecord record = mLockIdToRecordMap.get(lockId);
       if (record == null) {
-        throw new NotFoundException(
-            "Failed to unlockBlock: lockId " + lockId + " has no lock record");
+        throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND, lockId);
       }
       long userId = record.userId();
       lock = record.lock();
@@ -141,8 +141,7 @@ public final class BlockLockManager {
       for (long lockId : userLockIds) {
         LockRecord record = mLockIdToRecordMap.get(lockId);
         if (null == record) {
-          throw new NotFoundException(
-              "Failed to unlockBlock: lockId " + lockId + " has no lock record");
+          throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND, lockId);
         }
         if (blockId == record.blockId()) {
           mLockIdToRecordMap.remove(lockId);
@@ -155,8 +154,8 @@ public final class BlockLockManager {
           return;
         }
       }
-      throw new NotFoundException("Failed to unlock blockId " + blockId + " for userId " + userId
-          + ": no lock is found for userId " + userId);
+      throw new NotFoundException(ExceptionMessage.LOCK_NOT_FOUND_FOR_BLOCK_AND_USER, blockId,
+          userId);
     }
   }
 
@@ -175,16 +174,15 @@ public final class BlockLockManager {
     synchronized (mSharedMapsLock) {
       LockRecord record = mLockIdToRecordMap.get(lockId);
       if (null == record) {
-        throw new NotFoundException(
-            "Failed to validateLock: lockId " + lockId + " has no lock record");
+        throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND, lockId);
       }
       if (userId != record.userId()) {
-        throw new InvalidStateException("Failed to validateLock: lockId " + lockId
-            + " is owned by userId " + record.userId() + ", not " + userId);
+        throw new InvalidStateException(ExceptionMessage.LOCK_ID_FOR_DIFFERENT_USER, lockId,
+            record.userId(), userId);
       }
       if (blockId != record.blockId()) {
-        throw new InvalidStateException("Failed to validateLock: lockId " + lockId
-            + " is for blockId " + record.blockId() + ", not " + blockId);
+        throw new InvalidStateException(ExceptionMessage.LOCK_ID_FOR_DIFFERENT_BLOCK, lockId,
+            record.blockId(), blockId);
       }
     }
   }
@@ -203,7 +201,7 @@ public final class BlockLockManager {
       for (long lockId : userLockIds) {
         LockRecord record = mLockIdToRecordMap.get(lockId);
         if (null == record) {
-          LOG.error("Failed to cleanup userId {}: no lock record for lockId {}", userId, lockId);
+          LOG.error(ExceptionMessage.LOCK_RECORD_NOT_FOUND.getMessage(lockId));
           continue;
         }
         Lock lock = record.lock();

--- a/servers/src/main/java/tachyon/worker/block/BlockLockManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockLockManager.java
@@ -154,8 +154,8 @@ public final class BlockLockManager {
           return;
         }
       }
-      throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_BLOCK_AND_USER, blockId,
-          userId);
+      throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_BLOCK_AND_USER,
+          blockId, userId);
     }
   }
 

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -28,6 +28,7 @@ import com.google.common.base.Preconditions;
 
 import tachyon.Constants;
 import tachyon.exception.AlreadyExistsException;
+import tachyon.exception.ExceptionMessage;
 import tachyon.exception.InvalidStateException;
 import tachyon.exception.NotFoundException;
 import tachyon.exception.OutOfSpaceException;
@@ -73,8 +74,8 @@ public class BlockMetadataManager {
     return ret;
   }
 
-  private void initBlockMetadataManager() throws AlreadyExistsException,
-      IOException, OutOfSpaceException {
+  private void initBlockMetadataManager()
+      throws AlreadyExistsException, IOException, OutOfSpaceException {
     // Initialize storage tiers
     int totalTiers = WorkerContext.getConf().getInt(Constants.WORKER_MAX_TIERED_STORAGE_LEVEL);
     mAliasToTiers = new HashMap<Integer, StorageTier>(totalTiers);
@@ -104,8 +105,8 @@ public class BlockMetadataManager {
    * @throws OutOfSpaceException when no more space left to hold the block
    * @throws AlreadyExistsException when the block already exists
    */
-  public void addTempBlockMeta(TempBlockMeta tempBlockMeta) throws OutOfSpaceException,
-      AlreadyExistsException {
+  public void addTempBlockMeta(TempBlockMeta tempBlockMeta)
+      throws OutOfSpaceException, AlreadyExistsException {
     StorageDir dir = tempBlockMeta.getParentDir();
     dir.addTempBlockMeta(tempBlockMeta);
   }
@@ -118,8 +119,8 @@ public class BlockMetadataManager {
    * @throws AlreadyExistsException when the block already exists in committed blocks
    * @throws NotFoundException when temp block can not be found
    */
-  public void commitTempBlockMeta(TempBlockMeta tempBlockMeta) throws OutOfSpaceException,
-      AlreadyExistsException, NotFoundException {
+  public void commitTempBlockMeta(TempBlockMeta tempBlockMeta)
+      throws OutOfSpaceException, AlreadyExistsException, NotFoundException {
     BlockMeta block = new BlockMeta(Preconditions.checkNotNull(tempBlockMeta));
     StorageDir dir = tempBlockMeta.getParentDir();
     dir.removeTempBlockMeta(tempBlockMeta);
@@ -188,7 +189,7 @@ public class BlockMetadataManager {
         }
       }
     }
-    throw new NotFoundException("Failed to get BlockMeta: blockId " + blockId + " not found");
+    throw new NotFoundException(ExceptionMessage.BLOCK_META_NOT_FOUND, blockId);
   }
 
   /**
@@ -224,8 +225,8 @@ public class BlockMetadataManager {
   public StorageDir getDir(BlockStoreLocation location) {
     if (location.equals(BlockStoreLocation.anyTier())
         || location.equals(BlockStoreLocation.anyDirInTier(location.tierAlias()))) {
-      throw new IllegalArgumentException("Failed to get block path: " + location
-          + " is not a specific dir.");
+      throw new IllegalArgumentException(
+          ExceptionMessage.GET_DIR_FROM_NON_SPECIFIC_LOCATION.getMessage(location));
     }
     return getTier(location.tierAlias()).getDir(location.dir());
   }
@@ -245,8 +246,7 @@ public class BlockMetadataManager {
         }
       }
     }
-    throw new NotFoundException("Failed to get TempBlockMeta: temp blockId " + blockId
-        + " not found");
+    throw new NotFoundException(ExceptionMessage.TEMP_BLOCK_META_NOT_FOUND, blockId);
   }
 
   /**
@@ -259,7 +259,8 @@ public class BlockMetadataManager {
   public StorageTier getTier(int tierAlias) {
     StorageTier tier = mAliasToTiers.get(tierAlias);
     if (tier == null) {
-      throw new IllegalArgumentException("Cannot find tier with alias " + tierAlias);
+      throw new IllegalArgumentException(
+          ExceptionMessage.TIER_ALIAS_NOT_FOUND.getMessage(tierAlias));
     }
     return tier;
   }

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -75,7 +75,7 @@ public class BlockMetadataManager {
   }
 
   private void initBlockMetadataManager()
-      throws AlreadyExistsException, IOException, OutOfSpaceException {
+    throws AlreadyExistsException, IOException, OutOfSpaceException {
     // Initialize storage tiers
     int totalTiers = WorkerContext.getConf().getInt(Constants.WORKER_MAX_TIERED_STORAGE_LEVEL);
     mAliasToTiers = new HashMap<Integer, StorageTier>(totalTiers);
@@ -106,7 +106,7 @@ public class BlockMetadataManager {
    * @throws AlreadyExistsException when the block already exists
    */
   public void addTempBlockMeta(TempBlockMeta tempBlockMeta)
-      throws OutOfSpaceException, AlreadyExistsException {
+    throws OutOfSpaceException, AlreadyExistsException {
     StorageDir dir = tempBlockMeta.getParentDir();
     dir.addTempBlockMeta(tempBlockMeta);
   }
@@ -120,7 +120,7 @@ public class BlockMetadataManager {
    * @throws NotFoundException when temp block can not be found
    */
   public void commitTempBlockMeta(TempBlockMeta tempBlockMeta)
-      throws OutOfSpaceException, AlreadyExistsException, NotFoundException {
+    throws OutOfSpaceException, AlreadyExistsException, NotFoundException {
     BlockMeta block = new BlockMeta(Preconditions.checkNotNull(tempBlockMeta));
     StorageDir dir = tempBlockMeta.getParentDir();
     dir.removeTempBlockMeta(tempBlockMeta);

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManagerView.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManagerView.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import com.google.common.base.Preconditions;
 
+import tachyon.exception.ExceptionMessage;
 import tachyon.exception.NotFoundException;
 import tachyon.master.BlockInfo;
 import tachyon.worker.block.meta.BlockMeta;
@@ -149,7 +150,8 @@ public class BlockMetadataManagerView {
   public StorageTierView getTierView(int tierAlias) {
     StorageTierView tierView = mAliasToTierViews.get(tierAlias);
     if (null == tierView) {
-      throw new IllegalArgumentException("Cannot find tier view with alias: " + tierAlias);
+      throw new IllegalArgumentException(
+          ExceptionMessage.TIER_VIEW_ALIAS_NOT_FOUND.getMessage(tierAlias));
     } else {
       return tierView;
     }

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -528,7 +528,7 @@ public final class TieredBlockStore implements BlockStore {
    */
   private TempBlockMeta createBlockMetaInternal(long userId, long blockId,
       BlockStoreLocation location, long initialBlockSize, boolean newBlock)
-          throws AlreadyExistsException {
+      throws AlreadyExistsException {
     // NOTE: a temp block is supposed to be visible for its own writer, unnecessary to acquire
     // block lock here since no sharing
     mMetadataWriteLock.lock();

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -146,8 +146,8 @@ public final class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public BlockWriter getBlockWriter(long userId, long blockId)
-      throws NotFoundException, IOException {
+  public BlockWriter getBlockWriter(long userId, long blockId) throws NotFoundException,
+      IOException {
     // NOTE: a temp block is supposed to only be visible by its own writer, unnecessary to acquire
     // block lock here since no sharing
     // TODO: handle the case where multiple writers compete for the same block
@@ -175,8 +175,8 @@ public final class TieredBlockStore implements BlockStore {
 
   @Override
   public TempBlockMeta createBlockMeta(long userId, long blockId, BlockStoreLocation location,
-      long initialBlockSize)
-          throws AlreadyExistsException, OutOfSpaceException, NotFoundException, IOException {
+      long initialBlockSize) throws AlreadyExistsException, OutOfSpaceException, NotFoundException,
+      IOException {
     for (int i = 0; i < MAX_RETRIES + 1; i ++) {
       TempBlockMeta tempBlockMeta =
           createBlockMetaInternal(userId, blockId, location, initialBlockSize, true);
@@ -208,8 +208,8 @@ public final class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public BlockMeta getBlockMeta(long userId, long blockId, long lockId)
-      throws NotFoundException, InvalidStateException {
+  public BlockMeta getBlockMeta(long userId, long blockId, long lockId) throws NotFoundException,
+      InvalidStateException {
     mLockManager.validateLock(userId, blockId, lockId);
     mMetadataReadLock.lock();
     try {
@@ -220,8 +220,8 @@ public final class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public void commitBlock(long userId, long blockId)
-      throws AlreadyExistsException, InvalidStateException, NotFoundException, IOException {
+  public void commitBlock(long userId, long blockId) throws AlreadyExistsException,
+      InvalidStateException, NotFoundException, IOException {
     BlockStoreLocation loc = commitBlockInternal(userId, blockId);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
@@ -231,8 +231,8 @@ public final class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public void abortBlock(long userId, long blockId)
-      throws AlreadyExistsException, NotFoundException, InvalidStateException, IOException {
+  public void abortBlock(long userId, long blockId) throws AlreadyExistsException,
+      NotFoundException, InvalidStateException, IOException {
     abortBlockInternal(userId, blockId);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
@@ -282,8 +282,8 @@ public final class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public void removeBlock(long userId, long blockId)
-      throws InvalidStateException, NotFoundException, IOException {
+  public void removeBlock(long userId, long blockId) throws InvalidStateException,
+      NotFoundException, IOException {
     removeBlockInternal(userId, blockId);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
@@ -405,8 +405,8 @@ public final class TieredBlockStore implements BlockStore {
    * @throws AlreadyExistsException if blockId already exists in committed blocks
    * @throws InvalidStateException if blockId is not owned by userId
    */
-  private void checkTempBlockOwnedByUser(long userId, long blockId)
-      throws NotFoundException, AlreadyExistsException, InvalidStateException {
+  private void checkTempBlockOwnedByUser(long userId, long blockId) throws NotFoundException,
+      AlreadyExistsException, InvalidStateException {
     if (mMetaManager.hasBlockMeta(blockId)) {
       throw new AlreadyExistsException(ExceptionMessage.TEMP_BLOCK_ID_COMMITTED, blockId);
     }
@@ -428,8 +428,8 @@ public final class TieredBlockStore implements BlockStore {
    * @throws InvalidStateException if blockId is not owned by userId
    * @throws IOException if I/O errors occur when deleting the block file
    */
-  private void abortBlockInternal(long userId, long blockId)
-      throws NotFoundException, AlreadyExistsException, InvalidStateException, IOException {
+  private void abortBlockInternal(long userId, long blockId) throws NotFoundException,
+      AlreadyExistsException, InvalidStateException, IOException {
     long lockId = mLockManager.lockBlock(userId, blockId, BlockLockType.WRITE);
     try {
       String path;
@@ -713,8 +713,8 @@ public final class TieredBlockStore implements BlockStore {
    * @throws IOException if I/O errors occur when moving block file
    */
   private MoveBlockResult moveBlockInternal(long userId, long blockId,
-      BlockStoreLocation newLocation)
-          throws NotFoundException, AlreadyExistsException, InvalidStateException, IOException {
+      BlockStoreLocation newLocation) throws NotFoundException, AlreadyExistsException,
+      InvalidStateException, IOException {
     long lockId = mLockManager.lockBlock(userId, blockId, BlockLockType.WRITE);
     try {
       long blockSize;
@@ -779,8 +779,8 @@ public final class TieredBlockStore implements BlockStore {
    * @throws NotFoundException if this block can not be found
    * @throws IOException if I/O errors occur when removing this block file
    */
-  private void removeBlockInternal(long userId, long blockId)
-      throws InvalidStateException, NotFoundException, IOException {
+  private void removeBlockInternal(long userId, long blockId) throws InvalidStateException,
+      NotFoundException, IOException {
     long lockId = mLockManager.lockBlock(userId, blockId, BlockLockType.WRITE);
     try {
       String filePath;

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -37,6 +37,7 @@ import tachyon.Constants;
 import tachyon.Pair;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.AlreadyExistsException;
+import tachyon.exception.ExceptionMessage;
 import tachyon.exception.InvalidStateException;
 import tachyon.exception.NotFoundException;
 import tachyon.exception.OutOfSpaceException;
@@ -65,20 +66,17 @@ import tachyon.worker.block.meta.TempBlockMeta;
  * <p>
  * This class is thread-safe, using the following lock hierarchy to ensure thread-safety:
  * <ul>
- * <li>
- * Any block-level operation (e.g., read, move or remove) on an existing block must acquire a block
- * lock for this block via {@link TieredBlockStore#mLockManager}. This block lock is a read/write
- * lock, guarding both the metadata operations and the following I/O on this block. It coordinates
- * different threads (clients) when accessing the same block concurrently.</li>
- * <li>
- * Any metadata operation (read or write) must go through {@link TieredBlockStore#mMetaManager} and
- * guarded by {@link TieredBlockStore#mMetadataLock}. This is also a read/write lock and coordinates
- * different threads (clients) when accessing the shared data structure for metadata.</li>
- * <li>
- * Method {@link #createBlockMeta} does not acquire the block lock, because it only creates a temp
- * block which is only visible to its writer before committed (thus no concurrent access).</li>
- * <li>
- * Eviction is done in {@link #freeSpaceInternal} and it is on the basis of best effort. For
+ * <li>Any block-level operation (e.g., read, move or remove) on an existing block must acquire a
+ * block lock for this block via {@link TieredBlockStore#mLockManager}. This block lock is a
+ * read/write lock, guarding both the metadata operations and the following I/O on this block. It
+ * coordinates different threads (clients) when accessing the same block concurrently.</li>
+ * <li>Any metadata operation (read or write) must go through {@link TieredBlockStore#mMetaManager}
+ * and guarded by {@link TieredBlockStore#mMetadataLock}. This is also a read/write lock and
+ * coordinates different threads (clients) when accessing the shared data structure for metadata.
+ * </li>
+ * <li>Method {@link #createBlockMeta} does not acquire the block lock, because it only creates a
+ * temp block which is only visible to its writer before committed (thus no concurrent access).</li>
+ * <li>Eviction is done in {@link #freeSpaceInternal} and it is on the basis of best effort. For
  * operations that may trigger this eviction (e.g., move, create, requestSpace), retry is used</li>
  * </ul>
  */
@@ -108,17 +106,15 @@ public final class TieredBlockStore implements BlockStore {
     mMetaManager = BlockMetadataManager.newBlockMetadataManager();
     mLockManager = new BlockLockManager();
 
-    BlockMetadataManagerView initManagerView =
-        new BlockMetadataManagerView(mMetaManager, Collections.<Integer>emptySet(),
-            Collections.<Long>emptySet());
+    BlockMetadataManagerView initManagerView = new BlockMetadataManagerView(mMetaManager,
+        Collections.<Integer>emptySet(), Collections.<Long>emptySet());
     mAllocator = Allocator.Factory.createAllocator(mTachyonConf, initManagerView);
     if (mAllocator instanceof BlockStoreEventListener) {
       registerBlockStoreEventListener((BlockStoreEventListener) mAllocator);
     }
 
-    initManagerView =
-        new BlockMetadataManagerView(mMetaManager, Collections.<Integer>emptySet(),
-            Collections.<Long>emptySet());
+    initManagerView = new BlockMetadataManagerView(mMetaManager, Collections.<Integer>emptySet(),
+        Collections.<Long>emptySet());
     mEvictor = Evictor.Factory.createEvictor(mTachyonConf, initManagerView, mAllocator);
     if (mEvictor instanceof BlockStoreEventListener) {
       registerBlockStoreEventListener((BlockStoreEventListener) mEvictor);
@@ -135,7 +131,8 @@ public final class TieredBlockStore implements BlockStore {
       return lockId;
     }
     mLockManager.unlockBlock(lockId);
-    throw new NotFoundException("Failed to lockBlock: no blockId " + blockId + " found");
+    throw new NotFoundException(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_BLOCK_AND_USER, blockId,
+        userId);
   }
 
   @Override
@@ -149,8 +146,8 @@ public final class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public BlockWriter getBlockWriter(long userId, long blockId) throws NotFoundException,
-      IOException {
+  public BlockWriter getBlockWriter(long userId, long blockId)
+      throws NotFoundException, IOException {
     // NOTE: a temp block is supposed to only be visible by its own writer, unnecessary to acquire
     // block lock here since no sharing
     // TODO: handle the case where multiple writers compete for the same block
@@ -178,8 +175,8 @@ public final class TieredBlockStore implements BlockStore {
 
   @Override
   public TempBlockMeta createBlockMeta(long userId, long blockId, BlockStoreLocation location,
-      long initialBlockSize) throws AlreadyExistsException, OutOfSpaceException, NotFoundException,
-      IOException {
+      long initialBlockSize)
+          throws AlreadyExistsException, OutOfSpaceException, NotFoundException, IOException {
     for (int i = 0; i < MAX_RETRIES + 1; i ++) {
       TempBlockMeta tempBlockMeta =
           createBlockMetaInternal(userId, blockId, location, initialBlockSize, true);
@@ -195,8 +192,8 @@ public final class TieredBlockStore implements BlockStore {
     }
     // TODO: we are probably seeing a rare transient failure, maybe define and throw some other
     // types of exception to indicate this case.
-    throw new OutOfSpaceException("Failed to create blockMeta: blockId " + blockId + " "
-        + "failed to allocate " + initialBlockSize + " bytes after " + MAX_RETRIES + " retries");
+    throw new OutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_ALLOCATION, initialBlockSize,
+        MAX_RETRIES, blockId);
   }
 
   // TODO: make this method to return a snapshot
@@ -211,8 +208,8 @@ public final class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public BlockMeta getBlockMeta(long userId, long blockId, long lockId) throws NotFoundException,
-      InvalidStateException {
+  public BlockMeta getBlockMeta(long userId, long blockId, long lockId)
+      throws NotFoundException, InvalidStateException {
     mLockManager.validateLock(userId, blockId, lockId);
     mMetadataReadLock.lock();
     try {
@@ -223,8 +220,8 @@ public final class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public void commitBlock(long userId, long blockId) throws AlreadyExistsException,
-      InvalidStateException, NotFoundException, IOException {
+  public void commitBlock(long userId, long blockId)
+      throws AlreadyExistsException, InvalidStateException, NotFoundException, IOException {
     BlockStoreLocation loc = commitBlockInternal(userId, blockId);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
@@ -234,8 +231,8 @@ public final class TieredBlockStore implements BlockStore {
   }
 
   @Override
-  public void abortBlock(long userId, long blockId) throws AlreadyExistsException,
-      NotFoundException, InvalidStateException, IOException {
+  public void abortBlock(long userId, long blockId)
+      throws AlreadyExistsException, NotFoundException, InvalidStateException, IOException {
     abortBlockInternal(userId, blockId);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
@@ -257,9 +254,8 @@ public final class TieredBlockStore implements BlockStore {
         freeSpaceInternal(userId, additionalBytes, requestResult.getSecond());
       }
     }
-    throw new OutOfSpaceException("Failed to requestSpace: blockId " + blockId
-        + " failed to allocate " + additionalBytes + " extra bytes after " + MAX_RETRIES
-        + " retries");
+    throw new OutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_ALLOCATION, additionalBytes,
+        MAX_RETRIES, blockId);
   }
 
   @Override
@@ -281,13 +277,13 @@ public final class TieredBlockStore implements BlockStore {
         freeSpaceInternal(userId, moveResult.blockSize(), newLocation);
       }
     }
-    throw new OutOfSpaceException("Failed to moveBlock: blockId " + blockId
-        + " failed to find space in " + newLocation + " after " + MAX_RETRIES + " retries");
+    throw new OutOfSpaceException(ExceptionMessage.NO_SPACE_FOR_BLOCK_MOVE, newLocation, blockId,
+        MAX_RETRIES);
   }
 
   @Override
-  public void removeBlock(long userId, long blockId) throws InvalidStateException,
-      NotFoundException, IOException {
+  public void removeBlock(long userId, long blockId)
+      throws InvalidStateException, NotFoundException, IOException {
     removeBlockInternal(userId, blockId);
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
@@ -302,7 +298,7 @@ public final class TieredBlockStore implements BlockStore {
     boolean hasBlock = mMetaManager.hasBlockMeta(blockId);
     mMetadataReadLock.unlock();
     if (!hasBlock) {
-      throw new NotFoundException("Failed to accessBlock: no blockId " + blockId + " found");
+      throw new NotFoundException(ExceptionMessage.NO_BLOCK_ID_FOUND, blockId);
     }
     synchronized (mBlockStoreEventListeners) {
       for (BlockStoreEventListener listener : mBlockStoreEventListeners) {
@@ -392,12 +388,10 @@ public final class TieredBlockStore implements BlockStore {
    */
   private void checkTempBlockIdAvailable(long blockId) throws AlreadyExistsException {
     if (mMetaManager.hasTempBlockMeta(blockId)) {
-      throw new AlreadyExistsException("checkTempBlockIdAvailable failed: blockId " + blockId
-          + " exists");
+      throw new AlreadyExistsException(ExceptionMessage.TEMP_BLOCK_ID_EXISTS, blockId);
     }
     if (mMetaManager.hasBlockMeta(blockId)) {
-      throw new AlreadyExistsException("checkTempBlockIdAvailable failed: blockId " + blockId
-          + " committed");
+      throw new AlreadyExistsException(ExceptionMessage.TEMP_BLOCK_ID_COMMITTED, blockId);
     }
   }
 
@@ -411,17 +405,16 @@ public final class TieredBlockStore implements BlockStore {
    * @throws AlreadyExistsException if blockId already exists in committed blocks
    * @throws InvalidStateException if blockId is not owned by userId
    */
-  private void checkTempBlockOwnedByUser(long userId, long blockId) throws NotFoundException,
-      AlreadyExistsException, InvalidStateException {
+  private void checkTempBlockOwnedByUser(long userId, long blockId)
+      throws NotFoundException, AlreadyExistsException, InvalidStateException {
     if (mMetaManager.hasBlockMeta(blockId)) {
-      throw new AlreadyExistsException(
-          "checkTempBlockOwnedByUser failed: blockId " + blockId + " is committed");
+      throw new AlreadyExistsException(ExceptionMessage.TEMP_BLOCK_ID_COMMITTED, blockId);
     }
     TempBlockMeta tempBlockMeta = mMetaManager.getTempBlockMeta(blockId);
     long ownerUserId = tempBlockMeta.getUserId();
     if (ownerUserId != userId) {
-      throw new InvalidStateException("checkTempBlockOwnedByUser failed: ownerUserId of blockId "
-          + blockId + " is " + ownerUserId + " but userId passed in is " + userId);
+      throw new InvalidStateException(ExceptionMessage.BLOCK_ID_FOR_DIFFERENT_USER, blockId,
+          ownerUserId, userId);
     }
   }
 
@@ -435,8 +428,8 @@ public final class TieredBlockStore implements BlockStore {
    * @throws InvalidStateException if blockId is not owned by userId
    * @throws IOException if I/O errors occur when deleting the block file
    */
-  private void abortBlockInternal(long userId, long blockId) throws NotFoundException,
-      AlreadyExistsException, InvalidStateException, IOException {
+  private void abortBlockInternal(long userId, long blockId)
+      throws NotFoundException, AlreadyExistsException, InvalidStateException, IOException {
     long lockId = mLockManager.lockBlock(userId, blockId, BlockLockType.WRITE);
     try {
       String path;
@@ -535,7 +528,7 @@ public final class TieredBlockStore implements BlockStore {
    */
   private TempBlockMeta createBlockMetaInternal(long userId, long blockId,
       BlockStoreLocation location, long initialBlockSize, boolean newBlock)
-      throws AlreadyExistsException {
+          throws AlreadyExistsException {
     // NOTE: a temp block is supposed to be visible for its own writer, unnecessary to acquire
     // block lock here since no sharing
     mMetadataWriteLock.lock();
@@ -594,8 +587,8 @@ public final class TieredBlockStore implements BlockStore {
       }
       // Increase the size of this temp block
       try {
-        mMetaManager.resizeTempBlockMeta(tempBlockMeta, tempBlockMeta.getBlockSize()
-            + additionalBytes);
+        mMetaManager.resizeTempBlockMeta(tempBlockMeta,
+            tempBlockMeta.getBlockSize() + additionalBytes);
       } catch (InvalidStateException ise) {
         throw Throwables.propagate(ise); // we shall never reach here
       }
@@ -623,7 +616,7 @@ public final class TieredBlockStore implements BlockStore {
       plan = mEvictor.freeSpaceWithView(availableBytes, location, getUpdatedView());
       // Absent plan means failed to evict enough space.
       if (null == plan) {
-        throw new OutOfSpaceException("Failed to free space: no eviction plan by evictor");
+        throw new OutOfSpaceException(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE);
       }
     } finally {
       mMetadataReadLock.unlock();
@@ -720,8 +713,8 @@ public final class TieredBlockStore implements BlockStore {
    * @throws IOException if I/O errors occur when moving block file
    */
   private MoveBlockResult moveBlockInternal(long userId, long blockId,
-      BlockStoreLocation newLocation) throws NotFoundException, AlreadyExistsException,
-      InvalidStateException, IOException {
+      BlockStoreLocation newLocation)
+          throws NotFoundException, AlreadyExistsException, InvalidStateException, IOException {
     long lockId = mLockManager.lockBlock(userId, blockId, BlockLockType.WRITE);
     try {
       long blockSize;
@@ -734,8 +727,7 @@ public final class TieredBlockStore implements BlockStore {
       mMetadataReadLock.lock();
       try {
         if (mMetaManager.hasTempBlockMeta(blockId)) {
-          throw new InvalidStateException("Failed to move block " + blockId
-              + ": block is uncommited");
+          throw new InvalidStateException(ExceptionMessage.MOVE_UNCOMMITTED_BLOCK, blockId);
         }
         srcBlockMeta = mMetaManager.getBlockMeta(blockId);
         srcLocation = srcBlockMeta.getBlockLocation();
@@ -787,8 +779,8 @@ public final class TieredBlockStore implements BlockStore {
    * @throws NotFoundException if this block can not be found
    * @throws IOException if I/O errors occur when removing this block file
    */
-  private void removeBlockInternal(long userId, long blockId) throws InvalidStateException,
-      NotFoundException, IOException {
+  private void removeBlockInternal(long userId, long blockId)
+      throws InvalidStateException, NotFoundException, IOException {
     long lockId = mLockManager.lockBlock(userId, blockId, BlockLockType.WRITE);
     try {
       String filePath;
@@ -796,8 +788,7 @@ public final class TieredBlockStore implements BlockStore {
       mMetadataReadLock.lock();
       try {
         if (mMetaManager.hasTempBlockMeta(blockId)) {
-          throw new InvalidStateException("Failed to remove block " + blockId
-              + ": block is uncommitted");
+          throw new InvalidStateException(ExceptionMessage.REMOVE_UNCOMMITTED_BLOCK, blockId);
         }
         blockMeta = mMetaManager.getBlockMeta(blockId);
         filePath = blockMeta.getPath();

--- a/servers/src/test/java/tachyon/worker/block/BlockLockManagerTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockLockManagerTest.java
@@ -23,6 +23,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
+import tachyon.exception.ExceptionMessage;
 import tachyon.exception.InvalidStateException;
 import tachyon.exception.NotFoundException;
 
@@ -55,18 +56,18 @@ public class BlockLockManagerTest {
 
   @Test
   public void unlockNonExistingLockTest() throws Exception {
-    long badBockId = 1;
+    long badLockId = 1;
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to unlockBlock: lockId " + badBockId + " has no lock record");
+    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND.getMessage(badLockId));
     // Unlock a non-existing lockId, expect to see IOException
-    mLockManager.unlockBlock(badBockId);
+    mLockManager.unlockBlock(badLockId);
   }
 
   @Test
   public void validateLockIdWithNoRecordTest() throws Exception {
     long badLockId = 1;
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to validateLock: lockId " + badLockId + " has no lock record");
+    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND.getMessage(badLockId));
     // Validate a non-existing lockId, expect to see IOException
     mLockManager.validateLock(TEST_USER_ID, TEST_BLOCK_ID, badLockId);
   }
@@ -76,8 +77,8 @@ public class BlockLockManagerTest {
     long lockId = mLockManager.lockBlock(TEST_USER_ID, TEST_BLOCK_ID, BlockLockType.READ);
     long wrongUserId = TEST_USER_ID + 1;
     mThrown.expect(InvalidStateException.class);
-    mThrown.expectMessage("Failed to validateLock: lockId " + lockId + " is owned by userId "
-        + TEST_USER_ID + ", not " + wrongUserId);
+    mThrown.expectMessage(
+        ExceptionMessage.LOCK_ID_FOR_DIFFERENT_USER.getMessage(lockId, TEST_USER_ID, wrongUserId));
     // Validate an existing lockId with wrong userId, expect to see IOException
     mLockManager.validateLock(wrongUserId, TEST_BLOCK_ID, lockId);
   }
@@ -87,8 +88,8 @@ public class BlockLockManagerTest {
     long lockId = mLockManager.lockBlock(TEST_USER_ID, TEST_BLOCK_ID, BlockLockType.READ);
     long wrongBlockId = TEST_BLOCK_ID + 1;
     mThrown.expect(InvalidStateException.class);
-    mThrown.expectMessage("Failed to validateLock: lockId " + lockId + " is for blockId "
-        + TEST_BLOCK_ID + ", not " + wrongBlockId);
+    mThrown.expectMessage(ExceptionMessage.LOCK_ID_FOR_DIFFERENT_BLOCK.getMessage(lockId,
+        TEST_BLOCK_ID, wrongBlockId));
     // Validate an existing lockId with wrong blockId, expect to see IOException
     mLockManager.validateLock(TEST_USER_ID, wrongBlockId, lockId);
   }
@@ -100,7 +101,7 @@ public class BlockLockManagerTest {
     long lockId1 = mLockManager.lockBlock(userId1, TEST_BLOCK_ID, BlockLockType.READ);
     long lockId2 = mLockManager.lockBlock(userId2, TEST_BLOCK_ID, BlockLockType.READ);
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to validateLock: lockId " + lockId2 + " has no lock record");
+    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND.getMessage(lockId2));
     mLockManager.cleanupUser(userId2);
     // Expect validating userId1 to get through
     mLockManager.validateLock(userId1, TEST_BLOCK_ID, lockId1);

--- a/servers/src/test/java/tachyon/worker/block/BlockLockManagerTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockLockManagerTest.java
@@ -58,7 +58,7 @@ public class BlockLockManagerTest {
   public void unlockNonExistingLockTest() throws Exception {
     long badLockId = 1;
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND.getMessage(badLockId));
+    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID.getMessage(badLockId));
     // Unlock a non-existing lockId, expect to see IOException
     mLockManager.unlockBlock(badLockId);
   }
@@ -67,7 +67,7 @@ public class BlockLockManagerTest {
   public void validateLockIdWithNoRecordTest() throws Exception {
     long badLockId = 1;
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND.getMessage(badLockId));
+    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID.getMessage(badLockId));
     // Validate a non-existing lockId, expect to see IOException
     mLockManager.validateLock(TEST_USER_ID, TEST_BLOCK_ID, badLockId);
   }
@@ -101,7 +101,7 @@ public class BlockLockManagerTest {
     long lockId1 = mLockManager.lockBlock(userId1, TEST_BLOCK_ID, BlockLockType.READ);
     long lockId2 = mLockManager.lockBlock(userId2, TEST_BLOCK_ID, BlockLockType.READ);
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND.getMessage(lockId2));
+    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID.getMessage(lockId2));
     mLockManager.cleanupUser(userId2);
     // Expect validating userId1 to get through
     mLockManager.validateLock(userId1, TEST_BLOCK_ID, lockId1);

--- a/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerTest.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Sets;
 
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
+import tachyon.exception.ExceptionMessage;
 import tachyon.exception.NotFoundException;
 import tachyon.exception.OutOfSpaceException;
 import tachyon.worker.WorkerContext;
@@ -40,7 +41,7 @@ import tachyon.worker.block.meta.StorageTier;
 import tachyon.worker.block.meta.TempBlockMeta;
 
 // TODO: improve code health of this unittest.
-public class BlockMetadataManagerTest {
+public final class BlockMetadataManagerTest {
   private static final long TEST_USER_ID = 2;
   private static final long TEST_BLOCK_ID = 9;
   private static final long TEST_TEMP_BLOCK_ID = 10;
@@ -106,7 +107,7 @@ public class BlockMetadataManagerTest {
   public void getTierNotExistingTest() throws Exception {
     int badTierAlias = 2;
     mThrown.expect(IllegalArgumentException.class);
-    mThrown.expectMessage("Cannot find tier with alias " + badTierAlias);
+    mThrown.expectMessage(ExceptionMessage.TIER_ALIAS_NOT_FOUND.getMessage(badTierAlias));
     mMetaManager.getTier(badTierAlias);
   }
 
@@ -180,15 +181,15 @@ public class BlockMetadataManagerTest {
   @Test
   public void getBlockMetaNotExistingTest() throws Exception {
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to get BlockMeta: blockId " + TEST_BLOCK_ID + " not found");
+    mThrown.expectMessage(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(TEST_BLOCK_ID));
     mMetaManager.getBlockMeta(TEST_BLOCK_ID);
   }
 
   @Test
   public void getTempBlockMetaNotExistingTest() throws Exception {
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to get TempBlockMeta: temp blockId " + TEST_TEMP_BLOCK_ID
-        + " not found");
+    mThrown
+        .expectMessage(ExceptionMessage.TEMP_BLOCK_META_NOT_FOUND.getMessage(TEST_TEMP_BLOCK_ID));
     mMetaManager.getTempBlockMeta(TEST_TEMP_BLOCK_ID);
   }
 

--- a/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerViewTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockMetadataManagerViewTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mockito;
 
 import com.google.common.collect.Sets;
 
+import tachyon.exception.ExceptionMessage;
 import tachyon.exception.NotFoundException;
 import tachyon.master.BlockInfo;
 import tachyon.worker.block.meta.BlockMeta;
@@ -36,7 +37,7 @@ import tachyon.worker.block.meta.StorageDirView;
 import tachyon.worker.block.meta.StorageTier;
 import tachyon.worker.block.meta.StorageTierView;
 
-public class BlockMetadataManagerViewTest {
+public final class BlockMetadataManagerViewTest {
   private static final int TEST_TIER_LEVEL = 0;
   private static final int TEST_DIR = 0;
   private static final long TEST_BLOCK_ID = 9;
@@ -54,11 +55,9 @@ public class BlockMetadataManagerViewTest {
   @Before
   public void before() throws Exception {
     File tempFolder = mTestFolder.newFolder();
-    mMetaManager =
-        TieredBlockStoreTestUtils.defaultMetadataManager(tempFolder.getAbsolutePath());
-    mMetaManagerView =
-        Mockito.spy(new BlockMetadataManagerView(mMetaManager, Sets.<Integer>newHashSet(),
-            Sets.<Long>newHashSet()));
+    mMetaManager = TieredBlockStoreTestUtils.defaultMetadataManager(tempFolder.getAbsolutePath());
+    mMetaManagerView = Mockito.spy(new BlockMetadataManagerView(mMetaManager,
+        Sets.<Integer>newHashSet(), Sets.<Long>newHashSet()));
   }
 
   @Test
@@ -110,8 +109,17 @@ public class BlockMetadataManagerViewTest {
   @Test
   public void getBlockMetaNotExistingTest() throws NotFoundException {
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to get BlockMeta: blockId " + TEST_BLOCK_ID + " not found");
+    mThrown.expectMessage(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(TEST_BLOCK_ID));
     mMetaManagerView.getBlockMeta(TEST_BLOCK_ID);
+  }
+
+
+  @Test
+  public void getTierNotExistingTest() throws Exception {
+    int badTierAlias = 3;
+    mThrown.expect(IllegalArgumentException.class);
+    mThrown.expectMessage(ExceptionMessage.TIER_VIEW_ALIAS_NOT_FOUND.getMessage(badTierAlias));
+    mMetaManagerView.getTierView(badTierAlias);
   }
 
   @Test
@@ -152,8 +160,8 @@ public class BlockMetadataManagerViewTest {
     Assert.assertFalse(mMetaManagerView.isBlockPinned(TEST_BLOCK_ID));
 
     // Pin block by passing its inode to mMetaManagerView
-    mMetaManagerView = new BlockMetadataManagerView(mMetaManager, Sets.newHashSet(inode),
-            Sets.<Long>newHashSet());
+    mMetaManagerView =
+        new BlockMetadataManagerView(mMetaManager, Sets.newHashSet(inode), Sets.<Long>newHashSet());
     Assert.assertFalse(mMetaManagerView.isBlockLocked(TEST_BLOCK_ID));
     Assert.assertTrue(mMetaManagerView.isBlockPinned(TEST_BLOCK_ID));
 
@@ -205,8 +213,8 @@ public class BlockMetadataManagerViewTest {
     BlockMeta blockMeta = new BlockMeta(TEST_BLOCK_ID, TEST_BLOCK_SIZE, dir);
     dir.addBlockMeta(blockMeta);
 
-    StorageTierView tierView2 = new StorageTierView(mMetaManager.getTier(tierAlias),
-        mMetaManagerView);
+    StorageTierView tierView2 =
+        new StorageTierView(mMetaManager.getTier(tierAlias), mMetaManagerView);
     assertSameTierView(tierView1, tierView2);
   }
 

--- a/servers/src/test/java/tachyon/worker/block/TieredBlockStoreTests.java
+++ b/servers/src/test/java/tachyon/worker/block/TieredBlockStoreTests.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Sets;
 import tachyon.StorageLevelAlias;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.AlreadyExistsException;
+import tachyon.exception.ExceptionMessage;
 import tachyon.exception.InvalidStateException;
 import tachyon.exception.NotFoundException;
 import tachyon.exception.OutOfSpaceException;
@@ -129,7 +130,8 @@ public final class TieredBlockStoreTests {
   @Test
   public void lockNonExistingBlockTest() throws Exception {
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to lockBlock: no blockId " + BLOCK_ID1 + " found");
+    mThrown.expectMessage(
+        ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_BLOCK_AND_USER.getMessage(BLOCK_ID1, USER_ID1));
 
     mBlockStore.lockBlock(USER_ID1, BLOCK_ID1);
   }
@@ -138,7 +140,7 @@ public final class TieredBlockStoreTests {
   public void unlockNonExistingLockTest() throws Exception {
     long badLockId = 1003;
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to unlockBlock: lockId " + badLockId + " has no lock record");
+    mThrown.expectMessage(ExceptionMessage.LOCK_RECORD_NOT_FOUND_FOR_LOCK_ID.getMessage(badLockId));
 
     mBlockStore.unlockBlock(badLockId);
   }
@@ -240,7 +242,7 @@ public final class TieredBlockStoreTests {
 
     // Expect an exception because no eviction plan is feasible
     mThrown.expect(OutOfSpaceException.class);
-    mThrown.expectMessage("Failed to free space: no eviction plan by evictor");
+    mThrown.expectMessage(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage());
     mBlockStore.createBlockMeta(USER_ID1, TEMP_BLOCK_ID, mTestDir1.toBlockStoreLocation(),
         mTestDir1.getCapacityBytes());
 
@@ -267,7 +269,7 @@ public final class TieredBlockStoreTests {
 
     // Expect an exception because no eviction plan is feasible
     mThrown.expect(OutOfSpaceException.class);
-    mThrown.expectMessage("Failed to free space: no eviction plan by evictor");
+    mThrown.expectMessage(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage());
     mBlockStore.moveBlock(USER_ID1, BLOCK_ID1, mTestDir2.toBlockStoreLocation());
 
     // Expect createBlockMeta to succeed after unlocking this block.
@@ -290,7 +292,7 @@ public final class TieredBlockStoreTests {
 
     // Expect an exception as no eviction plan is feasible
     mThrown.expect(OutOfSpaceException.class);
-    mThrown.expectMessage("Failed to free space: no eviction plan by evictor");
+    mThrown.expectMessage(ExceptionMessage.NO_EVICTION_PLAN_TO_FREE_SPACE.getMessage());
     mBlockStore.freeSpace(USER_ID1, mTestDir1.getCapacityBytes(), mTestDir1.toBlockStoreLocation());
 
     // Expect freeSpace to succeed after unlock this block.
@@ -302,7 +304,7 @@ public final class TieredBlockStoreTests {
   @Test
   public void getBlockWriterForNonExistingBlockTest() throws Exception {
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to get TempBlockMeta: temp blockId " + BLOCK_ID1 + " not found");
+    mThrown.expectMessage(ExceptionMessage.TEMP_BLOCK_META_NOT_FOUND.getMessage(BLOCK_ID1));
 
     mBlockStore.getBlockWriter(USER_ID1, BLOCK_ID1);
   }
@@ -310,7 +312,7 @@ public final class TieredBlockStoreTests {
   @Test
   public void abortNonExistingBlockTest() throws Exception {
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to get TempBlockMeta: temp blockId " + BLOCK_ID1 + " not found");
+    mThrown.expectMessage(ExceptionMessage.TEMP_BLOCK_META_NOT_FOUND.getMessage(BLOCK_ID1));
 
     mBlockStore.abortBlock(USER_ID1, BLOCK_ID1);
   }
@@ -318,8 +320,8 @@ public final class TieredBlockStoreTests {
   @Test
   public void abortBlockNotOwnedByUserIdTest() throws Exception {
     mThrown.expect(InvalidStateException.class);
-    mThrown.expectMessage("checkTempBlockOwnedByUser failed: ownerUserId of blockId "
-        + TEMP_BLOCK_ID + " is " + USER_ID1 + " but userId passed in is " + USER_ID2);
+    mThrown.expectMessage(
+        ExceptionMessage.BLOCK_ID_FOR_DIFFERENT_USER.getMessage(TEMP_BLOCK_ID, USER_ID1, USER_ID2));
 
     TieredBlockStoreTestUtils.createTempBlock(USER_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
     mBlockStore.abortBlock(USER_ID2, TEMP_BLOCK_ID);
@@ -328,8 +330,7 @@ public final class TieredBlockStoreTests {
   @Test
   public void abortCommitedBlockTest() throws Exception {
     mThrown.expect(AlreadyExistsException.class);
-    mThrown.expectMessage(
-        "checkTempBlockOwnedByUser failed: blockId " + TEMP_BLOCK_ID + " is committed");
+    mThrown.expectMessage(ExceptionMessage.TEMP_BLOCK_ID_COMMITTED.getMessage(TEMP_BLOCK_ID));
 
     TieredBlockStoreTestUtils.createTempBlock(USER_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
     mBlockStore.commitBlock(USER_ID1, TEMP_BLOCK_ID);
@@ -339,8 +340,7 @@ public final class TieredBlockStoreTests {
   @Test
   public void commitBlockTwiceTest() throws Exception {
     mThrown.expect(AlreadyExistsException.class);
-    mThrown.expectMessage(
-        "checkTempBlockOwnedByUser failed: blockId " + TEMP_BLOCK_ID + " is committed");
+    mThrown.expectMessage(ExceptionMessage.TEMP_BLOCK_ID_COMMITTED.getMessage(TEMP_BLOCK_ID));
 
     TieredBlockStoreTestUtils.createTempBlock(USER_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
     mBlockStore.commitBlock(USER_ID1, TEMP_BLOCK_ID);
@@ -350,7 +350,7 @@ public final class TieredBlockStoreTests {
   @Test
   public void commitNonExistingBlockTest() throws Exception {
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to get TempBlockMeta: temp blockId " + BLOCK_ID1 + " not found");
+    mThrown.expectMessage(ExceptionMessage.TEMP_BLOCK_META_NOT_FOUND.getMessage(BLOCK_ID1));
 
     mBlockStore.commitBlock(USER_ID1, BLOCK_ID1);
   }
@@ -358,8 +358,8 @@ public final class TieredBlockStoreTests {
   @Test
   public void commitBlockNotOwnedByUserIdTest() throws Exception {
     mThrown.expect(InvalidStateException.class);
-    mThrown.expectMessage("checkTempBlockOwnedByUser failed: ownerUserId of blockId "
-        + TEMP_BLOCK_ID + " is " + USER_ID1 + " but userId passed in is " + USER_ID2);
+    mThrown.expectMessage(
+        ExceptionMessage.BLOCK_ID_FOR_DIFFERENT_USER.getMessage(TEMP_BLOCK_ID, USER_ID1, USER_ID2));
 
     TieredBlockStoreTestUtils.createTempBlock(USER_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
     mBlockStore.commitBlock(USER_ID2, TEMP_BLOCK_ID);
@@ -368,7 +368,7 @@ public final class TieredBlockStoreTests {
   @Test
   public void removeTempBlockTest() throws Exception {
     mThrown.expect(InvalidStateException.class);
-    mThrown.expectMessage("Failed to remove block " + TEMP_BLOCK_ID + ": block is uncommitted");
+    mThrown.expectMessage(ExceptionMessage.REMOVE_UNCOMMITTED_BLOCK.getMessage(TEMP_BLOCK_ID));
 
     TieredBlockStoreTestUtils.createTempBlock(USER_ID1, TEMP_BLOCK_ID, BLOCK_SIZE, mTestDir1);
     mBlockStore.removeBlock(USER_ID1, TEMP_BLOCK_ID);
@@ -377,7 +377,7 @@ public final class TieredBlockStoreTests {
   @Test
   public void removeNonExistingBlockTest() throws Exception {
     mThrown.expect(NotFoundException.class);
-    mThrown.expectMessage("Failed to get BlockMeta: blockId " + BLOCK_ID1 + " not found");
+    mThrown.expectMessage(ExceptionMessage.BLOCK_META_NOT_FOUND.getMessage(BLOCK_ID1));
 
     mBlockStore.removeBlock(USER_ID1, BLOCK_ID1);
   }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-814

Other than describing exception message as plain strings in an adhoc way, it's better to aggregate them into a central place. The benefits include at least (1) writing unit tests (2) internationalization (3) refactoring, etc.