### PR TITLE
[SMALLFIX] Fix mvn test -Phdfs1Test

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
@@ -206,7 +206,7 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
       throws IOException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
-      return masterClient.loadFileInfoFromUfs(path.getPath(), ufsPath.getPath(), -1L, recursive);
+      return masterClient.loadFileInfoFromUfs(path.getPath(), ufsPath.toString(), -1L, recursive);
     } finally {
       mContext.releaseMasterClient(masterClient);
     }

--- a/servers/src/main/java/tachyon/master/file/journal/AddCheckpointEntry.java
+++ b/servers/src/main/java/tachyon/master/file/journal/AddCheckpointEntry.java
@@ -35,7 +35,7 @@ public class AddCheckpointEntry implements JournalEntry {
     mWorkerId = workerId;
     mFileId = fileId;
     mLength = length;
-    mCheckpointPath = checkpointPath.getPath();
+    mCheckpointPath = checkpointPath.toString();
     mOpTimeMs = opTimeMs;
   }
 


### PR DESCRIPTION
Should not use `getPath` on ufs `TachyonURI`, use `toString` instead to preserve scheme and host.