### PR TITLE
[TACHYON-880] Adding unit tests for tachyon.util.io.BufferUtils.

### DIFF
--- a/common/src/main/java/tachyon/util/io/BufferUtils.java
+++ b/common/src/main/java/tachyon/util/io/BufferUtils.java
@@ -231,7 +231,7 @@ public class BufferUtils {
       return false;
     }
     buf.rewind();
-    if (buf.remaining() != len) {
+    if (buf.remaining() < len) {
       return false;
     }
     for (int k = 0; k < len; k ++) {
@@ -249,9 +249,20 @@ public class BufferUtils {
    * @return ByteBuffer containing an increasing sequence of integers
    */
   public static ByteBuffer getIncreasingIntBuffer(int len) {
+    return getIncreasingIntBuffer(0, len);
+  }
+
+  /**
+   * Get a ByteBuffer containing an increasing sequence of integers starting at the given value.
+   *
+   * @param start the starting value to use
+   * @param len the target length of the sequence
+   * @return ByteBuffer containing an increasing sequence of integers
+   */
+  public static ByteBuffer getIncreasingIntBuffer(int start, int len) {
     ByteBuffer ret = ByteBuffer.allocate(len * 4);
     for (int k = 0; k < len; k ++) {
-      ret.putInt(k);
+      ret.putInt(start + k);
     }
     ret.flip();
     return ret;

--- a/common/src/main/java/tachyon/util/io/BufferUtils.java
+++ b/common/src/main/java/tachyon/util/io/BufferUtils.java
@@ -184,7 +184,7 @@ public class BufferUtils {
    *         sequence of bytes starting at <code>start</code>
    */
   public static boolean equalIncreasingByteArray(int start, int len, byte[] arr) {
-    if (arr == null || arr.length < len) {
+    if (arr == null || arr.length != len) {
       return false;
     }
     for (int k = 0; k < len; k ++) {
@@ -231,7 +231,7 @@ public class BufferUtils {
       return false;
     }
     buf.rewind();
-    if (buf.remaining() < len) {
+    if (buf.remaining() != len) {
       return false;
     }
     for (int k = 0; k < len; k ++) {

--- a/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
+++ b/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -33,7 +34,7 @@ public class BufferUtilsTest {
       buf.put(i);
     }
     bufClone = BufferUtils.cloneByteBuffer(buf);
-    Assert.assertTrue(bufClone.equals(buf));
+    Assert.assertEquals(buf, bufClone);
   }
 
   @Test
@@ -48,11 +49,10 @@ public class BufferUtilsTest {
       }
       bufList.add(buf);
     }
-    java.util.List<ByteBuffer> bufListClone = BufferUtils.cloneByteBufferList(bufList);
+    List<ByteBuffer> bufListClone = BufferUtils.cloneByteBufferList(bufList);
     Assert.assertTrue(bufListClone.size() == listLength);
-    int k = 0;
-    for (ByteBuffer bufClone : bufListClone) {
-      Assert.assertTrue(bufClone.equals(bufList.get(k ++)));
+    for (int k = 0 ; k < listLength; k ++) {
+      Assert.assertEquals(bufList.get(k), bufListClone.get(k));
     }
   }
 
@@ -65,7 +65,7 @@ public class BufferUtilsTest {
       bufDirect.put(i);
     }
     bufClone = BufferUtils.cloneByteBuffer(bufDirect);
-    Assert.assertTrue(bufClone.equals(bufDirect));
+    Assert.assertEquals(bufDirect, bufClone);
   }
 
   @Test
@@ -80,11 +80,10 @@ public class BufferUtilsTest {
       }
       bufDirectList.add(bufDirect);
     }
-    java.util.List<ByteBuffer> bufListClone = BufferUtils.cloneByteBufferList(bufDirectList);
+    List<ByteBuffer> bufListClone = BufferUtils.cloneByteBufferList(bufDirectList);
     Assert.assertTrue(bufListClone.size() == listLength);
-    int k = 0;
-    for (ByteBuffer bufClone : bufListClone) {
-      Assert.assertTrue(bufClone.equals(bufDirectList.get(k ++)));
+    for (int k = 0 ; k < listLength; k ++) {
+      Assert.assertEquals(bufDirectList.get(k), bufListClone.get(k));
     }
   }
 

--- a/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
+++ b/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
@@ -15,7 +15,10 @@
 
 package tachyon.util.io;
 
+import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.LinkedList;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,6 +37,26 @@ public class BufferUtilsTest {
   }
 
   @Test
+  public void cloneByteBufferListTest() {
+    final int bufferSize = 10;
+    final int listLength = 10;
+    ArrayList<ByteBuffer> bufList = new ArrayList<ByteBuffer>(listLength);
+    for (int k = 0; k < listLength; k ++) {
+      ByteBuffer buf = ByteBuffer.allocate(bufferSize);
+      for (byte i = 0; i < bufferSize; i ++) {
+        buf.put((byte) (i + k));
+      }
+      bufList.add(buf);
+    }
+    java.util.List<ByteBuffer> bufListClone = BufferUtils.cloneByteBufferList(bufList);
+    Assert.assertTrue(bufListClone.size() == listLength);
+    int k = 0;
+    for (ByteBuffer bufClone : bufListClone) {
+      Assert.assertTrue(bufClone.equals(bufList.get(k ++)));
+    }
+  }
+
+  @Test
   public void cloneDirectByteBufferTest() {
     final int bufferSize = 10;
     ByteBuffer bufDirect = ByteBuffer.allocateDirect(bufferSize);
@@ -45,12 +68,249 @@ public class BufferUtilsTest {
     Assert.assertTrue(bufClone.equals(bufDirect));
   }
 
+  @Test
+  public void cloneDirectByteBufferListTest() {
+    final int bufferSize = 10;
+    final int listLength = 10;
+    ArrayList<ByteBuffer> bufDirectList = new ArrayList<ByteBuffer>(listLength);
+    for (int k = 0; k < listLength; k ++) {
+      ByteBuffer bufDirect = ByteBuffer.allocateDirect(bufferSize);
+      for (byte i = 0; i < bufferSize; i ++) {
+        bufDirect.put((byte) (i + k));
+      }
+      bufDirectList.add(bufDirect);
+    }
+    java.util.List<ByteBuffer> bufListClone = BufferUtils.cloneByteBufferList(bufDirectList);
+    Assert.assertTrue(bufListClone.size() == listLength);
+    int k = 0;
+    for (ByteBuffer bufClone : bufListClone) {
+      Assert.assertTrue(bufClone.equals(bufDirectList.get(k ++)));
+    }
+  }
+
+  @Test
+  public void generateNewByteBufferFromThriftRPCResultsTest() {
+    final int bufferSize = 10;
+    ByteBuffer mockRPCbuf = ByteBuffer.allocate(bufferSize);
+    for (byte i = 0; i < bufferSize; i ++) {
+      mockRPCbuf.put(i);
+    }
+    mockRPCbuf.position(bufferSize / 2);
+    ByteBuffer buf = BufferUtils.generateNewByteBufferFromThriftRPCResults(mockRPCbuf);
+    Assert.assertTrue(buf.position() == 0);
+    Assert.assertTrue(buf.capacity() == bufferSize / 2);
+    for (int i = 0; i < bufferSize / 2; i ++) {
+      Assert.assertEquals(mockRPCbuf.get(i + bufferSize / 2), buf.get(i));
+    }
+  }
+
+  @Test
+  public void putIntByteBufferTest() {
+    class TestCase {
+      byte mExpected;
+      int mInput;
+
+      public TestCase(byte expected, int input) {
+        mExpected = expected;
+        mInput = input;
+      }
+    }
+
+    LinkedList<TestCase> testCases = new LinkedList<TestCase>();
+    testCases.add(new TestCase((byte) 0x00, 0x00));
+    testCases.add(new TestCase((byte) 0x12, 0x12));
+    testCases.add(new TestCase((byte) 0x34, 0x1234));
+    testCases.add(new TestCase((byte) 0x56, 0x123456));
+    testCases.add(new TestCase((byte) 0x78, 0x12345678));
+
+    for (TestCase testCase : testCases) {
+      ByteBuffer buf = ByteBuffer.allocate(1);
+      BufferUtils.putIntByteBuffer(buf, testCase.mInput);
+      Assert.assertEquals(testCase.mExpected, buf.get(0));
+    }
+  }
+
+  @Test
+  public void getIncreasingByteArrayTest() {
+    class TestCase {
+      byte[] mExpected;
+      int mLength;
+      int mStart;
+
+      public TestCase(byte[] expected, int length, int start) {
+        mExpected = expected;
+        mLength = length;
+        mStart = start;
+      }
+    }
+
+    LinkedList<TestCase> testCases = new LinkedList<TestCase>();
+    testCases.add(new TestCase(new byte[] {}, 0, 0));
+    testCases.add(new TestCase(new byte[] {}, 0, 3));
+    testCases.add(new TestCase(new byte[] {0}, 1, 0));
+    testCases.add(new TestCase(new byte[] {0, 1, 2}, 3, 0));
+    testCases.add(new TestCase(new byte[] {3}, 1, 3));
+    testCases.add(new TestCase(new byte[] {3, 4, 5}, 3, 3));
+
+    for (TestCase testCase : testCases) {
+      byte[] result = BufferUtils.getIncreasingByteArray(testCase.mStart, testCase.mLength);
+      Assert.assertEquals(testCase.mExpected.length, result.length);
+      for (int k = 0; k < result.length; k ++) {
+        Assert.assertEquals(testCase.mExpected[k], result[k]);
+      }
+    }
+  }
+
+  @Test
+  public void equalIncreasingByteArrayTest() {
+    class TestCase {
+      boolean mExpected;
+      byte[] mArray;
+      int mLength;
+      int mStart;
+
+      public TestCase(boolean expected, byte[] array, int length, int start) {
+        mExpected = expected;
+        mArray = array;
+        mLength = length;
+        mStart = start;
+      }
+    }
+
+    LinkedList<TestCase> testCases = new LinkedList<TestCase>();
+    testCases.add(new TestCase(false, null, 0, 0));
+    testCases.add(new TestCase(true, new byte[] {}, 0, 0));
+    testCases.add(new TestCase(true, new byte[] {1}, 0, 0));
+    testCases.add(new TestCase(true, new byte[] {}, 0, 3));
+    testCases.add(new TestCase(true, new byte[] {1}, 0, 3));
+    testCases.add(new TestCase(true, new byte[] {0}, 1, 0));
+    testCases.add(new TestCase(false, new byte[] {1}, 1, 0));
+    testCases.add(new TestCase(true, new byte[] {0, 1, 2}, 3, 0));
+    testCases.add(new TestCase(true, new byte[] {0, 1, 2, (byte) 0xFF}, 3, 0));
+    testCases.add(new TestCase(false, new byte[] {1, 2, 3}, 3, 0));
+    testCases.add(new TestCase(true, new byte[] {3}, 1, 3));
+    testCases.add(new TestCase(false, new byte[] {2}, 1, 3));
+    testCases.add(new TestCase(true, new byte[] {3, 4, 5}, 3, 3));
+    testCases.add(new TestCase(true, new byte[] {3, 4, 5, (byte) 0xFF}, 3, 3));
+    testCases.add(new TestCase(false, new byte[] {2, 3, 4}, 3, 3));
+
+    for (TestCase testCase : testCases) {
+      boolean result = BufferUtils.equalIncreasingByteArray(testCase.mStart, testCase.mLength,
+          testCase.mArray);
+      Assert.assertEquals(testCase.mExpected, result);
+    }
+  }
+
+  @Test
+  public void getIncreasingByteBufferTest() {
+    class TestCase {
+      ByteBuffer mExpected;
+      int mLength;
+      int mStart;
+
+      public TestCase(ByteBuffer expected, int length, int start) {
+        mExpected = expected;
+        mLength = length;
+        mStart = start;
+      }
+    }
+
+    LinkedList<TestCase> testCases = new LinkedList<TestCase>();
+    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {}), 0, 0));
+    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {}), 0, 3));
+    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {0}), 1, 0));
+    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {0, 1, 2}), 3, 0));
+    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {3}), 1, 3));
+    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {3, 4, 5}), 3, 3));
+
+    for (TestCase testCase : testCases) {
+      ByteBuffer result = BufferUtils.getIncreasingByteBuffer(testCase.mStart, testCase.mLength);
+      Assert.assertEquals(testCase.mExpected.capacity(), result.capacity());
+      for (int k = 0; k < result.capacity(); k ++) {
+        Assert.assertEquals(testCase.mExpected.get(k), result.get(k));
+      }
+    }
+  }
+
+  @Test
+  public void equalIncreasingByteBufferTest() {
+    class TestCase {
+      boolean mExpected;
+      ByteBuffer mBuffer;
+      int mLength;
+      int mStart;
+
+      public TestCase(boolean expected, ByteBuffer buffer, int length, int start) {
+        mExpected = expected;
+        mBuffer = buffer;
+        mLength = length;
+        mStart = start;
+      }
+    }
+
+    LinkedList<TestCase> testCases = new LinkedList<TestCase>();
+    testCases.add(new TestCase(false, null, 0, 0));
+    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {}), 0, 0));
+    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {1}), 0, 0));
+    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {}), 0, 3));
+    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {1}), 0, 3));
+    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {0}), 1, 0));
+    testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {1}), 1, 0));
+    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {0, 1, 2}), 3, 0));
+    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {0, 1, 2, (byte) 0xFF}), 3, 0));
+    testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {1, 2, 3}), 3, 0));
+    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {3}), 1, 3));
+    testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {2}), 1, 3));
+    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {3, 4, 5}), 3, 3));
+    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {3, 4, 5, (byte) 0xFF}), 3, 3));
+    testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {2, 3, 4}), 3, 3));
+
+    for (TestCase testCase : testCases) {
+      boolean result = BufferUtils.equalIncreasingByteBuffer(testCase.mStart, testCase.mLength,
+          testCase.mBuffer);
+      Assert.assertEquals(testCase.mExpected, result);
+    }
+  }
+
+  @Test
+  public void getIncreasingIntBufferTest() {
+    class TestCase {
+      ByteBuffer mExpected;
+      int mLength;
+      int mStart;
+
+      public TestCase(ByteBuffer expected, int length, int start) {
+        mExpected = expected;
+        mLength = length;
+        mStart = start;
+      }
+    }
+
+    LinkedList<TestCase> testCases = new LinkedList<TestCase>();
+    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {}), 0, 0));
+    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {}), 0, 3));
+    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {0, 0, 0, 0}), 1, 0));
+    testCases.add(new TestCase(ByteBuffer.wrap(
+        new byte[] {0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2}), 3, 0));
+    testCases.add(new TestCase(ByteBuffer.wrap(new byte[] {0, 0, 0, 3}), 1, 3));
+    testCases.add(new TestCase(ByteBuffer.wrap(
+        new byte[] {0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5}), 3, 3));
+
+    for (TestCase testCase : testCases) {
+      ByteBuffer result = BufferUtils.getIncreasingIntBuffer(testCase.mStart, testCase.mLength);
+      Assert.assertEquals(testCase.mExpected.limit(), result.limit());
+      for (int k = 0; k < result.limit(); k ++) {
+        Assert.assertEquals(testCase.mExpected.get(k), result.get(k));
+      }
+    }
+  }
+
   /**
-   *{@link BufferUtils#cleanDirectBuffer(ByteBuffer)} } forces to unmap an unused direct buffer.
+   *{@link BufferUtils#cleanDirectBuffer(ByteBuffer)} forces to unmap an unused direct buffer.
    * This test repeated allocates and de-allocates a direct buffer of size 16MB to make sure
    * cleanDirectBuffer is doing its job. The bufferArray is used to store references to the direct
    * buffers so that they won't get garbage collected automatically. It has been tested that if the
-   * call to cleanDirectBuffer is removed, this test will fail
+   * call to cleanDirectBuffer is removed, this test will fail.
    */
   @Test
   public void cleanDirectBufferTest() {

--- a/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
+++ b/common/src/test/java/tachyon/util/io/BufferUtilsTest.java
@@ -50,7 +50,7 @@ public class BufferUtilsTest {
       bufList.add(buf);
     }
     List<ByteBuffer> bufListClone = BufferUtils.cloneByteBufferList(bufList);
-    Assert.assertTrue(bufListClone.size() == listLength);
+    Assert.assertEquals(listLength, bufListClone.size());
     for (int k = 0 ; k < listLength; k ++) {
       Assert.assertEquals(bufList.get(k), bufListClone.get(k));
     }
@@ -81,7 +81,7 @@ public class BufferUtilsTest {
       bufDirectList.add(bufDirect);
     }
     List<ByteBuffer> bufListClone = BufferUtils.cloneByteBufferList(bufDirectList);
-    Assert.assertTrue(bufListClone.size() == listLength);
+    Assert.assertEquals(listLength, bufListClone.size());
     for (int k = 0 ; k < listLength; k ++) {
       Assert.assertEquals(bufDirectList.get(k), bufListClone.get(k));
     }
@@ -96,8 +96,8 @@ public class BufferUtilsTest {
     }
     mockRPCbuf.position(bufferSize / 2);
     ByteBuffer buf = BufferUtils.generateNewByteBufferFromThriftRPCResults(mockRPCbuf);
-    Assert.assertTrue(buf.position() == 0);
-    Assert.assertTrue(buf.capacity() == bufferSize / 2);
+    Assert.assertEquals(0, buf.position());
+    Assert.assertEquals(bufferSize / 2, buf.capacity());
     for (int i = 0; i < bufferSize / 2; i ++) {
       Assert.assertEquals(mockRPCbuf.get(i + bufferSize / 2), buf.get(i));
     }
@@ -179,18 +179,18 @@ public class BufferUtilsTest {
     LinkedList<TestCase> testCases = new LinkedList<TestCase>();
     testCases.add(new TestCase(false, null, 0, 0));
     testCases.add(new TestCase(true, new byte[] {}, 0, 0));
-    testCases.add(new TestCase(true, new byte[] {1}, 0, 0));
+    testCases.add(new TestCase(false, new byte[] {1}, 0, 0));
     testCases.add(new TestCase(true, new byte[] {}, 0, 3));
-    testCases.add(new TestCase(true, new byte[] {1}, 0, 3));
+    testCases.add(new TestCase(false, new byte[] {1}, 0, 3));
     testCases.add(new TestCase(true, new byte[] {0}, 1, 0));
     testCases.add(new TestCase(false, new byte[] {1}, 1, 0));
     testCases.add(new TestCase(true, new byte[] {0, 1, 2}, 3, 0));
-    testCases.add(new TestCase(true, new byte[] {0, 1, 2, (byte) 0xFF}, 3, 0));
+    testCases.add(new TestCase(false, new byte[] {0, 1, 2, (byte) 0xFF}, 3, 0));
     testCases.add(new TestCase(false, new byte[] {1, 2, 3}, 3, 0));
     testCases.add(new TestCase(true, new byte[] {3}, 1, 3));
     testCases.add(new TestCase(false, new byte[] {2}, 1, 3));
     testCases.add(new TestCase(true, new byte[] {3, 4, 5}, 3, 3));
-    testCases.add(new TestCase(true, new byte[] {3, 4, 5, (byte) 0xFF}, 3, 3));
+    testCases.add(new TestCase(false, new byte[] {3, 4, 5, (byte) 0xFF}, 3, 3));
     testCases.add(new TestCase(false, new byte[] {2, 3, 4}, 3, 3));
 
     for (TestCase testCase : testCases) {
@@ -250,18 +250,18 @@ public class BufferUtilsTest {
     LinkedList<TestCase> testCases = new LinkedList<TestCase>();
     testCases.add(new TestCase(false, null, 0, 0));
     testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {}), 0, 0));
-    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {1}), 0, 0));
+    testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {1}), 0, 0));
     testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {}), 0, 3));
