### PR TITLE
[SMALLFIX] Fix UfsUtilsIntegrationTest#loadUnderFsTest for hdfs1Test

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -331,7 +331,7 @@ public class TachyonFS extends AbstractTachyonFS {
     if (blockSizeByte > 0) {
       return (int) mFSMasterClient.createFile(path.getPath(), blockSizeByte, recursive);
     } else {
-      return (int) mFSMasterClient.loadFileInfoFromUfs(path.getPath(), ufsPath.getPath(),
+      return (int) mFSMasterClient.loadFileInfoFromUfs(path.getPath(), ufsPath.toString(),
           blockSizeByte, recursive);
     }
   }


### PR DESCRIPTION
Also, `MasterInfoIntegrationTest` for `-Phdfs1Test` didn't hang.