### PR TITLE
[TACHYON-883] add javadoc to all public methods of ClientMetrics

### DIFF
--- a/common/src/main/java/tachyon/worker/ClientMetrics.java
+++ b/common/src/main/java/tachyon/worker/ClientMetrics.java
@@ -52,7 +52,7 @@ public class ClientMetrics {
   /**
    * Increment BLOCKS_READ_LOCAL counter by the amount specified
    *
-   * @param n: amount to increment
+   * @param n amount to increment
    */
   public synchronized void incBlocksReadLocal(long n) {
     mMetrics.set(Constants.BLOCKS_READ_LOCAL_INDEX,
@@ -62,7 +62,7 @@ public class ClientMetrics {
   /**
    * Increment BLOCKS_READ_REMOTE counter by the amount specified
    *
-   * @param n: amount to increment
+   * @param n amount to increment
    */
   public synchronized void incBlocksReadRemote(long n) {
     mMetrics.set(Constants.BLOCKS_READ_REMOTE_INDEX,
@@ -72,7 +72,7 @@ public class ClientMetrics {
   /**
    * Increment BLOCKS_WRITTEN_LOCAL counter by the amount specified
    *
-   * @param n: amount to increment
+   * @param n amount to increment
    */
   public synchronized void incBlocksWrittenLocal(long n) {
     mMetrics.set(Constants.BLOCKS_WRITTEN_LOCAL_INDEX,
@@ -82,7 +82,7 @@ public class ClientMetrics {
   /**
    * Increment BLOCKS_WRITTEN_REMOTE counter by the amount specified
    *
-   * @param n: amount to increment
+   * @param n amount to increment
    */
   public synchronized void incBlocksWrittenRemote(long n) {
     mMetrics.set(Constants.BLOCKS_WRITTEN_REMOTE_INDEX,
@@ -92,7 +92,7 @@ public class ClientMetrics {
   /**
    * Increment BYTES_READ_LOCAL counter by the amount specified
    *
-   * @param n: amount to increment
+   * @param n amount to increment
    */
   public synchronized void incBytesReadLocal(long n) {
     mMetrics.set(Constants.BYTES_READ_LOCAL_INDEX,
@@ -102,7 +102,7 @@ public class ClientMetrics {
   /**
    * Increment BYTES_READ_REMOTE counter by the amount specified
    *
-   * @param n: amount to increment
+   * @param n amount to increment
    */
   public synchronized void incBytesReadRemote(long n) {
     mMetrics.set(Constants.BYTES_READ_REMOTE_INDEX,
@@ -112,7 +112,7 @@ public class ClientMetrics {
   /**
    * Increment BYTES_READ_UFS counter by the amount specified
    *
-   * @param n: amount to increment
+   * @param n amount to increment
    */
   public synchronized void incBytesReadUfs(long n) {
     mMetrics.set(Constants.BYTES_READ_UFS_INDEX, mMetrics.get(Constants.BYTES_READ_UFS_INDEX) + n);
@@ -121,7 +121,7 @@ public class ClientMetrics {
   /**
    * Increment BYTES_WRITTEN_LOCAL counter by the amount specified
    *
-   * @param n: amount to increment
+   * @param n amount to increment
    */
   public synchronized void incBytesWrittenLocal(long n) {
     mMetrics.set(Constants.BYTES_WRITTEN_LOCAL_INDEX,
@@ -131,7 +131,7 @@ public class ClientMetrics {
   /**
    * Increment BYTES_WRITTEN_REMOTE counter by the amount specified
    *
-   * @param n: amount to increment
+   * @param n amount to increment
    */
   public synchronized void incBytesWrittenRemote(long n) {
     mMetrics.set(Constants.BYTES_WRITTEN_REMOTE_INDEX,
@@ -141,7 +141,7 @@ public class ClientMetrics {
   /**
    * Increment BYTES_WRITTEN_UFS counter by the amount specified
    *
-   * @param n: amount to increment
+   * @param n amount to increment
    */
   public synchronized void incBytesWrittenUfs(long n) {
     mMetrics.set(Constants.BYTES_WRITTEN_UFS_INDEX,

--- a/common/src/main/java/tachyon/worker/ClientMetrics.java
+++ b/common/src/main/java/tachyon/worker/ClientMetrics.java
@@ -38,56 +38,111 @@ public class ClientMetrics {
     return defaultMetrics;
   }
 
+  /**
+   * Return current metrics as heartbeat data and reset metrics to default.
+   *
+   * @return current metrics (list of longs)
+   */
   public synchronized List<Long> getHeartbeatData() {
     List<Long> ret = mMetrics;
     mMetrics = createDefaultMetrics();
     return ret;
   }
 
+  /**
+   * Increment BLOCKS_READ_LOCAL counter by the amount specified
+   *
+   * @param n: amount to increment
+   */
   public synchronized void incBlocksReadLocal(long n) {
     mMetrics.set(Constants.BLOCKS_READ_LOCAL_INDEX,
         mMetrics.get(Constants.BLOCKS_READ_LOCAL_INDEX) + n);
   }
 
+  /**
+   * Increment BLOCKS_READ_REMOTE counter by the amount specified
+   *
+   * @param n: amount to increment
+   */
   public synchronized void incBlocksReadRemote(long n) {
     mMetrics.set(Constants.BLOCKS_READ_REMOTE_INDEX,
         mMetrics.get(Constants.BLOCKS_READ_REMOTE_INDEX) + n);
   }
 
+  /**
+   * Increment BLOCKS_WRITTEN_LOCAL counter by the amount specified
+   *
+   * @param n: amount to increment
+   */
   public synchronized void incBlocksWrittenLocal(long n) {
     mMetrics.set(Constants.BLOCKS_WRITTEN_LOCAL_INDEX,
         mMetrics.get(Constants.BLOCKS_WRITTEN_LOCAL_INDEX) + n);
   }
 
+  /**
+   * Increment BLOCKS_WRITTEN_REMOTE counter by the amount specified
+   *
+   * @param n: amount to increment
+   */
   public synchronized void incBlocksWrittenRemote(long n) {
     mMetrics.set(Constants.BLOCKS_WRITTEN_REMOTE_INDEX,
         mMetrics.get(Constants.BLOCKS_WRITTEN_REMOTE_INDEX) + n);
   }
 
+  /**
+   * Increment BYTES_READ_LOCAL counter by the amount specified
+   *
+   * @param n: amount to increment
+   */
   public synchronized void incBytesReadLocal(long n) {
     mMetrics.set(Constants.BYTES_READ_LOCAL_INDEX,
         mMetrics.get(Constants.BYTES_READ_LOCAL_INDEX) + n);
   }
 
+  /**
+   * Increment BYTES_READ_REMOTE counter by the amount specified
+   *
+   * @param n: amount to increment
+   */
   public synchronized void incBytesReadRemote(long n) {
     mMetrics.set(Constants.BYTES_READ_REMOTE_INDEX,
         mMetrics.get(Constants.BYTES_READ_REMOTE_INDEX) + n);
   }
 
+  /**
+   * Increment BYTES_READ_UFS counter by the amount specified
+   *
+   * @param n: amount to increment
+   */
   public synchronized void incBytesReadUfs(long n) {
     mMetrics.set(Constants.BYTES_READ_UFS_INDEX, mMetrics.get(Constants.BYTES_READ_UFS_INDEX) + n);
   }
 
+  /**
+   * Increment BYTES_WRITTEN_LOCAL counter by the amount specified
+   *
+   * @param n: amount to increment
+   */
   public synchronized void incBytesWrittenLocal(long n) {
     mMetrics.set(Constants.BYTES_WRITTEN_LOCAL_INDEX,
         mMetrics.get(Constants.BYTES_WRITTEN_LOCAL_INDEX) + n);
   }
 
+  /**
+   * Increment BYTES_WRITTEN_REMOTE counter by the amount specified
+   *
+   * @param n: amount to increment
+   */
   public synchronized void incBytesWrittenRemote(long n) {
     mMetrics.set(Constants.BYTES_WRITTEN_REMOTE_INDEX,
         mMetrics.get(Constants.BYTES_WRITTEN_REMOTE_INDEX) + n);
   }
 
+  /**
+   * Increment BYTES_WRITTEN_UFS counter by the amount specified
+   *
+   * @param n: amount to increment
+   */
   public synchronized void incBytesWrittenUfs(long n) {
     mMetrics.set(Constants.BYTES_WRITTEN_UFS_INDEX,
         mMetrics.get(Constants.BYTES_WRITTEN_UFS_INDEX) + n);


### PR DESCRIPTION
This checkin added javadoc to all public methods in ClientMetrics, hence TACHYON 884 through 893 can be considered fixed since they are all about javadocs of the very same class.

https://tachyon.atlassian.net/browse/TACHYON-883