### PR TITLE
[TACHYON-909] Improve JavaDoc comments for tachyon.client.*

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
@@ -33,7 +33,9 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
 
   /**
    * Creates a file with the default block size (1GB) in the system. It also creates necessary
-   * folders along the path. // TODO It should not create necessary path.
+   * folders along the path.
+   *
+   * TODO(hy): It should not create necessary path.
    *
    * @param path the path of the file
    * @return The unique file id. It returns -1 if the creation failed.
@@ -45,8 +47,9 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
   }
 
   /**
-   * Creates a file in the system. It also creates necessary folders along the path. // TODO It
-   * should not create necessary path.
+   * Creates a file in the system. It also creates necessary folders along the path.
+   *
+   * TODO(hy): It should not create necessary path.
    *
    * @param path the path of the file
    * @param blockSizeByte the block size of the file
@@ -63,7 +66,9 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
 
   /**
    * Creates a file in the system with a pre-defined underfsPath. It also creates necessary folders
-   * along the path. // TODO It should not create necessary path.
+   * along the path.
+   *
+   * TODO(hy): It should not create necessary path.
    *
    * @param path the path of the file in Tachyon
    * @param ufsPath the path of the file in the underfs

--- a/clients/unshaded/src/main/java/tachyon/client/BlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/BlockInStream.java
@@ -33,15 +33,15 @@ public abstract class BlockInStream extends InStream {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /**
-   * Get a new BlockInStream of the given block without under file system configuration. The block
-   * is decided by the tachyonFile and blockIndex
+   * Creates a new <code>BlockInStream</code> without under file system configuration. The block is
+   * decided by the tachyonFile and blockIndex.
    *
    * @param tachyonFile the file the block belongs to
    * @param readType the InStream's read type
    * @param blockIndex the index of the block in the tachyonFile
    * @param tachyonConf the TachyonConf instance for this file output stream.
    * @return A new LocalBlockInStream or RemoteBlockInStream
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
    */
   public static BlockInStream get(TachyonFile tachyonFile, ReadType readType, int blockIndex,
       TachyonConf tachyonConf) throws IOException {
@@ -49,15 +49,15 @@ public abstract class BlockInStream extends InStream {
   }
 
   /**
-   * Get a new BlockInStream of the given block with the under file system configuration. The block
-   * is decided by the tachyonFile and blockIndex
+   * Creates a new <code>BlockInStream</code> with the under file system configuration. The block is
+   * decided by the tachyonFile and blockIndex.
    *
    * @param tachyonFile the file the block belongs to
    * @param readType the InStream's read type
    * @param blockIndex the index of the block in the tachyonFile
    * @param ufsConf the under file system configuration
    * @return A new LocalBlockInStream or RemoteBlockInStream
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
    */
   public static BlockInStream get(TachyonFile tachyonFile, ReadType readType, int blockIndex,
       Object ufsConf, TachyonConf tachyonConf) throws IOException {
@@ -65,10 +65,10 @@ public abstract class BlockInStream extends InStream {
       LOG.info("Reading with local stream.");
       TachyonByteBuffer buf = tachyonFile.readLocalByteBuffer(blockIndex);
       if (buf != null) {
-//      TODO: Rethink this code path to work with the worker locking design
-//      if (readType.isPromote()) {
-//        tachyonFile.promoteBlock(blockIndex);
-//      }
+        // TODO(calvin): Rethink this code path to work with the worker locking design.
+        // if (readType.isPromote()) {
+        // tachyonFile.promoteBlock(blockIndex);
+        // }
         return new LocalBlockInStream(tachyonFile, readType, blockIndex, buf, tachyonConf);
       }
     }
@@ -82,10 +82,10 @@ public abstract class BlockInStream extends InStream {
   protected boolean mClosed = false;
 
   /**
-   * @param file
-   * @param readType
-   * @param blockIndex
-   * @param tachyonConf the TachyonConf instance for this file output stream.
+   * @param file the parent file
+   * @param readType the BlockInStream's read type
+   * @param blockIndex the index of the block
+   * @param tachyonConf the TachyonConf instance
    */
   BlockInStream(TachyonFile file, ReadType readType, int blockIndex, TachyonConf tachyonConf) {
     super(file, readType, tachyonConf);

--- a/clients/unshaded/src/main/java/tachyon/client/BlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/BlockInStream.java
@@ -41,7 +41,7 @@ public abstract class BlockInStream extends InStream {
    * @param blockIndex the index of the block in the tachyonFile
    * @param tachyonConf the TachyonConf instance for this file output stream.
    * @return A new LocalBlockInStream or RemoteBlockInStream
-   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public static BlockInStream get(TachyonFile tachyonFile, ReadType readType, int blockIndex,
       TachyonConf tachyonConf) throws IOException {
@@ -57,7 +57,7 @@ public abstract class BlockInStream extends InStream {
    * @param blockIndex the index of the block in the tachyonFile
    * @param ufsConf the under file system configuration
    * @return A new LocalBlockInStream or RemoteBlockInStream
-   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public static BlockInStream get(TachyonFile tachyonFile, ReadType readType, int blockIndex,
       Object ufsConf, TachyonConf tachyonConf) throws IOException {

--- a/clients/unshaded/src/main/java/tachyon/client/BlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/BlockOutStream.java
@@ -31,14 +31,14 @@ public abstract class BlockOutStream extends OutStream {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /**
-   * Get a new BlockOutStream with a default initial size allocated to the block.
+   * Gets a new <code>BlockOutStream</code> with a default initial size allocated to the block.
    *
    * @param tachyonFile The file this block belongs to.
    * @param opType The type of write.
    * @param blockIndex The index of the block in the tachyonFile.
    * @param tachyonConf The TachyonConf instance.
    * @return A new {@link LocalBlockOutStream} or {@link RemoteBlockOutStream}.
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
    */
   public static BlockOutStream get(TachyonFile tachyonFile, WriteType opType, int blockIndex,
       TachyonConf tachyonConf) throws IOException {
@@ -47,6 +47,7 @@ public abstract class BlockOutStream extends OutStream {
   }
 
   /**
+   * Gets a new <code>BlockOutStream</code> with the given initial size allocated to the block.
    *
    * @param tachyonFile The file this block belongs to.
    * @param opType The type of write.
@@ -54,7 +55,7 @@ public abstract class BlockOutStream extends OutStream {
    * @param initialBytes The initial size (in bytes) that will be allocated to the block.
    * @param tachyonConf The TachyonConf instance.
    * @return A new {@link LocalBlockOutStream} or {@link RemoteBlockOutStream}.
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
    */
   public static BlockOutStream get(TachyonFile tachyonFile, WriteType opType, int blockIndex,
       long initialBytes, TachyonConf tachyonConf) throws IOException {

--- a/clients/unshaded/src/main/java/tachyon/client/BlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/BlockOutStream.java
@@ -38,7 +38,7 @@ public abstract class BlockOutStream extends OutStream {
    * @param blockIndex The index of the block in the tachyonFile.
    * @param tachyonConf The TachyonConf instance.
    * @return A new {@link LocalBlockOutStream} or {@link RemoteBlockOutStream}.
-   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public static BlockOutStream get(TachyonFile tachyonFile, WriteType opType, int blockIndex,
       TachyonConf tachyonConf) throws IOException {
@@ -55,7 +55,7 @@ public abstract class BlockOutStream extends OutStream {
    * @param initialBytes The initial size (in bytes) that will be allocated to the block.
    * @param tachyonConf The TachyonConf instance.
    * @return A new {@link LocalBlockOutStream} or {@link RemoteBlockOutStream}.
-   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public static BlockOutStream get(TachyonFile tachyonFile, WriteType opType, int blockIndex,
       long initialBytes, TachyonConf tachyonConf) throws IOException {

--- a/clients/unshaded/src/main/java/tachyon/client/EmptyBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/EmptyBlockInStream.java
@@ -24,6 +24,8 @@ import tachyon.conf.TachyonConf;
  */
 public class EmptyBlockInStream extends InStream {
   /**
+   * Creates a new <code>EmptyBlockInStream</code>.
+   *
    * @param file the file the block belongs to
    * @param readType the InStream's read type
    * @param tachyonConf the TachyonConf instance for this stream.

--- a/clients/unshaded/src/main/java/tachyon/client/FileInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/FileInStream.java
@@ -36,10 +36,11 @@ public class FileInStream extends InStream {
   private Object mUFSConf = null;
 
   /**
+   * Creates a new <code>FileInStream</code> without under file system configuration.
+   *
    * @param file the file to be read
    * @param opType the InStream's read type
    * @param tachyonConf the TachyonConf instance for this stream.
-   * @throws IOException
    */
   public FileInStream(TachyonFile file, ReadType opType, TachyonConf tachyonConf)
       throws IOException {
@@ -47,11 +48,12 @@ public class FileInStream extends InStream {
   }
 
   /**
+   * Creates a new <code>FileInStream</code> with under file system configuration.
+   *
    * @param file the file to be read
    * @param opType the InStream's read type
    * @param ufsConf the under file system configuration
    * @param tachyonConf the TachyonConf instance for this stream.
-   * @throws IOException
    */
   public FileInStream(TachyonFile file, ReadType opType, Object ufsConf, TachyonConf tachyonConf)
       throws IOException {

--- a/clients/unshaded/src/main/java/tachyon/client/FileOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/FileOutStream.java
@@ -53,7 +53,7 @@ public class FileOutStream extends OutStream {
    * @param opType the OutStream's write type
    * @param ufsConf the under file system configuration
    * @param tachyonConf the TachyonConf instance for this file output stream.
-   * @throws IOException
+   * @throws IOException if the underlying file cannot be found
    */
   FileOutStream(TachyonFile file, WriteType opType, Object ufsConf, TachyonConf tachyonConf)
       throws IOException {
@@ -61,7 +61,7 @@ public class FileOutStream extends OutStream {
 
     mBlockCapacityByte = file.getBlockSizeByte();
 
-    // TODO Support and test append.
+    // TODO(hy): Support and test append.
     mCurrentBlockOutStream = null;
     mPreviousBlockOutStreams = new ArrayList<BlockOutStream>();
     mCachedBytes = 0;
@@ -141,7 +141,7 @@ public class FileOutStream extends OutStream {
 
   @Override
   public void flush() throws IOException {
-    // TODO We only flush the checkpoint output stream. Flush for RAMFS block streams.
+    // TODO(hy):  We only flush the checkpoint output stream. Flush for RAMFS block streams.
     if (mWriteType.isThrough()) {
       mCheckpointOutputStream.flush();
     }
@@ -220,7 +220,7 @@ public class FileOutStream extends OutStream {
             || mCurrentBlockOutStream.getRemainingSpaceBytes() == 0) {
           getNextBlock();
         }
-        // TODO Cache the exception here.
+        // TODO(hy): Cache the exception here.
         mCurrentBlockOutStream.write(b);
         mCachedBytes ++;
       } catch (IOException e) {

--- a/clients/unshaded/src/main/java/tachyon/client/LocalBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/LocalBlockInStream.java
@@ -34,10 +34,9 @@ public class LocalBlockInStream extends BlockInStream {
    * @param blockIndex the index of the block in the file
    * @param buf the buffer of the whole block in local memory
    * @param tachyonConf the TachyonConf instance for this stream.
-   * @throws IOException
    */
   LocalBlockInStream(TachyonFile file, ReadType readType, int blockIndex, TachyonByteBuffer buf,
-      TachyonConf tachyonConf) throws IOException {
+      TachyonConf tachyonConf) {
     super(file, readType, blockIndex, tachyonConf);
 
     mTachyonBuffer = buf;

--- a/clients/unshaded/src/main/java/tachyon/client/LocalBlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/LocalBlockOutStream.java
@@ -62,11 +62,14 @@ public class LocalBlockOutStream extends BlockOutStream {
   private boolean mClosed = false;
 
   /**
+   * Creates a new <code>LocalBlockOutStream</code> with a default initial size allocated to the
+   * block.
+   *
    * @param file the file the block belongs to
    * @param opType the OutStream's write type
    * @param blockIndex the index of the block in the file
    * @param tachyonConf the TachyonConf instance for this file output stream.
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   LocalBlockOutStream(TachyonFile file, WriteType opType, int blockIndex, TachyonConf tachyonConf)
       throws IOException {
@@ -75,15 +78,18 @@ public class LocalBlockOutStream extends BlockOutStream {
   }
 
   /**
+   * Creates a new <code>LocalBlockOutStream</code> with the given initial size allocated to the
+   * block.
+   *
    * @param file the file the block belongs to
    * @param opType the OutStream's write type
    * @param blockIndex the index of the block in the file
    * @param initialBytes the initial size bytes that will be allocated to the block
    * @param tachyonConf the TachyonConf instance for this file output stream.
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   LocalBlockOutStream(TachyonFile file, WriteType opType, int blockIndex, long initialBytes,
-                      TachyonConf tachyonConf) throws IOException {
+      TachyonConf tachyonConf) throws IOException {
     super(file, opType, tachyonConf);
 
     // BlockOutStream.get() already checks for the local worker, but this verifies the local worker
@@ -100,11 +106,11 @@ public class LocalBlockOutStream extends BlockOutStream {
     mBlockOffset = mBlockCapacityByte * blockIndex;
     mCanWrite = true;
 
-    // TODO: Use the new LocalFileBlockWriter api for writing local files.
+    // TODO(hy): Use the new LocalFileBlockWriter api for writing local files.
     mLocalFilePath = mTachyonFS.getLocalBlockTemporaryPath(mBlockId, initialBytes);
     mLocalFile = mCloser.register(new RandomAccessFile(mLocalFilePath, "rw"));
     mLocalFileChannel = mCloser.register(mLocalFile.getChannel());
-    // change the permission of the temporary file in order that the worker can move it.
+    // Change the permission of the temporary file in order that the worker can move it.
     FileUtils.changeLocalFileToFullPermission(mLocalFilePath);
     LOG.info(mLocalFilePath + " was created! tachyonFile: " + file + ", blockIndex: " + blockIndex
         + ", blockId: " + mBlockId + ", blockCapacityByte: " + mBlockCapacityByte);

--- a/clients/unshaded/src/main/java/tachyon/client/ReadType.java
+++ b/clients/unshaded/src/main/java/tachyon/client/ReadType.java
@@ -31,7 +31,8 @@ public enum ReadType {
   /**
    * If the block is on local Tachyon space but not on top storage layer, promote the block to top
    * storage layer after reading.
-   * TODO: Enable this again when lock upgrading is implemented in the worker
+   *
+   * TODO(calvin): Enable this again when lock upgrading is implemented in the worker.
    */
   //CACHE_PROMOTE(3);
 
@@ -52,8 +53,9 @@ public enum ReadType {
 
   /**
    * @return true if the read type is CACHE, false otherwise
+   *
+   * TODO(calvin): Add CACHE_PROMOTE back when it is enabled again.
    */
-  // TODO: Add CACHE_PROMOTE back when it is enabled again
   public boolean isCache() {
     return mValue == CACHE.mValue;
     // return mValue == CACHE.mValue || mValue == CACHE_PROMOTE.mValue;
@@ -61,7 +63,8 @@ public enum ReadType {
 
   /**
    * @return true if the read type is CACHE_PROMOTE, false otherwise
-   * TODO: Add this function back when CACHE_PROMOTE is enabled again
+   *
+   * TODO(calvin): Add this function back when CACHE_PROMOTE is enabled again.
    */
 //  public boolean isPromote() {
 //    return mValue == CACHE_PROMOTE.mValue;

--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockInStream.java
@@ -108,11 +108,13 @@ public class RemoteBlockInStream extends BlockInStream {
   private RemoteBlockReader mCurrentReader = null;
 
   /**
+   * Creates a new <code>RemoteBlockInStream</code> without under file system configuration.
+   *
    * @param file the file the block belongs to
    * @param readType the InStream's read type
    * @param blockIndex the index of the block in the file
    * @param tachyonConf the TachyonConf instance for this file output stream.
-   * @throws IOException
+   * @throws IOException if the underlying file is not complete or its metadata is corrupted
    */
   RemoteBlockInStream(TachyonFile file, ReadType readType, int blockIndex, TachyonConf tachyonConf)
       throws IOException {
@@ -120,11 +122,14 @@ public class RemoteBlockInStream extends BlockInStream {
   }
 
   /**
+   * Creates a new <code>RemoteBlockInStream</code> with under file system configuration.
+   *
    * @param file the file the block belongs to
    * @param readType the InStream's read type
    * @param blockIndex the index of the block in the file
    * @param ufsConf the under file system configuration
-   * @throws IOException
+   * @param tachyonConf the TachyonConf instance for this file output stream.
+   * @throws IOException if the underlying file is not complete or its metadata is corrupted
    */
   RemoteBlockInStream(TachyonFile file, ReadType readType, int blockIndex, Object ufsConf,
       TachyonConf tachyonConf) throws IOException {
@@ -142,9 +147,9 @@ public class RemoteBlockInStream extends BlockInStream {
   }
 
   /**
-   * Only called by {@link getDummyStream}.
-   * An alternative to construct a RemoteBlockInstream, bypassing all the checks.
-   * The returned RemoteBlockInStream can be used to call {#link #readRemoteByteBuffer}.
+   * An alternative to construct a RemoteBlockInstream, bypassing all the checks. The returned
+   * RemoteBlockInStream can be used to call {#link #readRemoteByteBuffer}. Only called by
+   * {@link #getDummyStream()}.
    *
    * @param file, any, could be null
    * @param readType, any type
@@ -159,10 +164,9 @@ public class RemoteBlockInStream extends BlockInStream {
   }
 
   /**
-   * Return a dummy RemoteBlockInStream object.
-   * The object can be used to perform near-stateless read using {@link #readRemoteByteBuffer}.
-   * (The only state kept is a handler for the underlying reader, so we can close the reader
-   * when we close the dummy stream.)
+   * Return a dummy RemoteBlockInStream object. The object can be used to perform near-stateless
+   * read using {@link #readRemoteByteBuffer}. (The only state kept is a handler for the underlying
+   * reader, so we can close the reader when we close the dummy stream.)
    *
    * <p>
    * See {@link tachyon.client.TachyonFile#readRemoteByteBuffer(ClientBlockInfo)} for usage.
@@ -170,14 +174,14 @@ public class RemoteBlockInStream extends BlockInStream {
    * @return a dummy RemoteBlockInStream object.
    */
   public static RemoteBlockInStream getDummyStream() {
-    return new RemoteBlockInStream(new TachyonFile(null, -1, null),
-        ReadType.NO_CACHE, -1, null, null, true);
+    return new RemoteBlockInStream(new TachyonFile(null, -1, null), ReadType.NO_CACHE, -1, null,
+        null, true);
   }
 
   /**
    * Cancels the re-caching attempt
    *
-   * @throws IOException
+   * @throws IOException when the underlying stream cannot be canceled
    */
   private void cancelRecache() throws IOException {
     if (mRecache) {
@@ -302,6 +306,16 @@ public class RemoteBlockInStream extends BlockInStream {
     return len;
   }
 
+  /**
+   * Reads from a remote byte buffer.
+   *
+   * @param tachyonFS a TachyonFS
+   * @param blockInfo the block information
+   * @param offset offset to start the read at
+   * @param len number of bytes to read
+   * @param conf Tachyon configuration
+   * @return <code>ByteBuffer</code> containing the bytes read
+   */
   public ByteBuffer readRemoteByteBuffer(TachyonFS tachyonFS, ClientBlockInfo blockInfo,
       long offset, long len, TachyonConf conf) {
     ByteBuffer buf = null;
@@ -351,8 +365,8 @@ public class RemoteBlockInStream extends BlockInStream {
     return buf;
   }
 
-  private ByteBuffer retrieveByteBufferFromRemoteMachine(InetSocketAddress address,
-      long blockId, long offset, long length, TachyonConf conf) throws IOException {
+  private ByteBuffer retrieveByteBufferFromRemoteMachine(InetSocketAddress address, long blockId,
+      long offset, long length, TachyonConf conf) throws IOException {
     // always clear the previous reader before assigning it to a new one
     closeReader();
     mCurrentReader = RemoteBlockReader.Factory.createRemoteBlockReader(conf);
@@ -432,8 +446,7 @@ public class RemoteBlockInStream extends BlockInStream {
    * @throws IOException
    */
   private boolean updateCurrentBuffer() throws IOException {
-    long bufferSize =
-        mTachyonConf.getBytes(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE);
+    long bufferSize = mTachyonConf.getBytes(Constants.USER_REMOTE_READ_BUFFER_SIZE_BYTE);
     if (mCurrentBuffer != null && mBufferStartPos <= mBlockPos
         && mBlockPos < Math.min(mBufferStartPos + bufferSize, mBlockInfo.length)) {
       // We move the buffer to read at mBlockPos

--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockOutStream.java
@@ -54,6 +54,9 @@ public class RemoteBlockOutStream extends BlockOutStream {
   private boolean mClosed = true;
 
   /**
+   * Creates a new <code>RemoteBlockOutStream</code> with a default initial size allocated to the
+   * block.
+   *
    * @param file the file the block belongs to
    * @param opType the OutStream's write type
    * @param blockIndex the index of the block in the file
@@ -67,6 +70,9 @@ public class RemoteBlockOutStream extends BlockOutStream {
   }
 
   /**
+   * Creates a new <code>RemoteBlockOutStream</code> with the given initial size allocated to the
+   * block.
+   *
    * @param file the file the block belongs to
    * @param opType the OutStream's write type
    * @param blockIndex the index of the block in the file
@@ -74,7 +80,7 @@ public class RemoteBlockOutStream extends BlockOutStream {
    *                     for now, since the data server will allocate space matching the size of the
    *                     first write.
    * @param tachyonConf the TachyonConf instance for this file output stream.
-   * @throws IOException
+   * @throws IOException if the requested operation is not supported
    */
   RemoteBlockOutStream(TachyonFile file, WriteType opType, int blockIndex, long initialBytes,
       TachyonConf tachyonConf) throws IOException {
@@ -102,12 +108,12 @@ public class RemoteBlockOutStream extends BlockOutStream {
   }
 
   /**
-   * Write data to the remote block. This is synchronized to serialize writes to the block.
+   * Writes data to the remote block. This is synchronized to serialize writes to the block.
    *
    * @param bytes An array of bytes representing the source data.
    * @param offset The offset into the source array of bytes.
    * @param length The length of the data to write (in bytes).
-   * @throws IOException
+   * @throws IOException when the write operation fails
    */
   private synchronized void writeToRemoteBlock(byte[] bytes, int offset, int length)
       throws IOException {
@@ -163,9 +169,6 @@ public class RemoteBlockOutStream extends BlockOutStream {
     return mBlockId;
   }
 
-  /**
-   * @return the remaining space of the block, in bytes
-   */
   @Override
   public long getRemainingSpaceBytes() {
     return mBlockCapacityBytes - mWrittenBytes;

--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockReader.java
@@ -33,8 +33,6 @@ public interface RemoteBlockReader extends Closeable {
 
   class Factory {
     /**
-     * Creates a new <code>RemoteBlockReader</code>.
-     *
      * @param conf Tachyon configuration
      * @return a new instance of <code>RemoteBlockReader</code>
      */

--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockReader.java
@@ -32,6 +32,12 @@ import tachyon.util.CommonUtils;
 public interface RemoteBlockReader extends Closeable {
 
   class Factory {
+    /**
+     * Creates a new <code>RemoteBlockReader</code>.
+     *
+     * @param conf Tachyon configuration
+     * @return a new instance of <code>RemoteBlockReader</code>
+     */
     public static RemoteBlockReader createRemoteBlockReader(TachyonConf conf) {
       try {
         return CommonUtils.createNewClassInstance(
@@ -43,7 +49,7 @@ public interface RemoteBlockReader extends Closeable {
   }
 
   /**
-   * Read a remote block with a offset and length.
+   * Reads a remote block with a offset and length.
    *
    * @param address The {@link InetSocketAddress} of the data server.
    * @param blockId the id of the block trying to read.

--- a/clients/unshaded/src/main/java/tachyon/client/RemoteBlockWriter.java
+++ b/clients/unshaded/src/main/java/tachyon/client/RemoteBlockWriter.java
@@ -31,6 +31,12 @@ import tachyon.util.CommonUtils;
 public interface RemoteBlockWriter extends Closeable {
 
   class Factory {
+    /**
+     * Creates a new <code>RemoteBlockWriter</code>.
+     *
+     * @param conf Tachyon configuration
+     * @return a new instance of <code>RemoteBlockWriter</code>
+     */
     public static RemoteBlockWriter createRemoteBlockWriter(TachyonConf conf) {
       try {
         return CommonUtils.createNewClassInstance(
@@ -42,22 +48,22 @@ public interface RemoteBlockWriter extends Closeable {
   }
 
   /**
-   * Open a block writer to a data server.
+   * Opens a block writer to a data server.
    *
    * @param address The {@link InetSocketAddress} of the data server.
    * @param blockId The id of the block to write.
    * @param userId The id of the user writing the block.
-   * @throws IOException
+   * @throws IOException when the operation fails
    */
   void open(InetSocketAddress address, long blockId, long userId) throws IOException;
 
   /**
-   * Write data to the remote block.
+   * Writes data to the remote block.
    *
    * @param bytes An array of bytes representing the source data.
    * @param offset The offset into the source array of bytes.
    * @param length The length of the data to write (in bytes).
-   * @throws IOException
+   * @throws IOException when the operation fails
    */
   void write(byte[] bytes, int offset, int length) throws IOException;
 }

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonByteBuffer.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonByteBuffer.java
@@ -48,9 +48,9 @@ public class TachyonByteBuffer implements Closeable {
   }
 
   /**
-   * Close the TachyonByteBuffer, here it is synchronized
+   * Closes the TachyonByteBuffer, here it is synchronized.
    *
-   * @throws IOException
+   * @throws IOException when the underlying block cannot be unlocked
    */
   @Override
   public synchronized void close() throws IOException {

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -966,7 +966,7 @@ public class TachyonFS extends AbstractTachyonFS {
    *
    * @param id the raw table's id
    * @param metadata the new meta data
-   * @throws IOException
+   * @throws IOException when an event that prevents the metadata from being updated is encountered
    */
   public synchronized void updateRawTableMetadata(int id, ByteBuffer metadata) throws IOException {
     mMasterClient.user_updateRawTableMetadata(id, metadata);

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -53,8 +53,8 @@ import tachyon.worker.WorkerClient;
 
 /**
  * Client API to use Tachyon as a file system. This API is not compatible with HDFS file system API;
- * while tachyon.hadoop.AbstractTFS provides another API that exposes Tachyon as HDFS file
- * system. Under the hood, this class maintains a MasterClient to talk to the master server and
+ * while tachyon.hadoop.AbstractTFS provides another API that exposes Tachyon as HDFS file system.
+ * Under the hood, this class maintains a MasterClient to talk to the master server and
  * WorkerClients to interact with different Tachyon workers.
  */
 public class TachyonFS extends AbstractTachyonFS {
@@ -184,8 +184,7 @@ public class TachyonFS extends AbstractTachyonFS {
     mWorkerClient =
         mCloser.register(new WorkerClient(mMasterClient, mExecutorService, mTachyonConf,
             mClientMetrics));
-    mUserFailedSpaceRequestLimits =
-        mTachyonConf.getInt(Constants.USER_FAILED_SPACE_REQUEST_LIMITS);
+    mUserFailedSpaceRequestLimits = mTachyonConf.getInt(Constants.USER_FAILED_SPACE_REQUEST_LIMITS);
 
     String scheme = mZookeeperMode ? Constants.SCHEME_FT : Constants.SCHEME;
     String authority = mMasterAddress.getHostName() + ":" + mMasterAddress.getPort();
@@ -401,7 +400,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @param fileId the file id
    * @param blockIndex The index of the block in the file.
    * @return the block id if exists
-   * @throws IOException when the file does not exist, or connection issue.
+   * @throws IOException if the file does not exist, or connection issue.
    */
   public synchronized long getBlockId(int fileId, int blockIndex) throws IOException {
     ClientFileInfo info = getFileStatus(fileId, true);
@@ -498,8 +497,8 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Gets <code>TachyonFile</code> based on the path. If useCachedMetadata is true, this will not see
-   * changes to the file's pin setting, or other dynamic properties.
+   * Gets <code>TachyonFile</code> based on the path. If useCachedMetadata is true, this will not
+   * see changes to the file's pin setting, or other dynamic properties.
    *
    * @param path file path.
    * @param useCachedMetadata whether to use the file metadata cache
@@ -524,7 +523,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @throws IOException when the underlying master RPC fails
    */
   public synchronized List<ClientBlockInfo> getFileBlocks(int fid) throws IOException {
-    // TODO Should read from mClientFileInfos if possible. Should add timeout to improve this.
+    // TODO(hy): Should read from mClientFileInfos if possible. Should add timeout to improve this.
     return mMasterClient.user_getFileBlocks(fid, "");
   }
 
@@ -573,7 +572,7 @@ public class TachyonFS extends AbstractTachyonFS {
     }
     path = info.getPath();
 
-    // TODO: LRU
+    // TODO(hy): LRU
     mIdToClientFileInfo.put(fileId, info);
     mPathToClientFileInfo.put(path, info);
 
@@ -901,8 +900,7 @@ public class TachyonFS extends AbstractTachyonFS {
       return -1;
     }
 
-    long userQuotaUnitBytes =
-        mTachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES);
+    long userQuotaUnitBytes = mTachyonConf.getBytes(Constants.USER_QUOTA_UNIT_BYTES);
 
     long toRequestSpaceBytes = Math.max(requestSpaceBytes, userQuotaUnitBytes);
     for (int attempt = 0; attempt < mUserFailedSpaceRequestLimits; attempt ++) {
@@ -1000,12 +998,13 @@ public class TachyonFS extends AbstractTachyonFS {
     Preconditions.checkNotNull(uri, "URI cannot be null.");
     Preconditions.checkArgument(uri.isPathAbsolute() || TachyonURI.EMPTY_URI.equals(uri),
         "URI must be absolute, unless it's empty.");
-    Preconditions.checkArgument(!uri.hasScheme() || mRootUri.getScheme().equals(uri.getScheme()),
+    Preconditions.checkArgument(
+        !uri.hasScheme() || mRootUri.getScheme().equals(uri.getScheme()),
         "URI's scheme: " + uri.getScheme() + " must match the file system's scheme: "
             + mRootUri.getScheme() + ", unless it doesn't have a scheme.");
-    Preconditions.checkArgument(!uri.hasAuthority()
-        || mRootUri.getAuthority().equals(uri.getAuthority()), "URI's authority: "
-        + uri.getAuthority() + " must match the file system's authority: "
-        + mRootUri.getAuthority() + ", unless it doesn't have an authority.");
+    Preconditions.checkArgument(
+        !uri.hasAuthority() || mRootUri.getAuthority().equals(uri.getAuthority()),
+        "URI's authority: " + uri.getAuthority() + " must match the file system's authority: "
+            + mRootUri.getAuthority() + ", unless it doesn't have an authority.");
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -60,7 +60,7 @@ import tachyon.worker.WorkerClient;
 public class TachyonFS extends AbstractTachyonFS {
 
   /**
-   * Create a TachyonFS handler.
+   * Creates a <code>TachyonFS</code> handler for the given path.
    *
    * @param tachyonPath a Tachyon path contains master address. e.g., tachyon://localhost:19998,
    *        tachyon://localhost:19998/ab/c.txt
@@ -73,7 +73,7 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Create a TachyonFS handler.
+   * Creates a <code>TachyonFS</code> handler for the given Tachyon URI.
    *
    * @param tachyonURI a Tachyon URI to indicate master address. e.g., tachyon://localhost:19998,
    *        tachyon://localhost:19998/ab/c.txt
@@ -86,7 +86,7 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Create a TachyonFS handler.
+   * Creates a <code>TachyonFS</code> handler for the given Tachyon URI and configuration.
    *
    * @param tachyonURI a Tachyon URI to indicate master address. e.g., tachyon://localhost:19998,
    *        tachyon://localhost:19998/ab/c.txt
@@ -115,7 +115,7 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Create a TachyonFS handler.
+   * Creates a <code>TachyonFS</code> handler for the given hostname, port, and Zookeeper mode.
    *
    * @param masterHost master host details
    * @param masterPort port master listens on
@@ -131,7 +131,7 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Create a TachyonFS handler.
+   * Creates a <code>TachyonFS</code> handler for the given Tachyon configuration.
    *
    * @param tachyonConf The TachyonConf instance.
    * @return the corresponding TachyonFS handler
@@ -193,10 +193,10 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Update the latest block access time on the worker.
+   * Updates the latest block access time on the worker.
    *
    * @param blockId the local block's id
-   * @throws IOException
+   * @throws IOException when it cannot access the block
    */
   synchronized void accessLocalBlock(long blockId) throws IOException {
     if (mWorkerClient.isLocal()) {
@@ -205,50 +205,50 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Notify the worker that the checkpoint file of the indicated file id has been added.
+   * Notifies the worker that the checkpoint file of the indicated file id has been added.
    *
    * @param fid the file id
-   * @throws IOException
+   * @throws IOException when the underlying worker RPC fails
    */
   synchronized void addCheckpoint(int fid) throws IOException {
     mWorkerClient.addCheckpoint(fid);
   }
 
   /**
-   * Notify the worker to checkpoint the file of the indicated file id asynchronously
+   * Notifies the worker to checkpoint the file of the indicated file id asynchronously
    *
    * @param fid the file id
    * @return true if succeed, false otherwise
-   * @throws IOException
+   * @throws IOException when the underlying worker RPC fails
    */
   synchronized boolean asyncCheckpoint(int fid) throws IOException {
     return mWorkerClient.asyncCheckpoint(fid);
   }
 
   /**
-   * Notify the worker that the block is cached.
+   * Notifies the worker that the block is cached.
    *
    * @param blockId the block id
-   * @throws IOException
+   * @throws IOException when the underlying worker RPC fails
    */
   public synchronized void cacheBlock(long blockId) throws IOException {
     mWorkerClient.cacheBlock(blockId);
   }
 
   /**
-   * Notify the worker the block is canceled.
+   * Notifies the worker the block is canceled.
    *
    * @param blockId the block id
-   * @throws IOException
+   * @throws IOException when the underlying worker RPC fails
    */
   public synchronized void cancelBlock(long blockId) throws IOException {
     mWorkerClient.cancelBlock(blockId);
   }
 
   /**
-   * Close the client. Close the connections to both the master and worker
+   * Closes the client connections to both the master and worker.
    *
-   * @throws IOException
+   * @throws IOException when it fails to close the connections
    */
   @Override
   public synchronized void close() throws IOException {
@@ -260,21 +260,21 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * The file is complete.
+   * Marks the file as complete.
    *
    * @param fid the file id
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   synchronized void completeFile(int fid) throws IOException {
     mMasterClient.user_completeFile(fid);
   }
 
   /**
-   * Create a user UnderFileSystem temporary folder and return it
+   * Creates a user UnderFileSystem temporary folder and returns it.
    *
    * @param ufsConf the configuration of UnderFileSystem
    * @return the UnderFileSystem temporary folder
-   * @throws IOException
+   * @throws IOException when the underlying worker RPC or under file system interaction fails
    */
   synchronized String createAndGetUserUfsTempFolder(Object ufsConf) throws IOException {
     String tmpFolder = mWorkerClient.getUserUfsTempFolder();
@@ -292,19 +292,19 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Create a Dependency
+   * Creates a dependency.
    *
    * @param parents the dependency's input files
    * @param children the dependency's output files
-   * @param commandPrefix
-   * @param data
-   * @param comment
-   * @param framework
-   * @param frameworkVersion
+   * @param commandPrefix identifies a command prefix
+   * @param data stores dependency data
+   * @param comment records a dependency comment
+   * @param framework identifies the framework
+   * @param frameworkVersion identifies the framework version
    * @param dependencyType the dependency's type, Wide or Narrow
    * @param childrenBlockSizeByte the block size of the dependency's output files
    * @return the dependency's id
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized int createDependency(List<String> parents, List<String> children,
       String commandPrefix, List<ByteBuffer> data, String comment, String framework,
@@ -322,6 +322,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @param blockSizeByte The size of the block in bytes. It is -1 iff ufsPath is non-empty.
    * @param recursive Creates necessary parent folders if true, not otherwise.
    * @return The file id, which is globally unique.
+   * @throws IOException when the underlying master RPC fails
    */
   @Override
   public synchronized int createFile(TachyonURI path, TachyonURI ufsPath, long blockSizeByte,
@@ -332,25 +333,25 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Create a RawTable and return its id
+   * Creates a <code>RawTable</code> and returns its id.
    *
    * @param path the RawTable's path
    * @param columns number of columns it has
    * @return the id if succeed, -1 otherwise
-   * @throws IOException
+   * @throws IOException when number of columns is invalid or the underlying master RPC fails
    */
   public synchronized int createRawTable(TachyonURI path, int columns) throws IOException {
     return createRawTable(path, columns, ByteBuffer.allocate(0));
   }
 
   /**
-   * Create a RawTable and return its id
+   * Creates a <code>RawTable</code> and returns its id.
    *
    * @param path the RawTable's path
    * @param columns number of columns it has
    * @param metadata the meta data of the RawTable
    * @return the id if succeed, -1 otherwise
-   * @throws IOException
+   * @throws IOException when number of columns is invalid or the underlying master RPC fails
    */
   public synchronized int createRawTable(TachyonURI path, int columns, ByteBuffer metadata)
       throws IOException {
@@ -365,15 +366,15 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Deletes a file or folder
+   * Deletes a file or folder.
    *
    * @param fileId The id of the file / folder. If it is not -1, path parameter is ignored.
    *        Otherwise, the method uses the path parameter.
    * @param path The path of the file / folder. It could be empty iff id is not -1.
    * @param recursive If fileId or path represents a non-empty folder, delete the folder recursively
-   *        or not
-   * @return true if deletes successfully, false otherwise.
-   * @throws IOException
+   *        or not.
+   * @return true if deletes successfully, false otherwise
+   * @throws IOException when the underlying master RPC fails
    */
   @Override
   public synchronized boolean delete(int fileId, TachyonURI path, boolean recursive)
@@ -383,11 +384,11 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Return whether the file exists or not
+   * Returns whether the file exists or not.
    *
    * @param path the file's path in Tachyon file system
    * @return true if it exists, false otherwise
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized boolean exist(TachyonURI path) throws IOException {
     return getFileStatus(-1, path, false) != null;
@@ -400,7 +401,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @param fileId the file id
    * @param blockIndex The index of the block in the file.
    * @return the block id if exists
-   * @throws IOException if the file does not exist, or connection issue.
+   * @throws IOException when the file does not exist, or connection issue.
    */
   public synchronized long getBlockId(int fileId, int blockIndex) throws IOException {
     ClientFileInfo info = getFileStatus(fileId, true);
@@ -424,55 +425,57 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Get a ClientBlockInfo by blockId
+   * Gets a ClientBlockInfo by the block id.
    *
    * @param blockId the id of the block
    * @return the ClientBlockInfo of the specified block
-   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
+   * @throws IOException when the underlying master RPC fails.
    */
   synchronized ClientBlockInfo getClientBlockInfo(long blockId) throws IOException {
     return mMasterClient.user_getClientBlockInfo(blockId);
   }
 
   /**
-   * Get a ClientDependencyInfo by the dependency id
+   * Gets a ClientDependencyInfo by the dependency id.
    *
    * @param depId the dependency id
    * @return the ClientDependencyInfo of the specified dependency
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized ClientDependencyInfo getClientDependencyInfo(int depId) throws IOException {
     return mMasterClient.getClientDependencyInfo(depId);
   }
 
   /**
-   * Get the user's ClientMetrics.
+   * Gets the user's <code>ClientMetrics</code>.
    *
-   * @return the ClientMetrics object.
+   * @return the <code>ClientMetrics</code> object.
    */
   ClientMetrics getClientMetrics() {
     return mClientMetrics;
   }
 
   /**
-   * Get <code>TachyonFile</code> based on the file id.
+   * Gets <code>TachyonFile</code> based on the file id.
    *
    * NOTE: This *will* use cached file metadata, and so will not see changes to dynamic properties,
    * such as the pinned flag. This is also different from the behavior of getFile(path), which by
    * default will not use cached metadata.
    *
    * @param fid file id.
-   * @return TachyonFile of the file id, or null if the file does not exist.
+   * @return <code>TachyonFile</code> of the file id, or null if the file does not exist
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized TachyonFile getFile(int fid) throws IOException {
     return getFile(fid, true);
   }
 
   /**
-   * Get <code>TachyonFile</code> based on the file id. If useCachedMetadata, this will not see
+   * Gets <code>TachyonFile</code> based on the file id. If useCachedMetadata, this will not see
    * changes to the file's pin setting, or other dynamic properties.
    *
    * @return TachyonFile of the file id, or null if the file does not exist.
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized TachyonFile getFile(int fid, boolean useCachedMetadata) throws IOException {
     ClientFileInfo clientFileInfo = getFileStatus(fid, TachyonURI.EMPTY_URI, useCachedMetadata);
@@ -483,11 +486,11 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Get <code>TachyonFile</code> based on the path. Does not utilize the file metadata cache.
+   * Gets <code>TachyonFile</code> based on the path. Does not utilize the file metadata cache.
    *
    * @param path file path.
    * @return TachyonFile of the path, or null if the file does not exist.
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized TachyonFile getFile(TachyonURI path) throws IOException {
     validateUri(path);
@@ -495,13 +498,13 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Get <code>TachyonFile</code> based on the path. If useCachedMetadata is true, this will not see
+   * Gets <code>TachyonFile</code> based on the path. If useCachedMetadata is true, this will not see
    * changes to the file's pin setting, or other dynamic properties.
    *
    * @param path file path.
    * @param useCachedMetadata whether to use the file metadata cache
    * @return TachyonFile of the path, or null if the file does not exist.
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized TachyonFile getFile(TachyonURI path, boolean useCachedMetadata)
       throws IOException {
@@ -514,11 +517,11 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Get all the blocks' info of the file
+   * Gets all the blocks' info of the file.
    *
    * @param fid the file id
    * @return the list of the blocks' info
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized List<ClientBlockInfo> getFileBlocks(int fid) throws IOException {
     // TODO Should read from mClientFileInfos if possible. Should add timeout to improve this.
@@ -541,7 +544,7 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Gets file status.
+   * Gets a file status.
    *
    * @param cache ClientFileInfo cache.
    * @param key the key in the cache.
@@ -549,7 +552,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @param path the path of the queried file. If fielId is not -1, this parameter is ignored.
    * @param useCachedMetaData whether to use the cached data or not.
    * @return the clientFileInfo.
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   private synchronized <K> ClientFileInfo getFileStatus(Map<K, ClientFileInfo> cache, K key,
       int fileId, String path, boolean useCachedMetaData) throws IOException {
@@ -586,7 +589,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @param path the path of the file or folder. valid iff fileId is -1.
    * @param useCachedMetadata if true use the local cached meta data
    * @return the ClientFileInfo of the file. null if the file does not exist.
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized ClientFileInfo getFileStatus(int fileId, TachyonURI path,
       boolean useCachedMetadata) throws IOException {
@@ -605,12 +608,12 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Get ClientFileInfo object based on fileId.
+   * Gets <code>ClientFileInfo</code> object based on fileId.
    *
    * @param fileId the file id of the file or folder.
    * @param useCachedMetadata if true use the local cached meta data
    * @return the ClientFileInfo of the file. null if the file does not exist.
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized ClientFileInfo getFileStatus(int fileId, boolean useCachedMetadata)
       throws IOException {
@@ -618,27 +621,27 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Get block's temporary path from worker with initial space allocated.
+   * Gets block's temporary path from worker with initial space allocated.
    *
    * @param blockId the id of the block
    * @param initialBytes the initial bytes allocated for the block file
    * @return the temporary path of the block file
-   * @throws IOException
+   * @throws IOException when the underlying worker RPC fails
    */
   public synchronized String getLocalBlockTemporaryPath(long blockId, long initialBytes)
       throws IOException {
     String blockPath = mWorkerClient.requestBlockLocation(blockId, initialBytes);
-    // TODO: Handle this in the worker?
+    // TODO(hy): Handle this in the worker?
     FileUtils.createBlockPath(blockPath);
     return blockPath;
   }
 
   /**
-   * Get the RawTable by id
+   * Gets <code>RawTable</code> by id.
    *
    * @param id the id of the raw table
    * @return the RawTable
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized RawTable getRawTable(int id) throws IOException {
     ClientRawTableInfo clientRawTableInfo = mMasterClient.user_getClientRawTableInfo(id, "");
@@ -646,11 +649,11 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Get the RawTable by path
+   * Get the <code>RawTable</code> by path.
    *
    * @param path the path of the raw table
    * @return the RawTable
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized RawTable getRawTable(TachyonURI path) throws IOException {
     validateUri(path);
@@ -661,7 +664,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * @return the address of the UnderFileSystem
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized String getUfsAddress() throws IOException {
     return mMasterClient.user_getUfsAddress();
@@ -679,7 +682,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * Returns the userId of the master client. This is only used for testing.
    *
    * @return the userId of the master client
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   long getUserId() throws IOException {
     return mMasterClient.getUserId();
@@ -687,7 +690,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * @return get the total number of bytes used in Tachyon cluster
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized long getUsedBytes() throws IOException {
     return mMasterClient.getUsedBytes();
@@ -695,7 +698,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * @return get the capacity of Tachyon cluster
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized long getCapacityBytes() throws IOException {
     return mMasterClient.getCapacityBytes();
@@ -710,7 +713,7 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * @return all the works' info
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized List<ClientWorkerInfo> getWorkersInfo() throws IOException {
     return mMasterClient.getWorkersInfo();
@@ -718,14 +721,13 @@ public class TachyonFS extends AbstractTachyonFS {
 
   /**
    * @return true if there is a local worker, false otherwise
-   * @throws IOException
    */
-  public synchronized boolean hasLocalWorker() throws IOException {
+  public synchronized boolean hasLocalWorker() {
     return mWorkerClient.isLocal();
   }
 
   /**
-   * Check if this client is connected to master.
+   * Checks if this client is connected to master.
    *
    * @return true if this client is connected to master, false otherwise
    */
@@ -734,7 +736,7 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Check if the indicated file id is a directory.
+   * Checks if the indicated file id is a directory.
    *
    * @param fid the file id
    * @return true if the file is a directory, false otherwise
@@ -744,12 +746,12 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * If the <code>path</code> is a directory, return all the direct entries in it. If the
-   * <code>path</code> is a file, return its ClientFileInfo.
+   * If the <code>path</code> is a directory, returns all the direct entries in it. If the
+   * <code>path</code> is a file, returns its ClientFileInfo.
    *
    * @param path the target directory/file path
    * @return A list of ClientFileInfo, null if the file or folder does not exist.
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   @Override
   public synchronized List<ClientFileInfo> listStatus(TachyonURI path) throws IOException {
@@ -758,13 +760,13 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Lock a block in the current TachyonFS.
+   * Locks a block in the current TachyonFS.
    *
    * @param blockId The id of the block to lock. <code>blockId</code> must be positive.
    * @param blockLockId The block lock id of the block of lock. <code>blockLockId</code> must be
    *        non-negative.
    * @return the path of the block file locked
-   * @throws IOException
+   * @throws IOException when the underlying worker RPC fails
    */
   synchronized String lockBlock(long blockId, int blockLockId) throws IOException {
     if (blockId <= 0 || blockLockId < 0) {
@@ -797,7 +799,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @param path the path of the folder to be created
    * @param recursive Creates necessary parent folders if true, not otherwise.
    * @return true if the folder is created successfully or already existing. false otherwise.
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   @Override
   public synchronized boolean mkdirs(TachyonURI path, boolean recursive) throws IOException {
@@ -805,13 +807,19 @@ public class TachyonFS extends AbstractTachyonFS {
     return mMasterClient.user_mkdirs(path.getPath(), recursive);
   }
 
-  /** Alias for setPinned(fid, true). */
+  /**
+   * An alias for setPinned(fid, true).
+   *
+   * @return the file id
+   * @throws IOException when the underlying worker RPC fails
+   * @see #setPinned(int, boolean)
+   */
   public synchronized void pinFile(int fid) throws IOException {
     setPinned(fid, true);
   }
 
   /**
-   * Frees an in-memory file or folder
+   * Frees an in-memory file or folder.
    *
    * @param fileId The id of the file / folder. If it is not -1, path parameter is ignored.
    *        Otherwise, the method uses the path parameter.
@@ -819,7 +827,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @param recursive If fileId or path represents a non-empty folder, free the folder recursively
    *        or not
    * @return true if in-memory free successfully, false otherwise.
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   @Override
   public synchronized boolean freepath(int fileId, TachyonURI path, boolean recursive)
@@ -829,11 +837,11 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Promote a block to the top StorageTier, after the block file is accessed.
+   * Promotes a block to the top StorageTier, after the block file is accessed.
    *
    * @param blockId the id of the block
    * @return true if success, false otherwise
-   * @throws IOException
+   * @throws IOException when the underlying worker RPC fails
    */
   public synchronized boolean promoteBlock(long blockId) throws IOException {
     if (mWorkerClient.isLocal()) {
@@ -850,7 +858,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @param srcPath The path of the source file / folder. It could be empty iff id is not -1.
    * @param dstPath The path of the destination file / folder. It could be empty iff id is not -1.
    * @return true if renames successfully, false otherwise.
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   @Override
   public synchronized boolean rename(int fileId, TachyonURI srcPath, TachyonURI dstPath)
@@ -861,32 +869,32 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Report the lost file to master
+   * Reports the lost file to master.
    *
    * @param fileId the lost file id
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized void reportLostFile(int fileId) throws IOException {
     mMasterClient.user_reportLostFile(fileId);
   }
 
   /**
-   * Request the dependency's needed files
+   * Requests the dependency's needed files.
    *
    * @param depId the dependency id
-   * @throws IOException
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized void requestFilesInDependency(int depId) throws IOException {
     mMasterClient.user_requestFilesInDependency(depId);
   }
 
   /**
-   * Try to request space for certain block. Only works when a local worker exists.
+   * Tries to request space for certain block. Only works when a local worker exists.
    *
    * @param blockId the id of the block that space will be allocated for
    * @param requestSpaceBytes size to request in bytes
    * @return the size bytes that allocated to the block, -1 if no local worker exists
-   * @throws IOException
+   * @throws IOException when the underlying file does not exist
    */
   public synchronized long requestSpace(long blockId, long requestSpaceBytes) throws IOException {
     if (!hasLocalWorker()) {
@@ -911,13 +919,17 @@ public class TachyonFS extends AbstractTachyonFS {
    *
    * Calling setPinned() on a folder will recursively set the "pinned" flag on all of that folder's
    * children. This may be an expensive operation for folders with many files/subfolders.
+   *
+   * @param fid the file id
+   * @param pinned the target "pinned" flag value
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized void setPinned(int fid, boolean pinned) throws IOException {
     mMasterClient.user_setPinned(fid, pinned);
   }
 
   /**
-   * Print out the string representation of this Tachyon server address.
+   * Prints out the string representation of this Tachyon server address.
    *
    * @return the string representation like tachyon://host:port or tachyon-ft://host:port
    */
@@ -927,12 +939,12 @@ public class TachyonFS extends AbstractTachyonFS {
   }
 
   /**
-   * Unlock a block in the current TachyonFS.
+   * Unlocks a block in the current TachyonFS.
    *
    * @param blockId The id of the block to unlock. <code>blockId</code> must be positive.
    * @param blockLockId The block lock id of the block of unlock. <code>blockLockId</code> must be
    *        non-negative.
-   * @throws IOException
+   * @throws IOException when the underlying workerRPC fails
    */
   synchronized boolean unlockBlock(long blockId, int blockLockId) throws IOException {
     if (blockId <= 0 || blockLockId < 0) {
@@ -957,17 +969,23 @@ public class TachyonFS extends AbstractTachyonFS {
     return mWorkerClient.unlockBlock(blockId);
   }
 
-  /** Alias for setPinned(fid, false). */
+  /**
+   * An alias for setPinned(fid, false).
+   *
+   * @return the file id
+   * @throws IOException when the underlying worker RPC fails
+   * @see #setPinned(int, boolean)
+   */
   public synchronized void unpinFile(int fid) throws IOException {
     setPinned(fid, false);
   }
 
   /**
-   * Update the RawTable's meta data
+   * Updates the RawTable's meta data
    *
    * @param id the raw table's id
    * @param metadata the new meta data
-   * @throws IOException when an event that prevents the metadata from being updated is encountered
+   * @throws IOException when the underlying master RPC fails
    */
   public synchronized void updateRawTableMetadata(int id, ByteBuffer metadata) throws IOException {
     mMasterClient.user_updateRawTableMetadata(id, metadata);

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -428,7 +428,7 @@ public class TachyonFS extends AbstractTachyonFS {
    *
    * @param blockId the id of the block
    * @return the ClientBlockInfo of the specified block
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
    */
   synchronized ClientBlockInfo getClientBlockInfo(long blockId) throws IOException {
     return mMasterClient.user_getClientBlockInfo(blockId);
@@ -932,6 +932,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @param blockId The id of the block to unlock. <code>blockId</code> must be positive.
    * @param blockLockId The block lock id of the block of unlock. <code>blockLockId</code> must be
    *        non-negative.
+   * @throws IOException
    */
   synchronized boolean unlockBlock(long blockId, int blockLockId) throws IOException {
     if (blockId <= 0 || blockLockId < 0) {

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFSCore.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFSCore.java
@@ -34,13 +34,14 @@ interface TachyonFSCore extends Closeable {
    *        not exist in the under file system yet.
    * @param blockSizeByte The size of the block in bytes. It is -1 iff ufsPath is non-empty.
    * @param recursive Creates necessary parent folders if true, not otherwise.
+   * @throws IOException when the operation fails
    * @return The file id, which is globally unique.
    */
   int createFile(TachyonURI path, TachyonURI ufsPath, long blockSizeByte, boolean recursive)
       throws IOException;
 
   /**
-   * Deletes a file or folder
+   * Deletes a file or folder.
    *
    * @param fileId The id of the file / folder. If it is not -1, path parameter is ignored.
    *        Otherwise, the method uses the path parameter.
@@ -48,7 +49,8 @@ interface TachyonFSCore extends Closeable {
    * @param recursive If fileId or path represents a non-empty folder, delete the folder recursively
    *        or not
    * @return true if deletes successfully, false otherwise.
-   * @throws IOException
+   * @throws IOException when the operation fails
+
    */
   boolean delete(int fileId, TachyonURI path, boolean recursive) throws IOException;
 
@@ -58,7 +60,7 @@ interface TachyonFSCore extends Closeable {
    * @param fileId the file id of the file or folder.
    * @param path the path of the file or folder. valid iff fileId is -1.
    * @return the ClientFileInfo of the file or folder, null if the file or folder does not exist.
-   * @throws IOException
+   * @throws IOException when the operation fails
    */
   ClientFileInfo getFileStatus(int fileId, TachyonURI path) throws IOException;
 
@@ -71,7 +73,7 @@ interface TachyonFSCore extends Closeable {
    *
    * @param path the target directory/file path
    * @return A list of ClientFileInfo, null if the file or folder does not exist.
-   * @throws IOException
+   * @throws IOException when the operation fails
    */
   List<ClientFileInfo> listStatus(TachyonURI path) throws IOException;
 
@@ -81,7 +83,7 @@ interface TachyonFSCore extends Closeable {
    * @param path the path of the folder to be created
    * @param recursive Creates necessary parent folders if true, not otherwise.
    * @return true if the folder is created successfully or already existing. false otherwise.
-   * @throws IOException
+   * @throws IOException when the operation fails
    */
   boolean mkdirs(TachyonURI path, boolean recursive) throws IOException;
 
@@ -93,19 +95,20 @@ interface TachyonFSCore extends Closeable {
    * @param srcPath The path of the source file / folder. It could be empty iff id is not -1.
    * @param dstPath The path of the destination file / folder. It could be empty iff id is not -1.
    * @return true if renames successfully, false otherwise.
-   * @throws IOException
+   * @throws IOException when the operation fails
    */
   boolean rename(int fileId, TachyonURI srcPath, TachyonURI dstPath) throws IOException;
 
  /**
-  * Memory free of a file or folder
+  * Frees memory of a file or folder.
+  *
   * @param fileId The id of the file / folder. If it is not -1, path parameter is ignored.
   *        Otherwise, the method uses the path parameter.
   * @param path The path of the file / folder. It could be empty iff id is not -1.
   * @param recursive If fileId or path represents a non-empty folder, free the folder recursively
   *        or not
   * @return true if in-memory free successfully, false otherwise.
-  * @throws IOException
+  * @throws IOException when the operation fails
   */
   boolean freepath(int fileId, TachyonURI path, boolean recursive) throws IOException;
 }

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFSTestUtils.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFSTestUtils.java
@@ -24,7 +24,7 @@ import tachyon.thrift.ClientFileInfo;
 
 public final class TachyonFSTestUtils {
   /**
-   * Create a simple file with <code>len</code> bytes.
+   * Creates a simple file with <code>len</code> bytes.
    *
    * @param tfs a TachyonFS handler
    * @param fileName the name of the file to be created
@@ -39,7 +39,7 @@ public final class TachyonFSTestUtils {
   }
 
   /**
-   * Create a simple file with <code>len</code> bytes.
+   * Creates a simple file with <code>len</code> bytes.
    *
    * @param tfs a TachyonFS handler
    * @param fileURI URI of the file
@@ -63,7 +63,7 @@ public final class TachyonFSTestUtils {
   }
 
   /**
-   * Create a simple file with <code>len</code> bytes.
+   * Creates a simple file with <code>len</code> bytes.
    *
    * @param tfs a TachyonFS handler
    * @param fileName the name of the file to be created
@@ -88,7 +88,7 @@ public final class TachyonFSTestUtils {
   }
 
   /**
-   * List files at a given <code>path</code>.
+   * Lists files at a given <code>path</code>.
    *
    * @param tfs a TachyonFS handler
    * @param path a path in tachyon file system

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
@@ -364,10 +364,10 @@ public class TachyonFile implements Comparable<TachyonFile> {
       return null;
     }
 
-    // TODO allow user to disable local read for this advanced API
+    // TODO(hy): allow user to disable local read for this advanced API
     TachyonByteBuffer ret = readLocalByteBuffer(blockIndex);
     if (ret == null) {
-      // TODO Make it local cache if the OpType is try cache.
+      // TODO(hy): Make it local cache if the OpType is try cache.
       ret = readRemoteByteBuffer(getClientBlockInfo(blockIndex));
     }
 

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
@@ -51,11 +51,11 @@ public class TachyonFile implements Comparable<TachyonFile> {
   private final TachyonConf mTachyonConf;
 
   /**
-   * A Tachyon File handler, based on file id
+   * Creates a new <code>TachyonFile</code>, based on file id.
    *
    * @param tfs the Tachyon file system client handler
    * @param fid the file id
-   * @param tachyonConf the TachyonConf for this file.
+   * @param tachyonConf the TachyonConf for this file
    */
   TachyonFile(TachyonFS tfs, int fid, TachyonConf tachyonConf) {
     mTachyonFS = tfs;
@@ -88,49 +88,52 @@ public class TachyonFile implements Comparable<TachyonFile> {
   }
 
   /**
-   * Return the id of a block in the file, specified by blockIndex
+   * Returns the id of a block in the file, specified by blockIndex.
    *
    * @param blockIndex the index of the block in this file
    * @return the block id
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public long getBlockId(int blockIndex) throws IOException {
     return mTachyonFS.getBlockId(mFileId, blockIndex);
   }
 
   /**
-   * Return the block size of this file
+   * Returns the block size of this file.
    *
    * @return the block size in bytes
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public long getBlockSizeByte() throws IOException {
     return getCachedFileStatus().getBlockSizeByte();
   }
 
   /**
-   * Get a ClientBlockInfo by the file id and block index
+   * Gets a ClientBlockInfo by the file id and block index
    *
-   * @param blockIndex The index of the block in the file.
+   * @param blockIndex The index of the block in the file
    * @return the ClientBlockInfo of the specified block
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public synchronized ClientBlockInfo getClientBlockInfo(int blockIndex) throws IOException {
     return mTachyonFS.getClientBlockInfo(getBlockId(blockIndex));
   }
 
   /**
-   * Return the creation time of this file
+   * Returns the creation time of this file
    *
    * @return the creation time, in milliseconds
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public long getCreationTimeMs() throws IOException {
     return getCachedFileStatus().getCreationTimeMs();
   }
 
+  /**
+   * @return the replication factor.
+   */
   public int getDiskReplication() {
-    // TODO Implement it.
+    // TODO(hy): Implement it.
     return 3;
   }
 
@@ -140,8 +143,8 @@ public class TachyonFile implements Comparable<TachyonFile> {
    * of the block; otherwise return a {@code FileInStream}.
    *
    * @param readType the InStream's read type
-   * @return the InStream
-   * @throws IOException
+   * @return the <code>InStream</code>
+   * @throws IOException when an event that prevents the operation from completing is encountered
    */
   public InStream getInStream(ReadType readType) throws IOException {
     if (readType == null) {
@@ -176,9 +179,9 @@ public class TachyonFile implements Comparable<TachyonFile> {
    * is no guarantee that the file still exists after this call returns, as Tachyon may evict blocks
    * from memory at any time.
    *
-   * @param blockIndex The index of the block in the file.
-   * @return filename on local file system or null if file not present on local file system.
-   * @throws IOException
+   * @param blockIndex The index of the block in the file
+   * @return filename on local file system or null if file not present on local file system
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public String getLocalFilename(int blockIndex) throws IOException {
     ClientBlockInfo blockInfo = getClientBlockInfo(blockIndex);
@@ -192,10 +195,10 @@ public class TachyonFile implements Comparable<TachyonFile> {
   }
 
   /**
-   * Return the net address of all the location hosts
+   * Returns the net address of all the location hosts
    *
    * @return the list of those net address, in String
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public List<String> getLocationHosts() throws IOException {
     List<String> ret = new ArrayList<String>();
@@ -212,22 +215,22 @@ public class TachyonFile implements Comparable<TachyonFile> {
   }
 
   /**
-   * Return the number of blocks the file has.
+   * Returns the number of blocks the file has.
    *
    * @return the number of blocks
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public int getNumberOfBlocks() throws IOException {
     return getUnCachedFileStatus().getBlockIds().size();
   }
 
   /**
-   * Return the {@code OutStream} of this file, use the specified write type. Always return a
+   * Returns the {@code OutStream} of this file, use the specified write type. Always return a
    * {@code FileOutStream}.
    *
    * @param writeType the OutStream's write type
    * @return the OutStream
-   * @throws IOException
+   * @throws IOException when an event that prevents the operation from completing is encountered
    */
   public OutStream getOutStream(WriteType writeType) throws IOException {
     if (isComplete()) {
@@ -242,17 +245,17 @@ public class TachyonFile implements Comparable<TachyonFile> {
   }
 
   /**
-   * Return the path of this file in the Tachyon file system
+   * Returns the path of this file in the Tachyon file system.
    *
    * @return the path
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public String getPath() throws IOException {
     return getUnCachedFileStatus().getPath();
   }
 
   /**
-   * To get the configuration object for UnderFileSystem.
+   * Gets the configuration object for UnderFileSystem.
    *
    * @return configuration object used for concrete ufs instance
    */
@@ -261,10 +264,10 @@ public class TachyonFile implements Comparable<TachyonFile> {
   }
 
   /**
-   * Return the under filesystem path in the under file system of this file
+   * Returns the under filesystem path in the under file system of this file
    *
    * @return the under filesystem path
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   String getUfsPath() throws IOException {
     ClientFileInfo info = getCachedFileStatus();
@@ -282,10 +285,10 @@ public class TachyonFile implements Comparable<TachyonFile> {
   }
 
   /**
-   * Return whether this file is complete or not
+   * Returns whether this file is complete or not
    *
    * @return true if this file is complete, false otherwise
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public boolean isComplete() throws IOException {
     return getCachedFileStatus().isComplete || getUnCachedFileStatus().isComplete;
@@ -293,7 +296,7 @@ public class TachyonFile implements Comparable<TachyonFile> {
 
   /**
    * @return true if this is a directory, false otherwise
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public boolean isDirectory() throws IOException {
     return getCachedFileStatus().isFolder;
@@ -301,7 +304,7 @@ public class TachyonFile implements Comparable<TachyonFile> {
 
   /**
    * @return true if this is a file, false otherwise
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public boolean isFile() throws IOException {
     return !isDirectory();
@@ -312,7 +315,7 @@ public class TachyonFile implements Comparable<TachyonFile> {
    * value is true only if the file is fully in memory.
    *
    * @return true if the file is fully in memory, false otherwise
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public boolean isInMemory() throws IOException {
     return getUnCachedFileStatus().getInMemoryPercentage() == 100;
@@ -320,7 +323,7 @@ public class TachyonFile implements Comparable<TachyonFile> {
 
   /**
    * @return the file size in bytes
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public long length() throws IOException {
     return getUnCachedFileStatus().getLength();
@@ -328,18 +331,18 @@ public class TachyonFile implements Comparable<TachyonFile> {
 
   /**
    * @return true if this file is pinned, false otherwise
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public boolean needPin() throws IOException {
     return getUnCachedFileStatus().isPinned;
   }
 
   /**
-   * Promote block back to top layer after access
+   * Promotes block back to top layer after access.
    *
    * @param blockIndex the index of the block
    * @return true if success, false otherwise
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   public boolean promoteBlock(int blockIndex) throws IOException {
     ClientBlockInfo blockInfo = getClientBlockInfo(blockIndex);
@@ -349,11 +352,11 @@ public class TachyonFile implements Comparable<TachyonFile> {
   /**
    * Advanced API.
    *
-   * Return a TachyonByteBuffer of the block specified by the blockIndex
+   * Returns a TachyonByteBuffer of the block specified by the blockIndex
    *
    * @param blockIndex The block index of the current file to read.
    * @return TachyonByteBuffer containing the block.
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   @Deprecated
   public TachyonByteBuffer readByteBuffer(int blockIndex) throws IOException {
@@ -372,11 +375,11 @@ public class TachyonFile implements Comparable<TachyonFile> {
   }
 
   /**
-   * Get the the whole block.
+   * Gets the the whole block.
    *
    * @param blockIndex The block index of the current file to read.
    * @return TachyonByteBuffer containing the block.
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   TachyonByteBuffer readLocalByteBuffer(int blockIndex) throws IOException {
     return readLocalByteBuffer(blockIndex, 0, -1);
@@ -385,11 +388,11 @@ public class TachyonFile implements Comparable<TachyonFile> {
   /**
    * Read local block return a TachyonByteBuffer
    *
-   * @param blockIndex The id of the block.
-   * @param offset The start position to read.
-   * @param len The length to read. -1 represents read the whole block.
-   * @return <code>TachyonByteBuffer</code> containing the block.
-   * @throws IOException
+   * @param blockIndex The id of the block
+   * @param offset The start position to read
+   * @param len The length to read. -1 represents read the whole block
+   * @return <code>TachyonByteBuffer</code> containing the block
+   * @throws IOException when the offset is negative is the length is less than -1
    */
   private TachyonByteBuffer readLocalByteBuffer(int blockIndex, long offset, long len)
       throws IOException {
@@ -449,9 +452,9 @@ public class TachyonFile implements Comparable<TachyonFile> {
   /**
    * Get the the whole block from remote workers.
    *
-   * @param blockInfo The blockInfo of the block to read.
-   * @return TachyonByteBuffer containing the block.
-   * @throws IOException if the underlying stream throws IOException during close().
+   * @param blockInfo The blockInfo of the block to read
+   * @return TachyonByteBuffer containing the block
+   * @throws IOException if the underlying stream throws IOException during close()
    */
   TachyonByteBuffer readRemoteByteBuffer(ClientBlockInfo blockInfo) throws IOException {
     // Create a dummy RemoteBlockInstream object.
@@ -472,7 +475,14 @@ public class TachyonFile implements Comparable<TachyonFile> {
     return new TachyonByteBuffer(mTachyonFS, outBuf, blockInfo.blockId, -1);
   }
 
-  // TODO remove this method. do streaming cache. This is not a right API.
+  /**
+   * Re-caches this file into memory.
+   *
+   * TODO(hy): remove this method. do streaming cache. This is not a right API.
+   *
+   * @return true if succeed, false otherwise
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
+   */
   public boolean recache() throws IOException {
     int numberOfBlocks = getNumberOfBlocks();
     if (numberOfBlocks == 0) {
@@ -488,11 +498,11 @@ public class TachyonFile implements Comparable<TachyonFile> {
   }
 
   /**
-   * Re-cache the block into memory
+   * Re-caches the given block into memory.
    *
-   * @param blockIndex The block index of the current file.
+   * @param blockIndex The block index of the current file
    * @return true if succeed, false otherwise
-   * @throws IOException
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted
    */
   boolean recache(int blockIndex) throws IOException {
     String path = getUfsPath();
@@ -540,11 +550,11 @@ public class TachyonFile implements Comparable<TachyonFile> {
   }
 
   /**
-   * Rename this file
+   * Renames this file.
    *
    * @param path the new name
    * @return true if succeed, false otherwise
-   * @throws IOException
+   * @throws IOException if an event that prevent the operation from completing is encountered
    */
   public boolean rename(TachyonURI path) throws IOException {
     return mTachyonFS.rename(mFileId, path);
@@ -552,9 +562,9 @@ public class TachyonFile implements Comparable<TachyonFile> {
 
   /**
    * To set the configuration object for UnderFileSystem. The conf object is understood by the
-   * concrete underfs' implementation.
+   * concrete under file system implementation.
    *
-   * @param conf The configuration object accepted by ufs.
+   * @param conf The configuration object accepted by ufs
    */
   public void setUFSConf(Object conf) {
     mUFSConf = conf;

--- a/clients/unshaded/src/main/java/tachyon/client/UfsUtils.java
+++ b/clients/unshaded/src/main/java/tachyon/client/UfsUtils.java
@@ -41,8 +41,9 @@ public class UfsUtils {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /**
-   * Build a new path relative to a given mTachyonFS root by retrieving the given path relative to
+   * Builds a new path relative to a given mTachyonFS root by retrieving the given path relative to
    * the ufsRootPath.
+   *
    * @param tfsRootPath the destination point in mTachyonFS to load the under FS path onto
    * @param ufsRootPath the source path in the under FS to be loaded
    * @param path the path in the under FS be loaded, path.startsWith(ufsRootPath) must be true
@@ -60,7 +61,7 @@ public class UfsUtils {
   }
 
   /**
-   * Load files under path "ufsAddrRootPath" (excluding excludePathPrefix relative to the path) to
+   * Loads files under path "ufsAddrRootPath" (excluding excludePathPrefix relative to the path) to
    * the given tfs under a given destination path.
    *
    * @param tfsAddrRootPath the mTachyonFS address and path to load the src files, like
@@ -68,7 +69,7 @@ public class UfsUtils {
    * @param ufsAddrRootPath the address and root path of the under FS, like "hdfs://host:port/src".
    * @param excludePaths paths to exclude from ufsRootPath, which will not be loaded in mTachyonFS.
    * @param tachyonConf the instance of {@link tachyon.conf.TachyonConf} to be used.
-   * @throws IOException
+   * @throws IOException when an event that prevents the operation from completing is encountered
    */
   private static void loadUfs(TachyonURI tfsAddrRootPath, TachyonURI ufsAddrRootPath,
       String excludePaths, TachyonConf tachyonConf) throws IOException {
@@ -80,7 +81,7 @@ public class UfsUtils {
   }
 
   /**
-   * Load files under path "ufsAddress/ufsRootPath" (excluding excludePathPrefix) to the given tfs
+   * Loads files under path "ufsAddress/ufsRootPath" (excluding excludePathPrefix) to the given tfs
    * under the given tfsRootPath directory.
    *
    * @param tfs the mTachyonFS handler created out of address like "tachyon://host:port"
@@ -89,7 +90,7 @@ public class UfsUtils {
    * @param excludePathPrefix paths to exclude from ufsRootPath, which will not be registered in
    *        mTachyonFS.
    * @param tachyonConf instance of TachyonConf
-   * @throws IOException
+   * @throws IOException when an event that prevents the operation from completing is encountered
    */
   public static void loadUnderFs(TachyonFS tfs, TachyonURI tachyonPath, TachyonURI ufsAddrRootPath,
       PrefixList excludePathPrefix, TachyonConf tachyonConf) throws IOException {
@@ -138,7 +139,7 @@ public class UfsUtils {
         LOG.debug("Loading ufs. Make dir if needed for '" + directoryName + "'.");
         tfs.mkdir(directoryName);
       }
-      // TODO Add the following.
+      // TODO(hy): Add the following.
       // if (tfs.mkdir(tfsRootPath)) {
       // LOG.info("directory " + tfsRootPath + " does not exist in Tachyon: created");
       // } else {
@@ -154,7 +155,7 @@ public class UfsUtils {
     while (!ufsPathQueue.isEmpty()) {
       TachyonURI ufsPath = ufsPathQueue.poll(); // this is the absolute path
       LOG.info("Loading: " + ufsPath);
-      if (ufs.isFile(ufsPath.toString())) { // TODO: Fix path matching issue
+      if (ufs.isFile(ufsPath.toString())) { // TODO(hy): Fix path matching issue.
         TachyonURI tfsPath = buildTFSPath(directoryName, ufsAddrRootPath, ufsPath);
         LOG.debug("Loading ufs. tfs path = " + tfsPath + ".");
         if (tfs.exist(tfsPath)) {
@@ -197,7 +198,7 @@ public class UfsUtils {
           LOG.debug("Loading ufs. ufs path is a directory. make dir = "
                   + tfsPath + ".");
           tfs.mkdir(tfsPath);
-          // TODO Add the following.
+          // TODO(hy): Add the following.
           // if (tfs.mkdir(tfsPath)) {
           // LOG.info("Created mTachyonFS folder " + tfsPath + " with checkpoint location " +
           // ufsPath);

--- a/clients/unshaded/src/main/java/tachyon/client/WriteType.java
+++ b/clients/unshaded/src/main/java/tachyon/client/WriteType.java
@@ -28,7 +28,7 @@ public enum WriteType {
    */
   TRY_CACHE(2),
   /**
-   * Write the file synchronously to the under fs, and also try to cache it,
+   * Write the file synchronously to the under fs, and also try to cache it.
    */
   CACHE_THROUGH(3),
   /**
@@ -48,8 +48,6 @@ public enum WriteType {
   }
 
   /**
-   * Return the value of the write type
-   *
    * @return the value of the write type
    */
   public int getValue() {

--- a/clients/unshaded/src/main/java/tachyon/client/netty/ClientHandler.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/ClientHandler.java
@@ -46,14 +46,27 @@ public final class ClientHandler extends SimpleChannelInboundHandler<RPCMessage>
 
   private final HashSet<ResponseListener> mListeners;
 
+  /**
+   * Creates a new <code>ClientHandler</code>.
+   */
   public ClientHandler() {
     mListeners = new HashSet<ResponseListener>(4);
   }
 
+  /**
+   * Adds a <code>ResponseListener</code> listener to the client handler.
+   *
+   * @param listener the listener to add
+   */
   public void addListener(ResponseListener listener) {
     mListeners.add(listener);
   }
 
+  /**
+   * Removes a <code>ResponseListener</code> listener from the client handler.
+   *
+   * @param listener the listener to remove
+   */
   public void removeListener(ResponseListener listener) {
     mListeners.remove(listener);
   }

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -49,7 +49,7 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
   /**
    * Creates a new <code>NettyRemoteBlockReader</code>.
    *
-   * TODO: Creating a new remote block reader may be expensive, so consider a connection pool.
+   * TODO(gene): Creating a new remote block reader may be expensive, so consider a connection pool.
    */
   public NettyRemoteBlockReader() {
     mHandler = new ClientHandler();

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockReader.java
@@ -43,10 +43,14 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
 
   private final Bootstrap mClientBootstrap;
   private final ClientHandler mHandler;
-  /** A reference to read response so we can explicitly release the resource after reading.*/
+  /** A reference to read response so we can explicitly release the resource after reading. */
   private RPCBlockReadResponse mReadResponse = null;
 
-  // TODO: Creating a new remote block reader may be expensive, so consider a connection pool.
+  /**
+   * Creates a new <code>NettyRemoteBlockReader</code>.
+   *
+   * TODO: Creating a new remote block reader may be expensive, so consider a connection pool.
+   */
   public NettyRemoteBlockReader() {
     mHandler = new ClientHandler();
     mClientBootstrap = NettyClient.createClientBootstrap(mHandler);
@@ -94,6 +98,8 @@ public final class NettyRemoteBlockReader implements RemoteBlockReader {
   }
 
   /**
+   * {@inheritDoc}
+   *
    * Release the underlying buffer of previous/current read response.
    */
   @Override

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockWriter.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockWriter.java
@@ -52,6 +52,9 @@ public final class NettyRemoteBlockWriter implements RemoteBlockWriter {
   // Total number of bytes written to the remote block.
   private long mWrittenBytes;
 
+  /**
+   * Creates a new <code>NettyRemoteBlockWrite</code>.
+   */
   public NettyRemoteBlockWriter() {
     mHandler = new ClientHandler();
     mClientBootstrap = NettyClient.createClientBootstrap(mHandler);

--- a/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockWriter.java
+++ b/clients/unshaded/src/main/java/tachyon/client/netty/NettyRemoteBlockWriter.java
@@ -85,7 +85,7 @@ public final class NettyRemoteBlockWriter implements RemoteBlockWriter {
   public void write(byte[] bytes, int offset, int length) throws IOException {
     SingleResponseListener listener = new SingleResponseListener();
     try {
-      // TODO: keep connection open across multiple write calls.
+      // TODO(hy): keep connection open across multiple write calls.
       ChannelFuture f = mClientBootstrap.connect(mAddress).sync();
 
       LOG.info("Connected to remote machine " + mAddress);

--- a/clients/unshaded/src/main/java/tachyon/client/table/RawColumn.java
+++ b/clients/unshaded/src/main/java/tachyon/client/table/RawColumn.java
@@ -47,7 +47,7 @@ public class RawColumn {
   /**
    * Creates a new column partition.
    *
-   * TODO: creating file here should be based on id.
+   * TODO(hy): creating file here should be based on id.
    *
    * @param pId the partition id
    * @return whether operation succeeded
@@ -63,7 +63,7 @@ public class RawColumn {
   /**
    * Gets an existing partition.
    *
-   * TODO: creating file here should be based on id.
+   * TODO(hy): creating file here should be based on id.
    *
    * @param pId the partition id
    * @return <code>TachyonFile</code> with the given partition
@@ -76,7 +76,7 @@ public class RawColumn {
   /**
    * Gets an existing partition.
    *
-   * TODO: creating file here should be based on id.
+   * TODO(hy): creating file here should be based on id.
    *
    * @param pId the partition id
    * @param cachedMetadata whether to use the file metadata cache
@@ -93,7 +93,7 @@ public class RawColumn {
   /**
    * Identifies the number of column partitions.
    *
-   * TODO: creating file here should be based on id.
+   * TODO(hy): creating file here should be based on id.
    *
    * @return the number of column partitions
    * @throws IOException when any of the partition paths is invalid or points to a non-existing

--- a/clients/unshaded/src/main/java/tachyon/client/table/RawColumn.java
+++ b/clients/unshaded/src/main/java/tachyon/client/table/RawColumn.java
@@ -32,9 +32,11 @@ public class RawColumn {
   private final int mColumnIndex;
 
   /**
-   * @param tachyonClient
-   * @param rawTable
-   * @param columnIndex
+   * Creates a new <code>RawColumn</code>.
+   *
+   * @param tachyonClient the <code>TachyonFS</code> client
+   * @param rawTable the <code>RawTable</code> table this column belongs to
+   * @param columnIndex the column index
    */
   RawColumn(TachyonFS tachyonClient, RawTable rawTable, int columnIndex) {
     mTachyonFS = tachyonClient;
@@ -42,7 +44,13 @@ public class RawColumn {
     mColumnIndex = columnIndex;
   }
 
-  // TODO creating file here should be based on id.
+  /**
+   * Creates a new column partition. TODO creating file here should be based on id.
+   *
+   * @param pId the partition id
+   * @return whether operation succeeded
+   * @throws IOException when the partition the path is invalid or points to an existing object
+   */
   public boolean createPartition(int pId) throws IOException {
     TachyonURI tUri =
         new TachyonURI(PathUtils.concatPath(mRawTable.getPath(),
@@ -50,12 +58,25 @@ public class RawColumn {
     return mTachyonFS.createFile(tUri) > 0;
   }
 
-  // TODO creating file here should be based on id.
+  /**
+   * Gets an existing partition. TODO creating file here should be based on id.
+   *
+   * @param pId the partition id
+   * @return <code>TachyonFile</code> with the given partition
+   * @throws IOException when the partition the path is invalid or points to a non-existing object
+   */
   public TachyonFile getPartition(int pId) throws IOException {
     return getPartition(pId, false);
   }
 
-  // TODO creating file here should be based on id.
+  /**
+   * Gets an existing partition. TODO creating file here should be based on id.
+   *
+   * @param pId the partition id
+   * @param cachedMetadata whether to use the file metadata cache
+   * @return <code>TachyonFile</code> with the given partition
+   * @throws IOException when the partition the path is invalid or points to a non-existing object
+   */
   public TachyonFile getPartition(int pId, boolean cachedMetadata) throws IOException {
     TachyonURI tUri =
         new TachyonURI(PathUtils.concatPath(mRawTable.getPath(),
@@ -63,7 +84,13 @@ public class RawColumn {
     return mTachyonFS.getFile(tUri, cachedMetadata);
   }
 
-  // TODO creating file here should be based on id.
+  /**
+   * Identifies the number of column partitions. TODO creating file here should be based on id.
+   *
+   * @return the number of column partitions
+   * @throws IOException when any of the partition paths is invalid or points to a non-existing
+   *         object
+   */
   public int partitions() throws IOException {
     TachyonURI tUri =
         new TachyonURI(PathUtils.concatPath(mRawTable.getPath(),

--- a/clients/unshaded/src/main/java/tachyon/client/table/RawColumn.java
+++ b/clients/unshaded/src/main/java/tachyon/client/table/RawColumn.java
@@ -45,7 +45,9 @@ public class RawColumn {
   }
 
   /**
-   * Creates a new column partition. TODO creating file here should be based on id.
+   * Creates a new column partition.
+   *
+   * TODO: creating file here should be based on id.
    *
    * @param pId the partition id
    * @return whether operation succeeded
@@ -59,7 +61,9 @@ public class RawColumn {
   }
 
   /**
-   * Gets an existing partition. TODO creating file here should be based on id.
+   * Gets an existing partition.
+   *
+   * TODO: creating file here should be based on id.
    *
    * @param pId the partition id
    * @return <code>TachyonFile</code> with the given partition
@@ -70,7 +74,9 @@ public class RawColumn {
   }
 
   /**
-   * Gets an existing partition. TODO creating file here should be based on id.
+   * Gets an existing partition.
+   *
+   * TODO: creating file here should be based on id.
    *
    * @param pId the partition id
    * @param cachedMetadata whether to use the file metadata cache
@@ -85,7 +91,9 @@ public class RawColumn {
   }
 
   /**
-   * Identifies the number of column partitions. TODO creating file here should be based on id.
+   * Identifies the number of column partitions.
+   *
+   * TODO: creating file here should be based on id.
    *
    * @return the number of column partitions
    * @throws IOException when any of the partition paths is invalid or points to a non-existing

--- a/clients/unshaded/src/main/java/tachyon/client/table/RawTable.java
+++ b/clients/unshaded/src/main/java/tachyon/client/table/RawTable.java
@@ -33,8 +33,10 @@ public class RawTable {
   private final ClientRawTableInfo mClientRawTableInfo;
 
   /**
-   * @param tachyonClient
-   * @param clientRawTableInfo
+   * Creates a new <code>RawTable</code>
+   *
+   * @param tachyonClient the <code>TachyonFS</code> client
+   * @param clientRawTableInfo information describing the table
    */
   public RawTable(TachyonFS tachyonClient, ClientRawTableInfo clientRawTableInfo) {
     mTachyonFS = tachyonClient;
@@ -77,7 +79,7 @@ public class RawTable {
   }
 
   /**
-   * Get one column of the raw table
+   * Get one column of the raw table.
    *
    * @param columnIndex the index of the column
    * @return the RawColumn
@@ -94,7 +96,7 @@ public class RawTable {
    * Update the meta data of the raw table
    *
    * @param metadata the new meta data
-   * @throws IOException
+   * @throws IOException if an event that prevents the metadata from being updated is encountered.
    */
   public void updateMetadata(ByteBuffer metadata) throws IOException {
     mTachyonFS.updateRawTableMetadata(mClientRawTableInfo.getId(), metadata);

--- a/common/src/main/java/tachyon/master/MasterClient.java
+++ b/common/src/main/java/tachyon/master/MasterClient.java
@@ -671,7 +671,7 @@ public final class MasterClient implements Closeable {
    *
    * @param blockId the id of the block
    * @return the ClientBlockInfo of the specified block
-   * @throws IOException if the file does not exist or its block information is corrupted.
+   * @throws IOException if the underlying file does not exist or its metadata is corrupted.
    */
   public synchronized ClientBlockInfo user_getClientBlockInfo(long blockId) throws IOException {
     while (!mIsClosed) {


### PR DESCRIPTION
Some public methods in the tachyon.client.* package are not completely documented (e.g. method, @param, @throws descriptions). This PR makes sure that all JavaDoc contain the required @param and @throws description, use a consistent style, and all TODOs are tagged with their author.
