### PR TITLE
[SMALLFIX] Fixing broken HTTP links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tachyon
 
 The master branch is in version 0.8.0-SNAPSHOT:
 
-- [Tachyon Website](http://www.tachyonproject.org/) | [Tachyon Document](http://www.tachyonproject.org/documentation/) | [Master Branch Document](http://tachyon-project.org/documentation/master/)
+- [Tachyon Website](http://www.tachyon-project.org/) | [Tachyon Document](http://www.tachyon-project.org/documentation/) | [Master Branch Document](http://tachyon-project.org/documentation/master/)
 - [Contribute to Tachyon](http://tachyon-project.org/documentation/Contributing-to-Tachyon.html) and
 [New Contributor's Tasks](https://tachyon.atlassian.net/issues/?jql=project%20%3D%20TACHYON%20AND%20labels%20%3D%20NewContributor%20AND%20status%20%3D%20Open)
   - Please limit 2 tasks per new contributor. Afterwards, try some [beginner tasks](https://tachyon.atlassian.net/issues/?jql=project%20%3D%20TACHYON%20AND%20labels%20%3D%20Beginner%20AND%20status%20%3D%20Open) or [intermediate tasks](https://tachyon.atlassian.net/issues/?jql=project%20%3D%20TACHYON%20AND%20labels%20%3D%20Intermediate%20AND%20status%20%3D%20Open),

--- a/assembly/README.md
+++ b/assembly/README.md
@@ -24,4 +24,4 @@ should be included.
 ## Usage
 
 For more details on how to use the generated tar, go
-[to the docs](http://tachyon-project.org/Running-Tachyon-Locally.html).
+[to the docs](http://tachyon-project.org/documentation/Running-Tachyon-Locally.html).

--- a/deploy/vagrant/README.md
+++ b/deploy/vagrant/README.md
@@ -1,4 +1,4 @@
-This doc is for contributors on deploy module, for users, please go to the [online doc](http://tachyon-project.org/master/Deploy-Module.html).
+This doc is for contributors on deploy module, for users, please go to the [online doc](http://tachyon-project.org/documentation/master/Deploy-Module.html).
 
 ## Tools
 

--- a/docs/Running-Shark-on-Tachyon.md
+++ b/docs/Running-Shark-on-Tachyon.md
@@ -10,7 +10,7 @@ We also assume that the user has set up Tachyon and Hadoop in accordance to thes
 [Local Mode](Running-Tachyon-Locally.html) or [Cluster Mode](Running-Tachyon-on-a-Cluster.html).
 
 Shark 0.7 adds a new storage format to support efficiently reading data from
-[Tachyon](http://tachyonproject.org), which enables data sharing and isolation across instances of
+[Tachyon](http://tachyon-project.org), which enables data sharing and isolation across instances of
 Shark. Our meetup [slide](http://goo.gl/fVmxCG) gives a good overview of the benefits of using
 Tachyon to cache Shark's tables. In summary, the followings are four major ones:
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <packaging>pom</packaging>
   <name>Tachyon Parent</name>
   <description>Parent POM of Tachyon project: a Reliable Memory Centric Distributed Storage System</description>
-  <url>http://tachyonproject.org/</url>
+  <url>http://tachyon-project.org/</url>
   <licenses>
     <license>
       <name>Apache License</name>


### PR DESCRIPTION
This PR fixes HTTP links that were broken after adding the "documentation" component to the URL path for most Tachyon project pages. Also, for consistency this PR changes instances of tachyonproject.org to tachyon-project.org.