### PR TITLE
[TACHYON-838] Update getSimpleLoginUserTest in LoginUserTest

### DIFF
--- a/common/src/test/java/tachyon/security/LoginUserTest.java
+++ b/common/src/test/java/tachyon/security/LoginUserTest.java
@@ -54,7 +54,7 @@ public class LoginUserTest {
     User loginUser = LoginUser.get(conf);
 
     Assert.assertNotNull(loginUser);
-    Assert.assertFalse(loginUser.getName().isEmpty());
+    Assert.assertEquals(loginUser.getName(), System.getProperty("user.name"));
   }
 
   // TODO: getKerberosLoginUserTest()


### PR DESCRIPTION
JIRA: [TACHYON-838](https://tachyon.atlassian.net/browse/TACHYON-838)

In #1292 (TACHYON-786), in the test the login user name is verified equality instead of just being checked not null. As discussed there, this Jira is a follow-up to update the original test getSimpleLoginUserTest like that.