### PR TITLE
[TACHYON-898] Enable LoginUser in CUSTOM mode

### DIFF
--- a/common/src/main/java/tachyon/security/LoginUser.java
+++ b/common/src/main/java/tachyon/security/LoginUser.java
@@ -101,9 +101,11 @@ public class LoginUser {
    * @param authType the authentication type in configuration
    */
   private static void checkSecurityEnabled(AuthenticationFactory.AuthType authType) {
-    //TODO: add Kerberos and Custom condition check.
-    if (authType != AuthenticationFactory.AuthType.SIMPLE) {
-      throw new UnsupportedOperationException("User is only supported in SIMPLE mode");
+    //TODO: add Kerberos condition check.
+    if (authType != AuthenticationFactory.AuthType.SIMPLE
+        && authType != AuthenticationFactory.AuthType.CUSTOM) {
+      throw new UnsupportedOperationException("User is not supported in " + authType.getAuthName()
+          + " mode");
     }
   }
 }

--- a/common/src/main/java/tachyon/security/TachyonJaasConfiguration.java
+++ b/common/src/main/java/tachyon/security/TachyonJaasConfiguration.java
@@ -58,6 +58,7 @@ public class TachyonJaasConfiguration extends Configuration {
    * {@link tachyon.security.CustomLoginModule}. Upon failure, it use the OS specific login module
    * to fetch the OS user, and then use the {@link tachyon.security.TachyonLoginModule} to convert
    * it to a Tachyon user represented by {@link tachyon.security.User}.
+   * In CUSTOM mode, we also use this configuration.
    */
   private static final AppConfigurationEntry[] SIMPLE = new
       AppConfigurationEntry[]{CUSTOM_LOGIN, OS_SPECIFIC_LOGIN, TACHYON_LOGIN};
@@ -67,8 +68,8 @@ public class TachyonJaasConfiguration extends Configuration {
 
   @Override
   public AppConfigurationEntry[] getAppConfigurationEntry(String appName) {
-    if (appName.equalsIgnoreCase(AuthenticationFactory.AuthType.SIMPLE.getAuthName())) {
-      // TODO: also return SIMPLE for AuthenticationFactory.AuthType.CUSTOM
+    if (appName.equalsIgnoreCase(AuthenticationFactory.AuthType.SIMPLE.getAuthName())
+        || appName.equalsIgnoreCase(AuthenticationFactory.AuthType.CUSTOM.getAuthName())) {
       return SIMPLE;
     } else if (appName.equalsIgnoreCase(AuthenticationFactory.AuthType.KERBEROS.getAuthName())) {
       // TODO: return KERBEROS;

--- a/common/src/main/java/tachyon/security/login/AppLoginModule.java
+++ b/common/src/main/java/tachyon/security/login/AppLoginModule.java
@@ -26,13 +26,13 @@ import tachyon.Constants;
 import tachyon.security.User;
 
 /**
- * A custom login module that creates a user based on the user name provided through application
+ * An app login module that creates a user based on the user name provided through application
  * configuration. Specifically, through Java system property tachyon.security.username.
  * This module is useful if multiple Tachyon clients running under same OS user name
  * want to get different identifies (for resource and data management), or if Tachyon clients
  * running under different OS user names want to get same identify.
  */
-public class CustomLoginModule implements LoginModule {
+public class AppLoginModule implements LoginModule {
   private Subject mSubject;
   private User mUser;
 
@@ -45,7 +45,7 @@ public class CustomLoginModule implements LoginModule {
   /**
    * Retrieve the user name by querying the property of Constants.TACHYON_SECURITY_USERNAME.
    *
-   * @return true if customized user name is set and not empty.
+   * @return true if user name provided by application is set and not empty.
    * @throws javax.security.auth.login.LoginException
    */
   @Override

--- a/common/src/main/java/tachyon/security/login/TachyonJaasConfiguration.java
+++ b/common/src/main/java/tachyon/security/login/TachyonJaasConfiguration.java
@@ -40,10 +40,10 @@ public class TachyonJaasConfiguration extends Configuration {
       new AppConfigurationEntry(TachyonJaasProperties.getOsLoginModuleName(),
           AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, BASIC_JAAS_OPTIONS);
   /**
-   * This custom login module allows an customized user name to be specified.
+   * This app login module allows a user name provided by application to be specified.
    */
-  private static final AppConfigurationEntry CUSTOM_LOGIN =
-      new AppConfigurationEntry(CustomLoginModule.class.getName(),
+  private static final AppConfigurationEntry APP_LOGIN =
+      new AppConfigurationEntry(AppLoginModule.class.getName(),
           AppConfigurationEntry.LoginModuleControlFlag.SUFFICIENT, BASIC_JAAS_OPTIONS);
 
   private static final AppConfigurationEntry TACHYON_LOGIN =
@@ -55,13 +55,13 @@ public class TachyonJaasConfiguration extends Configuration {
 
   /**
    * In SIMPLE mode, JAAS first tries to retrieve the user name set by the application with
-   * {@link tachyon.security.login.CustomLoginModule}. Upon failure, it use the OS specific login
+   * {@link tachyon.security.login.AppLoginModule}. Upon failure, it use the OS specific login
    * module to fetch the OS user, and then use the {@link tachyon.security.login.TachyonLoginModule}
    * to convert it to a Tachyon user represented by {@link tachyon.security.User}.
    * In CUSTOM mode, we also use this configuration.
    */
   private static final AppConfigurationEntry[] SIMPLE = new
-      AppConfigurationEntry[]{CUSTOM_LOGIN, OS_SPECIFIC_LOGIN, TACHYON_LOGIN};
+      AppConfigurationEntry[]{APP_LOGIN, OS_SPECIFIC_LOGIN, TACHYON_LOGIN};
 
   // TODO: add Kerberos mode
   // private static final AppConfigurationEntry[] KERBEROS = ...

--- a/common/src/test/java/tachyon/security/LoginUserTest.java
+++ b/common/src/test/java/tachyon/security/LoginUserTest.java
@@ -94,6 +94,21 @@ public class LoginUserTest {
     Assert.assertEquals(loginUser.getName(), System.getProperty("user.name"));
   }
 
+  /**
+   * Test whether we can get login user with conf in CUSTOM mode.
+   * @throws Exception
+   */
+  @Test
+  public void getLoginUserInCustomModeTest() throws Exception {
+    TachyonConf conf = new TachyonConf();
+    conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "CUSTOM");
+
+    User loginUser = LoginUser.get(conf);
+
+    Assert.assertNotNull(loginUser);
+    Assert.assertEquals(loginUser.getName(), System.getProperty("user.name"));
+  }
+
   // TODO: getKerberosLoginUserTest()
 
   /**
@@ -102,13 +117,13 @@ public class LoginUserTest {
    */
   @Test
   public void securityEnabledTest() throws Throwable {
-    // TODO: add Kerberos/Custom in the white list when it is supported.
-    // throw exception when AuthType is not "SIMPLE"
+    // TODO: add Kerberos in the white list when it is supported.
+    // throw exception when AuthType is not "SIMPLE", or "CUSTOM"
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "NOSASL");
 
     mThrown.expect(UnsupportedOperationException.class);
-    mThrown.expectMessage("User is only supported in SIMPLE mode");
+    mThrown.expectMessage("User is not supported in NOSASL mode");
     LoginUser.get(conf);
   }
 }

--- a/common/src/test/java/tachyon/security/LoginUserTest.java
+++ b/common/src/test/java/tachyon/security/LoginUserTest.java
@@ -58,11 +58,12 @@ public class LoginUserTest {
   }
 
   /**
-   * Test whether we can get login user with conf in SIMPLE mode, when custom name is provided.
+   * Test whether we can get login user with conf in SIMPLE mode, when user name is provided by
+   * the application through configuration.
    * @throws Exception
    */
   @Test
-  public void getCustomLoginUserTest() throws Exception {
+  public void getSimpleLoginUserProvidedByAppTest() throws Exception {
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
     //TODO: after TachyonConf is refactored into Singleton, we will use TachyonConf
@@ -76,12 +77,13 @@ public class LoginUserTest {
   }
 
   /**
-   * Test whether we can get login user with conf in SIMPLE mode, when custom name is set to an
-   * empty string. In this case, login should return the OS user instead of empty string.
+   * Test whether we can get login user with conf in SIMPLE mode, when user name is set to an
+   * empty string in the application configuration. In this case, login should return the OS user
+   * instead of empty string.
    * @throws Exception
    */
   @Test
-  public void getLoginUserWhenCustomIsEmpty() throws Exception {
+  public void getSimpleLoginUserWhenNotProvidedByAppTest() throws Exception {
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "SIMPLE");
     //TODO: after TachyonConf is refactored into Singleton, we will use TachyonConf
@@ -99,9 +101,48 @@ public class LoginUserTest {
    * @throws Exception
    */
   @Test
-  public void getLoginUserInCustomModeTest() throws Exception {
+  public void getCustomLoginUserTest() throws Exception {
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "CUSTOM");
+
+    User loginUser = LoginUser.get(conf);
+
+    Assert.assertNotNull(loginUser);
+    Assert.assertEquals(loginUser.getName(), System.getProperty("user.name"));
+  }
+
+  /**
+   * Test whether we can get login user with conf in CUSTOM mode, when user name is provided by
+   * the application through configuration.
+   * @throws Exception
+   */
+  @Test
+  public void getCustomLoginUserProvidedByAppTest() throws Exception {
+    TachyonConf conf = new TachyonConf();
+    conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "CUSTOM");
+    //TODO: after TachyonConf is refactored into Singleton, we will use TachyonConf
+    //instead of System.getProperty for retrieving user name.
+    System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "tachyon-user");
+
+    User loginUser = LoginUser.get(conf);
+
+    Assert.assertNotNull(loginUser);
+    Assert.assertEquals(loginUser.getName(), "tachyon-user");
+  }
+
+  /**
+   * Test whether we can get login user with conf in CUSTOM mode, when user name is set to an
+   * empty string in the application configuration. In this case, login should return the OS user
+   * instead of empty string.
+   * @throws Exception
+   */
+  @Test
+  public void getCustomLoginUserWhenNotProvidedByAppTest() throws Exception {
+    TachyonConf conf = new TachyonConf();
+    conf.set(Constants.TACHYON_SECURITY_AUTHENTICATION, "CUSTOM");
+    //TODO: after TachyonConf is refactored into Singleton, we will use TachyonConf
+    //instead of System.getProperty for retrieving user name.
+    System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "");
 
     User loginUser = LoginUser.get(conf);
 


### PR DESCRIPTION
JIAR: [TACHYON-898](https://tachyon.atlassian.net/browse/TACHYON-898)

In current login framework, the login user can only be fetched in SIMPLE mode. Getting login user will throw UnsupportedOperationException in other mode. In this PR, we enable getting login user in CUSTOM mode.

This issue was found when doing integration test in #1297 . Configured with CUSTOM mode, client side will throw unsupported exception when getting login user for connecting to server. This PR resolve this.

@ooq , @apc999 , could you help to review this? Thanks.