### PR TITLE
[TACHYON-934] Made TachyonFileSystem methods throw better exceptions

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
@@ -17,6 +17,8 @@ package tachyon.client;
 
 import java.io.IOException;
 
+import org.apache.thrift.TException;
+
 import tachyon.Constants;
 import tachyon.TachyonURI;
 import tachyon.conf.TachyonConf;
@@ -62,7 +64,11 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
       throw new IOException("Block size must be less than 2GB: " + blockSizeByte);
     }
 
-    return createFile(path, TachyonURI.EMPTY_URI, blockSizeByte, true);
+    try {
+      return createFile(path, TachyonURI.EMPTY_URI, blockSizeByte, true);
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 
   /**
@@ -77,7 +83,11 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
    * @throws IOException If file already exists, or path is invalid.
    */
   public synchronized int createFile(TachyonURI path, TachyonURI ufsPath) throws IOException {
-    return createFile(path, ufsPath, -1, true);
+    try {
+      return createFile(path, ufsPath, -1, true);
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 
   /**
@@ -90,7 +100,11 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
    * @throws IOException
    */
   public synchronized boolean delete(long fid, boolean recursive) throws IOException {
-    return delete(fid, TachyonURI.EMPTY_URI, recursive);
+    try {
+      return delete(fid, TachyonURI.EMPTY_URI, recursive);
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 
   /**
@@ -103,7 +117,11 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
    * @throws IOException
    */
   public synchronized boolean delete(TachyonURI path, boolean recursive) throws IOException {
-    return delete(-1, path, recursive);
+    try {
+      return delete(-1, path, recursive);
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 
   /**
@@ -115,7 +133,11 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
    * @throws IOException
    */
   public synchronized boolean mkdir(TachyonURI path) throws IOException {
-    return mkdirs(path, true);
+    try {
+      return mkdirs(path, true);
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 
   /**
@@ -127,7 +149,11 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
    * @throws IOException
    */
   public synchronized boolean rename(long fileId, TachyonURI dstPath) throws IOException {
-    return rename(fileId, TachyonURI.EMPTY_URI, dstPath);
+    try {
+      return rename(fileId, TachyonURI.EMPTY_URI, dstPath);
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 
   /**
@@ -139,7 +165,11 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
    * @throws IOException
    */
   public synchronized boolean rename(TachyonURI srcPath, TachyonURI dstPath) throws IOException {
-    return rename(-1, srcPath, dstPath);
+    try {
+      return rename(-1, srcPath, dstPath);
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 
  /**
@@ -152,6 +182,10 @@ abstract class AbstractTachyonFS implements TachyonFSCore {
   * @throws IOException
   */
   public synchronized boolean freepath(TachyonURI path, boolean recursive) throws IOException {
-    return freepath(-1, path, recursive);
+    try {
+      return freepath(-1, path, recursive);
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -312,7 +312,7 @@ public class TachyonFS extends AbstractTachyonFS {
       String commandPrefix, List<ByteBuffer> data, String comment, String framework,
       String frameworkVersion, int dependencyType, long childrenBlockSizeByte) throws IOException {
     return mFSMasterClient.user_createDependency(parents, children, commandPrefix, data, comment,
-            framework, frameworkVersion, dependencyType, childrenBlockSizeByte);
+        framework, frameworkVersion, dependencyType, childrenBlockSizeByte);
   }
 
   /**

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFSCore.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFSCore.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -20,7 +20,11 @@ import java.io.IOException;
 import java.util.List;
 
 import tachyon.TachyonURI;
+import tachyon.thrift.BlockInfoException;
+import tachyon.thrift.FileAlreadyExistException;
+import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.FileInfo;
+import tachyon.thrift.InvalidPathException;
 
 /**
  * Interface for Tachyon client APIs
@@ -39,7 +43,8 @@ interface TachyonFSCore extends Closeable {
    * @return The file id, which is globally unique.
    */
   int createFile(TachyonURI path, TachyonURI ufsPath, long blockSizeByte, boolean recursive)
-      throws IOException;
+      throws IOException, InvalidPathException, FileAlreadyExistException, BlockInfoException,
+      FileDoesNotExistException;
 
   /**
    * Deletes a file or folder.
@@ -51,9 +56,9 @@ interface TachyonFSCore extends Closeable {
    *        or not
    * @return true if deletes successfully, false otherwise.
    * @throws IOException when the operation fails
-
    */
-  boolean delete(long fileId, TachyonURI path, boolean recursive) throws IOException;
+  boolean delete(long fileId, TachyonURI path, boolean recursive) throws IOException,
+      InvalidPathException;
 
   /**
    * Gets the FileInfo object that represents the fileId, or the path if fileId is -1.
@@ -63,7 +68,8 @@ interface TachyonFSCore extends Closeable {
    * @return the FileInfo of the file or folder, null if the file or folder does not exist.
    * @throws IOException when the operation fails
    */
-  FileInfo getFileStatus(long fileId, TachyonURI path) throws IOException;
+  FileInfo getFileStatus(long fileId, TachyonURI path) throws IOException, InvalidPathException,
+      FileDoesNotExistException;
 
   /** Returns a URI whose scheme and authority identify this FileSystem. */
   TachyonURI getUri();
@@ -76,7 +82,8 @@ interface TachyonFSCore extends Closeable {
    * @return A list of FileInfo, null if the file or folder does not exist.
    * @throws IOException when the operation fails
    */
-  List<FileInfo> listStatus(TachyonURI path) throws IOException;
+  List<FileInfo> listStatus(TachyonURI path) throws IOException, InvalidPathException,
+      FileDoesNotExistException;
 
   /**
    * Creates a folder.
@@ -86,7 +93,8 @@ interface TachyonFSCore extends Closeable {
    * @return true if the folder is created successfully or already existing. false otherwise.
    * @throws IOException when the operation fails
    */
-  boolean mkdirs(TachyonURI path, boolean recursive) throws IOException;
+  boolean mkdirs(TachyonURI path, boolean recursive) throws IOException, FileAlreadyExistException,
+      InvalidPathException;
 
   /**
    * Renames a file or folder to another path.
@@ -98,18 +106,20 @@ interface TachyonFSCore extends Closeable {
    * @return true if renames successfully, false otherwise.
    * @throws IOException when the operation fails
    */
-  boolean rename(long fileId, TachyonURI srcPath, TachyonURI dstPath) throws IOException;
+  boolean rename(long fileId, TachyonURI srcPath, TachyonURI dstPath) throws IOException,
+      InvalidPathException, FileDoesNotExistException;
 
- /**
-  * Frees memory of a file or folder.
-  *
-  * @param fileId The id of the file / folder. If it is not -1, path parameter is ignored.
-  *        Otherwise, the method uses the path parameter.
-  * @param path The path of the file / folder. It could be empty iff id is not -1.
-  * @param recursive If fileId or path represents a non-empty folder, free the folder recursively
-  *        or not
-  * @return true if in-memory free successfully, false otherwise.
-  * @throws IOException when the operation fails
-  */
-  boolean freepath(long fileId, TachyonURI path, boolean recursive) throws IOException;
+  /**
+   * Frees memory of a file or folder.
+   *
+   * @param fileId The id of the file / folder. If it is not -1, path parameter is ignored.
+   *        Otherwise, the method uses the path parameter.
+   * @param path The path of the file / folder. It could be empty iff id is not -1.
+   * @param recursive If fileId or path represents a non-empty folder, free the folder recursively
+   *        or not
+   * @return true if in-memory free successfully, false otherwise.
+   * @throws IOException when the operation fails
+   */
+  boolean freepath(long fileId, TachyonURI path, boolean recursive) throws IOException,
+      InvalidPathException, FileDoesNotExistException;
 }

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFSTestUtils.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFSTestUtils.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -18,6 +18,8 @@ package tachyon.client;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.thrift.TException;
 
 import tachyon.TachyonURI;
 import tachyon.client.file.FileOutStream;
@@ -71,16 +73,22 @@ public final class TachyonFSTestUtils {
    */
   public static TachyonFile createByteFile(TachyonFileSystem tfs, TachyonURI fileURI,
       CacheType cacheType, UnderStorageType underStorageType, int len) throws IOException {
-    ClientOptions options =
-        new ClientOptions.Builder(ClientContext.getConf()).setCacheType(cacheType)
-            .setUnderStorageType(underStorageType).build();
-    FileOutStream os = tfs.getOutStream(fileURI, options);
+    try {
+      ClientOptions options =
+          new ClientOptions.Builder(ClientContext.getConf()).setCacheType(cacheType)
+              .setUnderStorageType(underStorageType).build();
+      FileOutStream os = tfs.getOutStream(fileURI, options);
 
-    for (int k = 0; k < len; k ++) {
-      os.write((byte) k);
+      byte[] arr = new byte[len];
+      for (int k = 0; k < len; k ++) {
+        arr[k] = (byte) k;
+      }
+      os.write(arr);
+      os.close();
+      return tfs.open(fileURI);
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
     }
-    os.close();
-    return tfs.open(fileURI);
   }
 
   /**
@@ -98,16 +106,20 @@ public final class TachyonFSTestUtils {
   public static TachyonFile createByteFile(TachyonFileSystem tfs, String fileName,
       CacheType cacheType, UnderStorageType underStorageType, int len, long blockCapacityByte)
       throws IOException {
-    ClientOptions options =
-        new ClientOptions.Builder(ClientContext.getConf()).setCacheType(cacheType)
-            .setUnderStorageType(underStorageType).setBlockSize(blockCapacityByte).build();
-    FileOutStream os = tfs.getOutStream(new TachyonURI(fileName), options);
+    try {
+      ClientOptions options =
+          new ClientOptions.Builder(ClientContext.getConf()).setCacheType(cacheType)
+              .setUnderStorageType(underStorageType).setBlockSize(blockCapacityByte).build();
+      FileOutStream os = tfs.getOutStream(new TachyonURI(fileName), options);
 
-    for (int k = 0; k < len; k ++) {
-      os.write((byte) k);
+      for (int k = 0; k < len; k ++) {
+        os.write((byte) k);
+      }
+      os.close();
+      return tfs.open(new TachyonURI(fileName));
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
     }
-    os.close();
-    return tfs.open(new TachyonURI(fileName));
   }
 
   /**
@@ -119,17 +131,21 @@ public final class TachyonFSTestUtils {
    * @throws IOException if <code>path</code> does not exist or is invalid
    */
   public static List<String> listFiles(TachyonFileSystem tfs, String path) throws IOException {
-    List<FileInfo> infos = tfs.listStatus(tfs.open(new TachyonURI(path)));
-    List<String> res = new ArrayList<String>();
-    for (FileInfo info : infos) {
-      res.add(info.getPath());
+    try {
+      List<FileInfo> infos = tfs.listStatus(tfs.open(new TachyonURI(path)));
+      List<String> res = new ArrayList<String>();
+      for (FileInfo info : infos) {
+        res.add(info.getPath());
 
-      if (info.isFolder) {
-        res.addAll(listFiles(tfs, info.getPath()));
+        if (info.isFolder) {
+          res.addAll(listFiles(tfs, info.getPath()));
+        }
       }
-    }
 
-    return res;
+      return res;
+    } catch (TException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 
 }

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
@@ -29,7 +29,9 @@ import tachyon.client.file.FileOutStream;
 import tachyon.client.file.TachyonFileSystem;
 import tachyon.conf.TachyonConf;
 import tachyon.thrift.FileBlockInfo;
+import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.FileInfo;
+import tachyon.thrift.InvalidPathException;
 import tachyon.thrift.NetAddress;
 
 /**
@@ -167,7 +169,13 @@ public class TachyonFile implements Comparable<TachyonFile> {
     } else {
       optionsBuilder.setCacheType(CacheType.NO_CACHE);
     }
-    return mTFS.getInStream(mTFS.open(uri), optionsBuilder.build());
+    try {
+      return mTFS.getInStream(mTFS.open(uri), optionsBuilder.build());
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    } catch (FileDoesNotExistException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 
   /**

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFSCore.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFSCore.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -19,7 +19,10 @@ import java.io.IOException;
 import java.util.List;
 
 import tachyon.TachyonURI;
+import tachyon.thrift.FileAlreadyExistException;
+import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.FileInfo;
+import tachyon.thrift.InvalidPathException;
 
 /**
  * User facing interface for the Tachyon File System client APIs. File refers to any type of inode,
@@ -40,18 +43,20 @@ interface TachyonFSCore {
    * removed. If the file is a folder, its contents will be freed recursively.
    *
    * @param file the handler for the file
-   * @throws IOException if the master is unable to free the file
+   * @throws FileDoesNotExistException if the file does not exist
+   * @throws IOException if the master is unable to free the file for some other reason
    */
-  void free(TachyonFile file) throws IOException;
+  void free(TachyonFile file) throws IOException, FileDoesNotExistException;
 
   /**
    * Gets the FileInfo object that represents the Tachyon file
    *
    * @param file the handler for the file.
    * @return the FileInfo of the file, null if the file does not exist.
-   * @throws IOException if the master is unable to obtain the file's metadata
+   * @throws FileDoesNotExistException if the file does not exist
+   * @throws IOException if the master cannot retrieve the file's metadata for some other reason
    */
-  FileInfo getInfo(TachyonFile file) throws IOException;
+  FileInfo getInfo(TachyonFile file) throws IOException, FileDoesNotExistException;
 
   /**
    * If the file is a folder, returns the {@link FileInfo} of all the direct entries in it.
@@ -59,18 +64,22 @@ interface TachyonFSCore {
    *
    * @param file the handler for the file
    * @return a list of FileInfos representing the files which are children of the given file
-   * @throws IOException if the file does not exist
+   * @throws FileDoesNotExistException if the file does not exist
+   * @throws IOException if the master cannot retrieve the file status for some other reason
    */
-  List<FileInfo> listStatus(TachyonFile file) throws IOException;
+  List<FileInfo> listStatus(TachyonFile file) throws IOException, FileDoesNotExistException;
 
   /**
    * Creates a folder. If the parent folders do not exist, they will be created automatically.
    *
    * @param path the handler for the file
    * @return true if the folder is created successfully or already existing, false otherwise.
+   * @throws InvalidPathException if the provided path is invalid
+   * @throws FileAlreadyExistException if there is already a file at the given path
    * @throws IOException if the master cannot create the folder under the specified path
    */
-  boolean mkdirs(TachyonURI path) throws IOException;
+  boolean mkdirs(TachyonURI path) throws IOException, InvalidPathException,
+      FileAlreadyExistException;
 
   /**
    * Resolves a {@link TachyonURI} to a {@link TachyonFile} which is used as the file handler for
@@ -78,9 +87,10 @@ interface TachyonFSCore {
    *
    * @param path the path of the file, this should be in Tachyon space
    * @return a TachyonFile which acts as a file handler for the path
+   * @throws InvalidPathException if the provided path is invalid
    * @throws IOException if the path does not exist in Tachyon space
    */
-  TachyonFile open(TachyonURI path) throws IOException;
+  TachyonFile open(TachyonURI path) throws IOException, InvalidPathException;
 
   /**
    * Renames an existing file in Tachyon space to another path in Tachyon space.
@@ -88,7 +98,8 @@ interface TachyonFSCore {
    * @param src The file handler for the source file
    * @param dst The path of the destination file, this path should not exist
    * @return true if successful, false otherwise
+   * @throws FileDoesNotExistException if the source file does not exist
    * @throws IOException if the destination already exists or is invalid
    */
-  boolean rename(TachyonFile src, TachyonURI dst) throws IOException;
+  boolean rename(TachyonFile src, TachyonURI dst) throws IOException, FileDoesNotExistException;
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
@@ -22,7 +22,11 @@ import java.util.List;
 import tachyon.TachyonURI;
 import tachyon.client.FileSystemMasterClient;
 import tachyon.client.ClientOptions;
+import tachyon.thrift.BlockInfoException;
+import tachyon.thrift.FileAlreadyExistException;
+import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.FileInfo;
+import tachyon.thrift.InvalidPathException;
 
 /**
  * Tachyon File System client. This class is the entry point for all file level operations on
@@ -84,15 +88,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Removes the file from Tachyon Storage. The underlying under storage system file will not be
-   * removed. If the file is a folder, its contents will be freed recursively. This method is
-   * asynchronous and will be propagated to the workers through their heartbeats.
-   *
-   * @param file the handler for the file
-   * @throws IOException if the master is unable to free the file
+   * {@inheritDoc} This method is asynchronous and will be propagated to the workers through their
+   * heartbeats.
    */
   @Override
-  public void free(TachyonFile file) throws IOException {
+  public void free(TachyonFile file) throws IOException, FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       masterClient.free(file.getFileId(), true);
@@ -102,21 +102,15 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Gets the FileInfo object that represents the Tachyon file. The file info is a snapshot of the
-   * file metadata, and the locations, last modified time, and path are possibly inconsistent.
-   *
-   * @param file the handler for the file.
-   * @return the FileInfo of the file, null if the file does not exist.
-   * @throws IOException if the master is unable to obtain the file's metadata
+   * {@inheritDoc} The file info is a snapshot of the file metadata, and the locations, last
+   * modified time, and path are possibly inconsistent.
    */
   // TODO: Consider FileInfo caching
   @Override
-  public FileInfo getInfo(TachyonFile file) throws IOException {
+  public FileInfo getInfo(TachyonFile file) throws IOException, FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.getFileInfo(file.getFileId());
-    } catch (IOException e) {
-      return null;
     } finally {
       mContext.releaseMasterClient(masterClient);
     }
@@ -130,9 +124,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
    * @param file the handler for the file.
    * @param options the set of options specific to this operation.
    * @return an input stream to read the file
-   * @throws IOException if the file does not exist or the stream cannot be opened
+   * @throws FileDoesNotExistException if the file does not exist
+   * @throws IOException if the stream cannot be opened for some other reason
    */
-  public FileInStream getInStream(TachyonFile file, ClientOptions options) throws IOException {
+  public FileInStream getInStream(TachyonFile file, ClientOptions options) throws IOException,
+      FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       // TODO: Make sure the file is not a folder
@@ -154,9 +150,13 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
    * @param path the Tachyon path of the file
    * @param options the set of options specific to this operation
    * @return an output stream to write the file
+   * @throws InvalidPathException if the provided path is invalid
+   * @throws FileAlreadyExistException if the file being written to already exists
+   * @throws BlockInfoException if the provided block size is invalid
    * @throws IOException if the file already exists or if the stream cannot be opened
    */
-  public FileOutStream getOutStream(TachyonURI path, ClientOptions options) throws IOException {
+  public FileOutStream getOutStream(TachyonURI path, ClientOptions options) throws IOException,
+      InvalidPathException, FileAlreadyExistException, BlockInfoException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       long fileId = masterClient.createFile(path.getPath(), options.getBlockSize(), true);
@@ -173,16 +173,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * If the file is a folder, return the {@link FileInfo} of all the direct entries in it. Otherwise
-   * return the FileInfo for the file. The file infos are snapshots of the file metadata, and the
-   * locations, last modified time, and path are possibly inconsistent.
-   *
-   * @param file the handler for the file
-   * @return a list of FileInfos representing the files which are children of the given file
-   * @throws IOException if the file does not exist
+   * {@inheritDoc} The file infos are snapshots of the file metadata, and the locations, last
+   * modified time, and path are possibly inconsistent.
    */
   @Override
-  public List<FileInfo> listStatus(TachyonFile file) throws IOException {
+  public List<FileInfo> listStatus(TachyonFile file) throws IOException, FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.getFileInfoList(file.getFileId());
@@ -200,10 +195,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
    * @param ufsPath the under storage system path of the file that will back the Tachyon file
    * @param recursive if true, the parent directories to the file in Tachyon will be created
    * @return the file id of the resulting file in Tachyon
+   * @throws FileDoesNotExistException if there is no file at the given path
    * @throws IOException if the Tachyon path is invalid or the ufsPath does not exist
    */
   public long loadFileFromUfs(TachyonURI path, TachyonURI ufsPath, boolean recursive)
-      throws IOException {
+      throws IOException, FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.loadFileFromUfs(path.getPath(), ufsPath.getPath(), -1L, recursive);
@@ -213,14 +209,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Creates a folder. If the parent folders do not exist, they will be created automatically.
-   *
-   * @param path the handler for the file
-   * @return true if the folder is created successfully or already existing, false otherwise.
-   * @throws IOException if the master cannot create the folder under the specified path
+   * {@inheritDoc}
    */
   @Override
-  public boolean mkdirs(TachyonURI path) throws IOException {
+  public boolean mkdirs(TachyonURI path) throws IOException, InvalidPathException,
+      FileAlreadyExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       // TODO: Change this RPC's arguments
@@ -231,15 +224,10 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Resolves a {@link TachyonURI} to a {@link TachyonFile} which is used as the file handler for
-   * non-create operations.
-   *
-   * @param path the path of the file, this should be in Tachyon space
-   * @return a TachyonFile which acts as a file handler for the path
-   * @throws IOException if the path does not exist in Tachyon space
+   * {@inheritDoc}
    */
   @Override
-  public TachyonFile open(TachyonURI path) throws IOException {
+  public TachyonFile open(TachyonURI path) throws IOException, InvalidPathException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return new TachyonFile(masterClient.getFileId(path.getPath()));
@@ -254,9 +242,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
    *
    * @param file the file handler for the file to pin
    * @param pinned true to pin the file, false to unpin it
+   * @throws FileDoesNotExistException if the file does not exist
    * @throws IOException if an error occurs during the pin operation
    */
-  public void setPin(TachyonFile file, boolean pinned) throws IOException {
+  public void setPin(TachyonFile file, boolean pinned) throws IOException,
+      FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       masterClient.setPinned(file.getFileId(), pinned);
@@ -266,15 +256,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Renames an existing file in Tachyon space to another path in Tachyon space.
-   *
-   * @param src The file handler for the source file
-   * @param dst The path of the destination file, this path should not exist
-   * @return true if successful, false otherwise
-   * @throws IOException if the destination already exists or is invalid
+   * {@inheritDoc}
    */
   @Override
-  public boolean rename(TachyonFile src, TachyonURI dst) throws IOException {
+  public boolean rename(TachyonFile src, TachyonURI dst) throws IOException,
+      FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.renameFile(src.getFileId(), dst.getPath());

--- a/examples/src/main/java/tachyon/examples/BasicCheckpoint.java
+++ b/examples/src/main/java/tachyon/examples/BasicCheckpoint.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +99,7 @@ public class BasicCheckpoint implements Callable<Boolean> {
     return pass;
   }
 
-  private void writeFile(TachyonFS tachyonClient) throws IOException {
+  private void writeFile(TachyonFS tachyonClient) throws IOException, TException {
     for (int i = 0; i < mNumFiles; i ++) {
       ByteBuffer buf = ByteBuffer.allocate(80);
       buf.order(ByteOrder.nativeOrder());

--- a/integration-tests/src/test/java/tachyon/client/BlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/BlockInStreamIntegrationTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -77,7 +78,7 @@ public class BlockInStreamIntegrationTest {
    * Test <code>void read()</code>.
    */
   @Test
-  public void readTest1() throws IOException {
+  public void readTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -107,7 +108,7 @@ public class BlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>.
    */
   @Test
-  public void readTest2() throws IOException {
+  public void readTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -133,7 +134,7 @@ public class BlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code>.
    */
   @Test
-  public void readTest3() throws IOException {
+  public void readTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -160,7 +161,7 @@ public class BlockInStreamIntegrationTest {
    * Test <code>long skip(long len)</code>.
    */
   @Test
-  public void skipTest() throws IOException {
+  public void skipTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {

--- a/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -82,7 +83,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>void read() across block boundary</code>.
    */
   @Test
-  public void readTest1() throws IOException {
+  public void readTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -124,7 +125,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>.
    */
   @Test
-  public void readTest2() throws IOException {
+  public void readTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -150,7 +151,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code>.
    */
   @Test
-  public void readTest3() throws IOException {
+  public void readTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -176,7 +177,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code> for end of file.
    */
   @Test
-  public void readEndOfFileTest() throws IOException {
+  public void readEndOfFileTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -204,9 +205,10 @@ public class FileInStreamIntegrationTest {
    * position.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekExceptionTest1() throws IOException {
+  public void seekExceptionTest1() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
@@ -231,7 +233,7 @@ public class FileInStreamIntegrationTest {
    * @throws IllegalArgumentException
    */
   @Test
-  public void seekExceptionTest2() throws IOException {
+  public void seekExceptionTest2() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
@@ -253,9 +255,10 @@ public class FileInStreamIntegrationTest {
    * Test <code>void seek(long pos)</code>.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekTest() throws IOException {
+  public void seekTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -278,7 +281,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>long skip(long len)</code>.
    */
   @Test
-  public void skipTest() throws IOException {
+  public void skipTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {

--- a/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -71,9 +72,9 @@ public class FileOutStreamIntegrationTest {
   public static Collection<Object[]> data() {
     List<Object[]> list = new ArrayList<Object[]>();
     // Enable local writes.
-    list.add(new Object[] { true });
+    list.add(new Object[] {true});
     // Disable local writes.
-    list.add(new Object[] { false });
+    list.add(new Object[] {false});
     return list;
   }
 
@@ -120,9 +121,8 @@ public class FileOutStreamIntegrationTest {
    * @param fileLen
    * @throws IOException
    */
-  private void checkWrite(TachyonURI filePath, UnderStorageType underStorageType, int fileLen, int
-      increasingByteArrayLen)
-      throws IOException {
+  private void checkWrite(TachyonURI filePath, UnderStorageType underStorageType, int fileLen,
+      int increasingByteArrayLen) throws IOException, TException {
     for (ClientOptions op : getOptionSet()) {
       TachyonFile file = mTfs.open(filePath);
       FileInfo info = mTfs.getInfo(file);
@@ -157,7 +157,7 @@ public class FileOutStreamIntegrationTest {
    * Test <code>void write(int b)</code>.
    */
   @Test
-  public void writeTest1() throws IOException {
+  public void writeTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -166,7 +166,8 @@ public class FileOutStreamIntegrationTest {
     }
   }
 
-  private void writeTest1Util(TachyonURI filePath, ClientOptions op, int len) throws IOException {
+  private void writeTest1Util(TachyonURI filePath, ClientOptions op, int len) throws IOException,
+      TException {
     OutStream os = mTfs.getOutStream(filePath, op);
     for (int k = 0; k < len; k ++) {
       os.write((byte) k);
@@ -179,7 +180,7 @@ public class FileOutStreamIntegrationTest {
    * Test <code>void write(byte[] b)</code>.
    */
   @Test
-  public void writeTest2() throws IOException {
+  public void writeTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -188,7 +189,8 @@ public class FileOutStreamIntegrationTest {
     }
   }
 
-  private void writeTest2Util(TachyonURI filePath, ClientOptions op, int len) throws IOException {
+  private void writeTest2Util(TachyonURI filePath, ClientOptions op, int len) throws IOException,
+      TException {
     OutStream os = mTfs.getOutStream(filePath, op);
     os.write(BufferUtils.getIncreasingByteArray(len));
     os.close();
@@ -199,7 +201,7 @@ public class FileOutStreamIntegrationTest {
    * Test <code>void write(byte[] b, int off, int len)</code>.
    */
   @Test
-  public void writeTest3() throws IOException {
+  public void writeTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -208,7 +210,8 @@ public class FileOutStreamIntegrationTest {
     }
   }
 
-  private void writeTest3Util(TachyonURI filePath, ClientOptions op, int len) throws IOException {
+  private void writeTest3Util(TachyonURI filePath, ClientOptions op, int len) throws IOException,
+      TException {
     OutStream os = mTfs.getOutStream(filePath, op);
     os.write(BufferUtils.getIncreasingByteArray(0, len / 2), 0, len / 2);
     os.write(BufferUtils.getIncreasingByteArray(len / 2, len / 2), 0, len / 2);
@@ -224,7 +227,7 @@ public class FileOutStreamIntegrationTest {
    * @throws InterruptedException
    */
   @Test
-  public void longWriteChangesUserId() throws IOException, InterruptedException {
+  public void longWriteChangesUserId() throws IOException, InterruptedException, TException {
     TachyonURI filePath = new TachyonURI(PathUtils.uniqPath());
     int len = 2;
     OutStream os = mTfs.getOutStream(filePath, sWriteUnderStore);
@@ -237,13 +240,13 @@ public class FileOutStreamIntegrationTest {
 
   /**
    * Tests if out-of-order writes are possible. Writes could be out-of-order when the following are
-   * both true:
-   * - a "large" write (over half the internal buffer size) follows a smaller write.
-   * - the "large" write does not cause the internal buffer to overflow.
+   * both true: - a "large" write (over half the internal buffer size) follows a smaller write. -
+   * the "large" write does not cause the internal buffer to overflow.
+   * 
    * @throws IOException
    */
   @Test
-  public void outOfOrderWriteTest() throws IOException {
+  public void outOfOrderWriteTest() throws IOException, TException {
     TachyonURI filePath = new TachyonURI(PathUtils.uniqPath());
     OutStream os = mTfs.getOutStream(filePath, sWriteTachyon);
 

--- a/integration-tests/src/test/java/tachyon/client/IsolatedTachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/IsolatedTachyonFileSystemIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -67,15 +68,16 @@ public class IsolatedTachyonFileSystemIntegrationTest {
     mWorkerTachyonConf.set(Constants.MAX_COLUMNS, "257");
     mWorkerToMasterHeartbeatIntervalMs =
         mWorkerTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
-    mWriteBoth = new ClientOptions.Builder(mWorkerTachyonConf).setCacheType(CacheType.CACHE)
-        .setUnderStorageType(UnderStorageType.PERSIST).build();
+    mWriteBoth =
+        new ClientOptions.Builder(mWorkerTachyonConf).setCacheType(CacheType.CACHE)
+            .setUnderStorageType(UnderStorageType.PERSIST).build();
     mWriteUnderStorage =
         new ClientOptions.Builder(mWorkerTachyonConf).setCacheType(CacheType.NO_CACHE)
             .setUnderStorageType(UnderStorageType.PERSIST).build();
   }
 
   @Test
-  public void lockBlockTest1() throws IOException {
+  public void lockBlockTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     int numOfFiles = 5;
     int fileSize = WORKER_CAPACITY_BYTES / numOfFiles;
@@ -86,8 +88,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
     for (int k = 0; k < numOfFiles; k ++) {
       Assert.assertTrue(mTfs.getInfo(files.get(k)).getInMemoryPercentage() == 100);
     }
-    files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + numOfFiles,
-        mWriteBoth, fileSize));
+    files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + numOfFiles, mWriteBoth, fileSize));
 
     CommonUtils.sleepMs(mWorkerToMasterHeartbeatIntervalMs);
 
@@ -98,7 +99,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void lockBlockTest2() throws IOException {
+  public void lockBlockTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile tFile = null;
     tachyon.client.InStream is = null;
@@ -129,7 +130,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void lockBlockTest3() throws IOException {
+  public void lockBlockTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile tFile = null;
     tachyon.client.InStream is = null;
@@ -165,7 +166,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void unlockBlockTest1() throws IOException {
+  public void unlockBlockTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile tFile = null;
     InStream is = null;
@@ -196,7 +197,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void unlockBlockTest2() throws IOException {
+  public void unlockBlockTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile tFile = null;
     InStream is = null;
@@ -230,7 +231,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void unlockBlockTest3() throws IOException {
+  public void unlockBlockTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile tFile = null;
     InStream is = null;
@@ -240,8 +241,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
     int fileSize = WORKER_CAPACITY_BYTES / numOfFiles;
     List<TachyonFile> files = new ArrayList<TachyonFile>();
     for (int k = 0; k < numOfFiles; k ++) {
-      files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + k, mWriteBoth,
-          fileSize));
+      files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + k, mWriteBoth, fileSize));
     }
     for (int k = 0; k < numOfFiles; k ++) {
       FileInfo info = mTfs.getInfo(files.get(k));

--- a/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -82,7 +83,7 @@ public class LocalBlockInStreamIntegrationTest {
    * Test <code>void read()</code>.
    */
   @Test
-  public void readTest1() throws IOException {
+  public void readTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -126,7 +127,7 @@ public class LocalBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>.
    */
   @Test
-  public void readTest2() throws IOException {
+  public void readTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -154,7 +155,7 @@ public class LocalBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code>.
    */
   @Test
-  public void readTest3() throws IOException {
+  public void readTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -183,9 +184,10 @@ public class LocalBlockInStreamIntegrationTest {
    * position.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekExceptionTest1() throws IOException {
+  public void seekExceptionTest1() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("Seek position is negative: -1");
     String uniqPath = PathUtils.uniqPath();
@@ -210,9 +212,10 @@ public class LocalBlockInStreamIntegrationTest {
    * that is past buffer limit.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekExceptionTest2() throws IOException {
+  public void seekExceptionTest2() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("Seek position is past EOF: 1, fileSize = 0");
 
@@ -236,9 +239,10 @@ public class LocalBlockInStreamIntegrationTest {
    * Test <code>void seek(long pos)</code>.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekTest() throws IOException {
+  public void seekTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -262,7 +266,7 @@ public class LocalBlockInStreamIntegrationTest {
    * Test <code>long skip(long len)</code>.
    */
   @Test
-  public void skipTest() throws IOException {
+  public void skipTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {

--- a/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -120,7 +121,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read()</code>. Read from underfs.
    */
   @Test
-  public void readTest1() throws IOException {
+  public void readTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -181,7 +182,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>. Read from underfs.
    */
   @Test
-  public void readTest2() throws IOException {
+  public void readTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -218,7 +219,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code>. Read from underfs.
    */
   @Test
-  public void readTest3() throws IOException {
+  public void readTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -255,7 +256,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read()</code>. Read from remote data server.
    */
   @Test
-  public void readTest4() throws IOException {
+  public void readTest4() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -286,7 +287,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>. Read from remote data server.
    */
   @Test
-  public void readTest5() throws IOException {
+  public void readTest5() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -313,7 +314,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code>. Read from remote data server.
    */
   @Test
-  public void readTest6() throws IOException {
+  public void readTest6() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -340,7 +341,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>. Read from underfs.
    */
   @Test
-  public void readTest7() throws IOException {
+  public void readTest7() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -361,9 +362,10 @@ public class RemoteBlockInStreamIntegrationTest {
    * position.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekExceptionTest1() throws IOException {
+  public void seekExceptionTest1() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("Seek position is negative: -1");
     String uniqPath = PathUtils.uniqPath();
@@ -385,9 +387,10 @@ public class RemoteBlockInStreamIntegrationTest {
    * that is past block size.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekExceptionTest2() throws IOException {
+  public void seekExceptionTest2() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("Seek position is past EOF: 1, fileSize = 0");
     String uniqPath = PathUtils.uniqPath();
@@ -408,9 +411,10 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void seek(long pos)</code>.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekTest() throws IOException {
+  public void seekTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -433,7 +437,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>long skip(long len)</code>.
    */
   @Test
-  public void skipTest() throws IOException {
+  public void skipTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -462,7 +466,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Tests that reading a file the whole way through with the CACHE ReadType will recache it
    */
   @Test
-  public void completeFileReadTriggersRecache() throws IOException {
+  public void completeFileReadTriggersRecache() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     int len = 2;
     TachyonFile f =
@@ -481,7 +485,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * recache
    */
   @Test
-  public void incompleteFileReadCancelsRecache() throws IOException {
+  public void incompleteFileReadCancelsRecache() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile f =
         TachyonFSTestUtils.createByteFile(mTfs, uniqPath, mWriteUnderStore, 2);
@@ -498,7 +502,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Tests that reading a file consisting of more than one block from the underfs works
    */
   @Test
-  public void readMultiBlockFile() throws IOException {
+  public void readMultiBlockFile() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     int blockSizeByte = 10;
     int numBlocks = 10;
@@ -523,7 +527,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Tests that seeking around a file cached locally works.
    */
   @Test
-  public void seekAroundLocalBlock() throws IOException {
+  public void seekAroundLocalBlock() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     // The number of bytes per remote block read should be set to 100 in the before function
     TachyonFile f = TachyonFSTestUtils.createByteFile(mTfs, uniqPath, mWriteTachyon, 200);

--- a/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -17,6 +17,7 @@ package tachyon.client;
 
 import java.io.IOException;
 
+import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -55,7 +56,7 @@ public class TachyonFileSystemIntegrationTest {
   public ExpectedException mThrown = ExpectedException.none();
 
   @Before
-  public final void before() throws IOException {
+  public final void before() throws IOException, TException {
     mMasterTachyonConf = sLocalTachyonCluster.getMasterTachyonConf();
     mMasterTachyonConf.set(Constants.MAX_COLUMNS, "257");
     mWorkerTachyonConf = sLocalTachyonCluster.getWorkerTachyonConf();
@@ -69,8 +70,8 @@ public class TachyonFileSystemIntegrationTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
     System.setProperty(Constants.USER_FILE_BUFFER_BYTES, Integer.toString(USER_QUOTA_UNIT_BYTES));
-    sLocalTachyonCluster = new LocalTachyonCluster(WORKER_CAPACITY_BYTES, USER_QUOTA_UNIT_BYTES,
-        Constants.GB);
+    sLocalTachyonCluster =
+        new LocalTachyonCluster(WORKER_CAPACITY_BYTES, USER_QUOTA_UNIT_BYTES, Constants.GB);
     sLocalTachyonCluster.start();
     sTfs = sLocalTachyonCluster.getClient();
     sHost = sLocalTachyonCluster.getMasterHostname();
@@ -84,12 +85,12 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void getRootTest() throws IOException {
+  public void getRootTest() throws IOException, TException {
     Assert.assertEquals(0, sTfs.getInfo(sTfs.open(new TachyonURI("/"))).getFileId());
   }
 
   @Test
-  public void createFileTest() throws IOException {
+  public void createFileTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = 1; k < 5; k ++) {
       TachyonURI uri = new TachyonURI(uniqPath + k);
@@ -99,7 +100,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test(expected = IOException.class)
-  public void createFileWithFileAlreadyExistExceptionTest() throws IOException {
+  public void createFileWithFileAlreadyExistExceptionTest() throws IOException, TException {
     TachyonURI uri = new TachyonURI(PathUtils.uniqPath());
     sTfs.getOutStream(uri, sWriteBoth).close();
     Assert.assertNotNull(sTfs.getInfo(sTfs.open(uri)));
@@ -109,7 +110,7 @@ public class TachyonFileSystemIntegrationTest {
   // TODO: Validate the URI
   @Ignore
   @Test
-  public void createFileWithInvalidPathExceptionTest() throws IOException {
+  public void createFileWithInvalidPathExceptionTest() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("URI must be absolute, unless it's empty.");
     sTfs.getOutStream(new TachyonURI("root/testFile1"), sWriteBoth);
@@ -119,13 +120,12 @@ public class TachyonFileSystemIntegrationTest {
 
   // TODO: Check worker capacity?
   @Test
-  public void deleteFileTest() throws IOException {
+  public void deleteFileTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
 
     for (int k = 0; k < 5; k ++) {
       TachyonURI fileURI = new TachyonURI(uniqPath + k);
-      TachyonFile f =
-          TachyonFSTestUtils.createByteFile(sTfs, fileURI.getPath(), sWriteBoth, k);
+      TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, fileURI.getPath(), sWriteBoth, k);
       Assert.assertTrue(sTfs.getInfo(f).getInMemoryPercentage() == 100);
       Assert.assertNotNull(sTfs.getInfo(f));
     }
@@ -139,7 +139,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void getFileStatusTest() throws IOException {
+  public void getFileStatusTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     int writeBytes = USER_QUOTA_UNIT_BYTES * 2;
     TachyonURI uri = new TachyonURI(uniqPath);
@@ -151,7 +151,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void mkdirTest() throws IOException {
+  public void mkdirTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = 0; k < 10; k ++) {
       Assert.assertTrue(sTfs.mkdirs(new TachyonURI(uniqPath + k)));
@@ -160,7 +160,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void renameFileTest1() throws IOException {
+  public void renameFileTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonURI path1 = new TachyonURI(uniqPath + 1);
     sTfs.getOutStream(path1, sWriteBoth).close();
@@ -178,7 +178,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void renameFileTest2() throws IOException {
+  public void renameFileTest2() throws IOException, TException {
     TachyonURI uniqUri = new TachyonURI(PathUtils.uniqPath());
     sTfs.getOutStream(uniqUri, sWriteBoth).close();
     TachyonFile f = sTfs.open(uniqUri);

--- a/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -18,6 +18,7 @@ package tachyon.client;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -61,7 +62,7 @@ public class UfsUtilsIntegrationTest {
   }
 
   @Test
-  public void loadUnderFsTest() throws IOException {
+  public void loadUnderFsTest() throws IOException, TException {
     String[] exclusions = {"/tachyon", "/exclusions"};
     String[] inclusions = {"/inclusions/sub-1", "/inclusions/sub-2"};
     for (String exclusion : exclusions) {

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractDeleteIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractDeleteIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/master/FileSystemMasterClientIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/FileSystemMasterClientIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -28,6 +28,7 @@ import org.junit.Test;
 import tachyon.Constants;
 import tachyon.client.FileSystemMasterClient;
 import tachyon.conf.TachyonConf;
+import tachyon.thrift.FileDoesNotExistException;
 
 /**
  * Test the internal implementation of tachyon Master via a
@@ -56,8 +57,9 @@ public class FileSystemMasterClientIntegrationTest {
 
   @Test
   public void openCloseTest() throws TException, IOException {
-    FileSystemMasterClient fsMasterClient = new FileSystemMasterClient(
-        mLocalTachyonCluster.getMaster().getAddress(), mExecutorService, mMasterTachyonConf);
+    FileSystemMasterClient fsMasterClient =
+        new FileSystemMasterClient(mLocalTachyonCluster.getMaster().getAddress(), mExecutorService,
+            mMasterTachyonConf);
     Assert.assertFalse(fsMasterClient.isConnected());
     fsMasterClient.connect();
     Assert.assertTrue(fsMasterClient.isConnected());
@@ -72,12 +74,14 @@ public class FileSystemMasterClientIntegrationTest {
   }
 
   @Test(timeout = 3000, expected = IOException.class)
-  public void user_getClientBlockInfoReturnsOnError() throws IOException {
+  public void user_getClientBlockInfoReturnsOnError() throws IOException,
+          FileDoesNotExistException {
     // This test was created to show that an infinite loop occurs.
     // The timeout will protect against this, and the change was to throw a IOException
     // in the cases we don't want to disconnect from master
-    FileSystemMasterClient fsMasterClient = new FileSystemMasterClient(
-        mLocalTachyonCluster.getMaster().getAddress(), mExecutorService, mMasterTachyonConf);
+    FileSystemMasterClient fsMasterClient =
+        new FileSystemMasterClient(mLocalTachyonCluster.getMaster().getAddress(), mExecutorService,
+            mMasterTachyonConf);
     fsMasterClient.getFileInfo(Long.MAX_VALUE);
     fsMasterClient.close();
   }

--- a/integration-tests/src/test/java/tachyon/master/MasterFaultToleranceIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/MasterFaultToleranceIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -67,7 +68,7 @@ public class MasterFaultToleranceIntegrationTest {
    * @throws java.io.IOException
    */
   private void faultTestDataCreation(TachyonURI folderName, List<Pair<Long, TachyonURI>> answer)
-      throws IOException {
+      throws IOException, TException {
     mTfs.mkdirs(folderName);
     answer.add(new Pair<Long, TachyonURI>(mTfs.open(folderName).getFileId(), folderName));
 
@@ -85,21 +86,22 @@ public class MasterFaultToleranceIntegrationTest {
    * @param answer the correct results
    * @throws java.io.IOException
    */
-  private void faultTestDataCheck(List<Pair<Long, TachyonURI>> answer) throws IOException {
+  private void faultTestDataCheck(List<Pair<Long, TachyonURI>> answer) throws IOException,
+      TException {
     List<String> files = TachyonFSTestUtils.listFiles(mTfs, TachyonURI.SEPARATOR);
     Collections.sort(files);
     Assert.assertEquals(answer.size(), files.size());
     for (int k = 0; k < answer.size(); k ++) {
       Assert.assertEquals(answer.get(k).getSecond().toString(),
           mTfs.getInfo(new TachyonFile(answer.get(k).getFirst())).getPath());
-      Assert.assertEquals(answer.get(k).getFirst().intValue(),
-          mTfs.open(answer.get(k).getSecond()).getFileId());
+      Assert.assertEquals(answer.get(k).getFirst().intValue(), mTfs.open(answer.get(k).getSecond())
+          .getFileId());
     }
   }
 
   @Ignore
   @Test
-  public void faultTest() throws IOException {
+  public void faultTest() throws IOException, TException {
     int clients = 10;
     List<Pair<Long, TachyonURI>> answer = Lists.newArrayList();
     for (int k = 0; k < clients; k ++) {
@@ -125,7 +127,7 @@ public class MasterFaultToleranceIntegrationTest {
 
   @Ignore
   @Test
-  public void getClientsTest() throws IOException {
+  public void getClientsTest() throws IOException, TException {
     int clients = 10;
     ClientOptions option = new ClientOptions.Builder(new TachyonConf()).setBlockSize(1024).build();
     for (int k = 0; k < clients; k ++) {

--- a/integration-tests/src/test/java/tachyon/master/PinIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/PinIntegrationTest.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -148,7 +149,7 @@ public class PinIntegrationTest {
         Sets.newHashSet(file0.getFileId(), file3.getFileId()));
   }
 
-  private TachyonFile createEmptyFile(TachyonURI fileURI) throws IOException {
+  private TachyonFile createEmptyFile(TachyonURI fileURI) throws IOException, TException {
     ClientOptions options = new ClientOptions.Builder(new TachyonConf())
         .setCacheType(CacheType.CACHE).setUnderStorageType(UnderStorageType.NO_PERSIST).build();
     FileOutStream os = mTfs.getOutStream(fileURI, options);

--- a/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -85,8 +86,8 @@ public class DataServerIntegrationTest {
   private final String mDataServerClass;
   private final String mNettyTransferType;
   private final String mBlockReader;
-  private final ExecutorService mExecutorService =
-      Executors.newFixedThreadPool(2, ThreadFactoryUtils.build("test-executor-%d", true));
+  private final ExecutorService mExecutorService = Executors.newFixedThreadPool(2,
+      ThreadFactoryUtils.build("test-executor-%d", true));
 
   private LocalTachyonCluster mLocalTachyonCluster = null;
   private TachyonFileSystem mTFS = null;
@@ -159,20 +160,22 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void lengthTooSmall() throws IOException {
+  public void lengthTooSmall() throws IOException, TException {
     final int length = 20;
-    TachyonFile file = TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, length);
+    TachyonFile file =
+        TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, length);
     BlockInfo block = getFirstBlockInfo(file);
     DataServerMessage recvMsg = request(block, 0, length * -2);
     assertError(recvMsg, block.blockId);
   }
 
   @Test
-  public void multiReadTest() throws IOException {
+  public void multiReadTest() throws IOException, TException {
     final int length = 20;
-    TachyonFile file = TachyonFSTestUtils.createByteFile(mTFS, "/multiReadTest", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, length);
+    TachyonFile file =
+        TachyonFSTestUtils.createByteFile(mTFS, "/multiReadTest", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, length);
     BlockInfo block = getFirstBlockInfo(file);
     for (int i = 0; i < 10; i ++) {
       DataServerMessage recvMsg = request(block);
@@ -181,42 +184,46 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void negativeOffset() throws IOException {
+  public void negativeOffset() throws IOException, TException {
     final int length = 10;
-    TachyonFile file = TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, length);
+    TachyonFile file =
+        TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, length);
     BlockInfo block = getFirstBlockInfo(file);
     DataServerMessage recvMsg = request(block, length * -2, 1);
     assertError(recvMsg, block.blockId);
   }
 
   @Test
-  public void readMultiFiles() throws IOException {
+  public void readMultiFiles() throws IOException, TException {
     final int length = WORKER_CAPACITY_BYTES / 2 + 1;
-    TachyonFile file1 = TachyonFSTestUtils.createByteFile(mTFS, "/readFile1", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, length);
+    TachyonFile file1 =
+        TachyonFSTestUtils.createByteFile(mTFS, "/readFile1", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, length);
     BlockInfo block1 = getFirstBlockInfo(file1);
     DataServerMessage recvMsg1 = request(block1);
     assertValid(recvMsg1, length, block1.getBlockId(), 0, length);
 
-    TachyonFile file2 = TachyonFSTestUtils.createByteFile(mTFS, "/readFile2", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, length);
+    TachyonFile file2 =
+        TachyonFSTestUtils.createByteFile(mTFS, "/readFile2", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, length);
     BlockInfo block2 = getFirstBlockInfo(file2);
     DataServerMessage recvMsg2 = request(block2);
     assertValid(recvMsg2, length, block2.getBlockId(), 0, length);
 
-    CommonUtils.sleepMs(
-        mWorkerTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS) * 2 + 10);
+    CommonUtils
+        .sleepMs(mWorkerTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS) * 2
+                + 10);
 
     FileInfo fileInfo = mTFS.getInfo(mTFS.open(new TachyonURI("/readFile1")));
     Assert.assertEquals(0, fileInfo.inMemoryPercentage);
   }
 
   @Test
-  public void readPartialTest1()
-      throws InvalidPathException, FileAlreadyExistException, IOException {
-    TachyonFile file = TachyonFSTestUtils.createByteFile(mTFS, "/testFile", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, 10);
+  public void readPartialTest1() throws IOException, TException {
+    TachyonFile file =
+        TachyonFSTestUtils.createByteFile(mTFS, "/testFile", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, 10);
     BlockInfo block = getFirstBlockInfo(file);
     final int offset = 0;
     final int length = 6;
@@ -225,10 +232,10 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void readPartialTest2()
-      throws InvalidPathException, FileAlreadyExistException, IOException {
-    TachyonFile file = TachyonFSTestUtils.createByteFile(mTFS, "/testFile", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, 10);
+  public void readPartialTest2() throws IOException, TException {
+    TachyonFile file =
+        TachyonFSTestUtils.createByteFile(mTFS, "/testFile", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, 10);
     BlockInfo block = getFirstBlockInfo(file);
     final int offset = 2;
     final int length = 6;
@@ -238,40 +245,41 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void readTest() throws InvalidPathException, FileAlreadyExistException, IOException {
+  public void readTest() throws IOException, TException {
     final int length = 10;
-    TachyonFile file = TachyonFSTestUtils.createByteFile(mTFS, "/testFile", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, length);
+    TachyonFile file =
+        TachyonFSTestUtils.createByteFile(mTFS, "/testFile", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, length);
     BlockInfo block = getFirstBlockInfo(file);
     DataServerMessage recvMsg = request(block);
     assertValid(recvMsg, length, block.getBlockId(), 0, length);
   }
 
   @Test
-  public void readThroughClientTest()
-      throws InvalidPathException, FileAlreadyExistException, IOException {
+  public void readThroughClientTest() throws IOException, TException {
     final int length = 10;
-    TachyonFile file = TachyonFSTestUtils.createByteFile(mTFS, "/testFile", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, length);
+    TachyonFile file =
+        TachyonFSTestUtils.createByteFile(mTFS, "/testFile", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, length);
     BlockInfo block = getFirstBlockInfo(file);
 
     RemoteBlockReader client =
         RemoteBlockReader.Factory.createRemoteBlockReader(mWorkerTachyonConf);
-    ByteBuffer result = client.readRemoteBlock(
-        new InetSocketAddress(block.getLocations().get(0).getWorkerAddress().getMHost(),
-            block.getLocations().get(0).getWorkerAddress().getMSecondaryPort()),
-        block.getBlockId(), 0, length);
+    ByteBuffer result =
+        client.readRemoteBlock(new InetSocketAddress(block.getLocations().get(0).getWorkerAddress()
+            .getMHost(), block.getLocations().get(0).getWorkerAddress().getMSecondaryPort()),
+            block.getBlockId(), 0, length);
 
     Assert.assertEquals(BufferUtils.getIncreasingByteBuffer(length), result);
   }
 
   // TODO: Make this work with the new BlockReader
   // @Test
-  public void readThroughClientNonExistentTest()
-      throws InvalidPathException, FileAlreadyExistException, IOException {
+  public void readThroughClientNonExistentTest() throws IOException, TException {
     final int length = 10;
-    TachyonFile file = TachyonFSTestUtils.createByteFile(mTFS, "/testFile", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, length);
+    TachyonFile file =
+        TachyonFSTestUtils.createByteFile(mTFS, "/testFile", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, length);
     BlockInfo block = getFirstBlockInfo(file);
 
     // Get the maximum block id, for use in determining a non-existent block id.
@@ -285,29 +293,31 @@ public class DataServerIntegrationTest {
 
     RemoteBlockReader client =
         RemoteBlockReader.Factory.createRemoteBlockReader(mWorkerTachyonConf);
-    ByteBuffer result = client.readRemoteBlock(
-        new InetSocketAddress(block.getLocations().get(0).getWorkerAddress().getMHost(),
-            block.getLocations().get(0).getWorkerAddress().getMSecondaryPort()),
-        maxBlockId + 1, 0, length);
+    ByteBuffer result =
+        client.readRemoteBlock(new InetSocketAddress(block.getLocations().get(0).getWorkerAddress()
+            .getMHost(), block.getLocations().get(0).getWorkerAddress().getMSecondaryPort()),
+            maxBlockId + 1, 0, length);
 
     Assert.assertNull(result);
   }
 
   @Test
-  public void readTooLarge() throws IOException {
+  public void readTooLarge() throws IOException, TException {
     final int length = 20;
-    TachyonFile file = TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, length);
+    TachyonFile file =
+        TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, length);
     BlockInfo block = getFirstBlockInfo(file);
     DataServerMessage recvMsg = request(block, 0, length * 2);
     assertError(recvMsg, block.blockId);
   }
 
   @Test
-  public void tooLargeOffset() throws IOException {
+  public void tooLargeOffset() throws IOException, TException {
     final int length = 10;
-    TachyonFile file = TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", CacheType.CACHE,
-        UnderStorageType.NO_PERSIST, length);
+    TachyonFile file =
+        TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", CacheType.CACHE,
+            UnderStorageType.NO_PERSIST, length);
     BlockInfo block = getFirstBlockInfo(file);
     DataServerMessage recvMsg = request(block, length * 2, 1);
     assertError(recvMsg, block.blockId);
@@ -316,7 +326,7 @@ public class DataServerIntegrationTest {
   /**
    * Requests a block from the server. This call will read the full block.
    */
-  private DataServerMessage request(final BlockInfo block) throws IOException {
+  private DataServerMessage request(final BlockInfo block) throws IOException, TException {
     return request(block, 0, -1);
   }
 
@@ -325,12 +335,12 @@ public class DataServerIntegrationTest {
    * response from the server.
    */
   private DataServerMessage request(final BlockInfo block, final long offset, final long length)
-      throws IOException {
+      throws IOException, TException {
     DataServerMessage sendMsg =
         DataServerMessage.createBlockRequestMessage(block.blockId, offset, length);
-    SocketChannel socketChannel = SocketChannel
-        .open(new InetSocketAddress(block.getLocations().get(0).getWorkerAddress().getMHost(),
-            block.getLocations().get(0).getWorkerAddress().getMSecondaryPort()));
+    SocketChannel socketChannel =
+        SocketChannel.open(new InetSocketAddress(block.getLocations().get(0).getWorkerAddress()
+            .getMHost(), block.getLocations().get(0).getWorkerAddress().getMSecondaryPort()));
     try {
       while (!sendMsg.finishSending()) {
         sendMsg.send(socketChannel);
@@ -355,8 +365,9 @@ public class DataServerIntegrationTest {
    * @param tachyonFile the file to get the first MasterBlockInfo for
    * @return the MasterBlockInfo of the first block in the file
    * @throws IOException
+   * @throws TException
    */
-  private BlockInfo getFirstBlockInfo(TachyonFile tachyonFile) throws IOException {
+  private BlockInfo getFirstBlockInfo(TachyonFile tachyonFile) throws IOException, TException {
     FileInfo fileInfo = mTFS.getInfo(tachyonFile);
     return mBlockMasterClient.getBlockInfo(fileInfo.blockIds.get(0));
   }

--- a/integration-tests/src/test/java/tachyon/worker/block/meta/CapacityUsageIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/block/meta/CapacityUsageIntegrationTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -75,7 +76,7 @@ public class CapacityUsageIntegrationTest {
   }
 
   private TachyonFile createAndWriteFile(TachyonURI filePath, CacheType cacheType,
-      UnderStorageType underStorageType, int len) throws IOException {
+      UnderStorageType underStorageType, int len) throws IOException, TException {
     ByteBuffer buf = ByteBuffer.allocate(len);
     buf.order(ByteOrder.nativeOrder());
     for (int k = 0; k < len; k ++) {
@@ -90,7 +91,7 @@ public class CapacityUsageIntegrationTest {
     return mTFS.open(filePath);
   }
 
-  private void deleteDuringEviction(int i) throws IOException {
+  private void deleteDuringEviction(int i) throws IOException, TException {
     final String fileName1 = "/file" + i + "_1";
     final String fileName2 = "/file" + i + "_2";
     TachyonFile file1 = createAndWriteFile(new TachyonURI(fileName1), CacheType.CACHE,
@@ -109,7 +110,7 @@ public class CapacityUsageIntegrationTest {
 
   // TODO: Rethink the approach of this test and what it should be testing
   // @Test
-  public void deleteDuringEvictionTest() throws IOException {
+  public void deleteDuringEvictionTest() throws IOException, TException {
     // This test may not trigger eviction each time, repeat it 20 times.
     for (int i = 0; i < 20; i ++) {
       deleteDuringEviction(i);

--- a/servers/src/main/java/tachyon/web/WebInterfaceDownloadServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceDownloadServlet.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -97,7 +97,8 @@ public final class WebInterfaceDownloadServlet extends HttpServlet {
    * @throws IOException
    */
   private void downloadFile(TachyonURI path, HttpServletRequest request,
-      HttpServletResponse response) throws FileDoesNotExistException, IOException {
+      HttpServletResponse response) throws FileDoesNotExistException, IOException,
+      InvalidPathException {
     TachyonFileSystem tachyonClient = TachyonFileSystem.get();
     TachyonFile fd = tachyonClient.open(path);
     FileInfo tFile = tachyonClient.getInfo(fd);
@@ -114,8 +115,9 @@ public final class WebInterfaceDownloadServlet extends HttpServlet {
     FileInStream is = null;
     ServletOutputStream out = null;
     try {
-      ClientOptions op = new ClientOptions.Builder(mFsMaster.getTachyonConf()).setCacheType(
-          CacheType.NO_CACHE).build();
+      ClientOptions op =
+          new ClientOptions.Builder(mFsMaster.getTachyonConf()).setCacheType(CacheType.NO_CACHE)
+              .build();
       is = tachyonClient.getInStream(fd, op);
       out = response.getOutputStream();
       ByteStreams.copy(is, out);

--- a/shell/src/test/java/tachyon/shell/TFsShellUtilsTest.java
+++ b/shell/src/test/java/tachyon/shell/TFsShellUtilsTest.java
@@ -104,12 +104,12 @@ public class TFsShellUtilsTest {
       TException {
     /**
      * Generate such local structure /testWildCards
-                ├── foo |
-                        ├── foobar1
-                        └── foobar2
-                ├── bar |
-                        └── foobar3
-                └── foobar4
+     *                                ├── foo |
+     *                                        ├── foobar1
+     *                                        └── foobar2
+     *                                ├── bar |
+     *                                        └── foobar3
+     *                                └── foobar4
      */
     TachyonFile fd;
     try {
@@ -145,12 +145,12 @@ public class TFsShellUtilsTest {
       throws IOException {
     /**
      * Generate such local structure /testWildCards
-                ├── foo |
-                        ├── foobar1
-                        └── foobar2
-                ├── bar |
-                        └── foobar3
-                └── foobar4
+     *                                ├── foo |
+     *                                        ├── foobar1
+     *                                        └── foobar2
+     *                                ├── bar |
+     *                                        └── foobar3
+     *                                └── foobar4
      */
     FileUtils.deleteDirectory(new File(localTachyonCluster.getTachyonHome() + "/testWildCards"));
     new File(localTachyonCluster.getTachyonHome() + "/testWildCards").mkdir();

--- a/shell/src/test/java/tachyon/shell/TFsShellUtilsTest.java
+++ b/shell/src/test/java/tachyon/shell/TFsShellUtilsTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -63,8 +64,9 @@ public class TFsShellUtilsTest {
 
   @Test
   public void getFilePathTest() throws IOException {
-    String[] paths = new String[] {Constants.HEADER + "localhost:19998/dir",
-        Constants.HEADER_FT + "localhost:19998/dir", "/dir", "dir"};
+    String[] paths =
+        new String[] {Constants.HEADER + "localhost:19998/dir",
+            Constants.HEADER_FT + "localhost:19998/dir", "/dir", "dir"};
     String expected = "/dir";
     for (String path : paths) {
       String result = TFsShellUtils.getFilePath(path, new TachyonConf());
@@ -94,24 +96,27 @@ public class TFsShellUtilsTest {
     };
   }
 
-  public String resetTachyonFileHierarchy() throws IOException {
+  public String resetTachyonFileHierarchy() throws IOException, TException {
     return resetTachyonFileHierarchy(mTfs);
   }
 
-  public static String resetTachyonFileHierarchy(TachyonFileSystem tfs) throws IOException {
+  public static String resetTachyonFileHierarchy(TachyonFileSystem tfs) throws IOException,
+      TException {
     /**
      * Generate such local structure /testWildCards
-     *                                ├── foo |
-     *                                        ├── foobar1
-     *                                        └── foobar2
-     *                                ├── bar |
-     *                                        └── foobar3
-     *                                └── foobar4
+                ├── foo |
+                        ├── foobar1
+                        └── foobar2
+                ├── bar |
+                        └── foobar3
+                └── foobar4
      */
     TachyonFile fd;
     try {
       fd = tfs.open(new TachyonURI("/testWildCars"));
     } catch (IOException ioe) {
+      fd = null;
+    } catch (TException ioe) {
       fd = null;
     }
     if (fd != null) {
@@ -140,12 +145,12 @@ public class TFsShellUtilsTest {
       throws IOException {
     /**
      * Generate such local structure /testWildCards
-     *                                ├── foo |
-     *                                        ├── foobar1
-     *                                        └── foobar2
-     *                                ├── bar |
-     *                                        └── foobar3
-     *                                └── foobar4
+                ├── foo |
+                        ├── foobar1
+                        └── foobar2
+                ├── bar |
+                        └── foobar3
+                └── foobar4
      */
     FileUtils.deleteDirectory(new File(localTachyonCluster.getTachyonHome() + "/testWildCards"));
     new File(localTachyonCluster.getTachyonHome() + "/testWildCards").mkdir();
@@ -160,7 +165,7 @@ public class TFsShellUtilsTest {
     return localTachyonCluster.getTachyonHome() + "/testWildCards";
   }
 
-  public List<String> getPaths(String path, FsType fsType) throws IOException {
+  public List<String> getPaths(String path, FsType fsType) throws IOException, TException {
     List<String> ret = null;
     if (fsType == FsType.TFS) {
       List<TachyonURI> tPaths = TFsShellUtils.getTachyonURIs(mTfs, new TachyonURI(path));
@@ -179,7 +184,7 @@ public class TFsShellUtilsTest {
     return ret;
   }
 
-  public String resetFsHierarchy(FsType fsType) throws IOException {
+  public String resetFsHierarchy(FsType fsType) throws IOException, TException {
     if (fsType == FsType.TFS) {
       return resetTachyonFileHierarchy();
     } else if (fsType == FsType.LOCAL) {
@@ -190,7 +195,7 @@ public class TFsShellUtilsTest {
   }
 
   @Test
-  public void getPathTest() throws IOException {
+  public void getPathTest() throws IOException, TException {
     for (FsType fsType : FsType.values()) {
       String rootDir = resetFsHierarchy(fsType);
 


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-934

We were turning everything into an IOException, which can make it hard
for callers to determine what went wrong in an operation. So now the
TachyonFileSystem and related classes don't wrap exceptions in an
IOException.

Also the FileSystemMasterClient uses an exponential backoff retry,
rather than looping forever, before throwing an exception and exiting.

There are a lot of miscellaneous refactors for deprecated code and tests
to get this to compile.