-    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {1}), 0, 3));
+    testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {1}), 0, 3));
     testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {0}), 1, 0));
     testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {1}), 1, 0));
     testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {0, 1, 2}), 3, 0));
-    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {0, 1, 2, (byte) 0xFF}), 3, 0));
+    testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {0, 1, 2, (byte) 0xFF}), 3, 0));
     testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {1, 2, 3}), 3, 0));
     testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {3}), 1, 3));
     testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {2}), 1, 3));
     testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {3, 4, 5}), 3, 3));
-    testCases.add(new TestCase(true, ByteBuffer.wrap(new byte[] {3, 4, 5, (byte) 0xFF}), 3, 3));
+    testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {3, 4, 5, (byte) 0xFF}), 3, 3));
     testCases.add(new TestCase(false, ByteBuffer.wrap(new byte[] {2, 3, 4}), 3, 3));
 
     for (TestCase testCase : testCases) {

--- a/integration-tests/src/test/java/tachyon/hadoop/HdfsFileInputStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/HdfsFileInputStreamIntegrationTest.java
@@ -143,6 +143,7 @@ public class HdfsFileInputStreamIntegrationTest {
     Assert.assertTrue(BufferUtils.equalIncreasingByteArray(FILE_LEN, buf));
     Assert.assertEquals(0, mUfsInputStream.getPos());
 
+    buf = new byte[FILE_LEN - 10];
     Arrays.fill(buf, (byte) 0);
     length = mInMemInputStream.read(10, buf, 0, FILE_LEN - 10);
     Assert.assertEquals(FILE_LEN - 10, length);


### PR DESCRIPTION
Some utility functions in tachyon.util.io.BufferUtils are missing unit tests; this PR adds more tests (increasing line coverage from 30% to 80%).