### PR TITLE
[SMALLFIX] Disable failing test in JournalShutdownIntegrationTest

### DIFF
--- a/integration-tests/src/test/java/tachyon/master/JournalShutdownIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/JournalShutdownIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import tachyon.Constants;
@@ -180,6 +181,7 @@ public class JournalShutdownIntegrationTest {
     cluster.stopUFS();
   }
 
+  @Ignore
   @Test
   public void multiMasterJournalCrashIntegrationTest() throws Exception {
     LocalTachyonClusterMultiMaster cluster = setupMultiMasterCluster();


### PR DESCRIPTION
The 'multiMasterJournalCrashIntegrationTest' in 'JournalShutdownIntegrationTest' may fail.
A ticket have been opened for this issue ([TACHYON-929](https://tachyon.atlassian.net/browse/TACHYON-929)).