### PR TITLE
[TACHYON-737] Deploy release with correct Hadoop version

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -59,6 +59,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
               ufs: UfsV.type,
 
               hadoop_version:     UfsV.hadoop.version,
+              hadoop_type:        UfsV.hadoop.type,
               hadoop_tarball_url: UfsV.hadoop.tarball_url,
 
               s3_id:     UfsV.s3.id,

--- a/deploy/vagrant/core/EnvSetup.rb
+++ b/deploy/vagrant/core/EnvSetup.rb
@@ -166,6 +166,10 @@ class HadoopVersion
   def spark_profile
     return @spark_profile
   end
+
+  def type
+    return @type
+  end
 end
 
 class S3Version

--- a/deploy/vagrant/provision/roles/tachyon/files/down_release.sh
+++ b/deploy/vagrant/provision/roles/tachyon/files/down_release.sh
@@ -6,8 +6,21 @@ DIST=/vagrant/shared/$TACHYON_DIST
 
 if [ ! -f $DIST ]; then
  version=`echo $DIST | cut -d'-' -f2`
+ if [ $UFS == "hadoop2" ]; then
+  if [ $HADOOP_TYPE == "apache" ]; then
+    hadoop_version=`echo $HADOOP_VERSION | cut -d'.' -f1,2`
+    TACHYON_DIST="tachyon-${version}-hadoop${hadoop_version}-bin.tar.gz"
+  elif [ $HADOOP_TYPE == "cdh" ]; then
+    TACHYON_DIST="tachyon-${version}-cdh4-bin.tar.gz"
+  fi
+ fi
  sudo yum install -y -q wget
  wget -q https://github.com/amplab/tachyon/releases/download/v${version}/${TACHYON_DIST} -P /vagrant/shared
+ if [ $? -eq 0 ]; then
+    tar xzf /vagrant/shared/$TACHYON_DIST -C /tachyon --strip-components 1
+ else
+    echo "ERROR: Your choice of UFS ${UFS}-${HADOOP_TYPE}-${HADOOP_VERSION} doesn't have a proper targeted Tachyon release download."
+    echo "Please choose Tachyon Github Type with desired branch."
+ fi
 fi
 
-tar xzf $DIST -C /tachyon --strip-components 1

--- a/deploy/vagrant/provision/roles/tachyon/files/down_release.sh
+++ b/deploy/vagrant/provision/roles/tachyon/files/down_release.sh
@@ -1,26 +1,29 @@
 #!/usr/bin/env bash
 
 mkdir -p /vagrant/shared
+version=`echo $TACHYON_DIST | cut -d'-' -f2`
+rc=0
 
-DIST=/vagrant/shared/$TACHYON_DIST
-
-if [ ! -f $DIST ]; then
- version=`echo $DIST | cut -d'-' -f2`
- if [ $UFS == "hadoop2" ]; then
+if [ $UFS == "hadoop2" ]; then
   if [ $HADOOP_TYPE == "apache" ]; then
     hadoop_version=`echo $HADOOP_VERSION | cut -d'.' -f1,2`
     TACHYON_DIST="tachyon-${version}-hadoop${hadoop_version}-bin.tar.gz"
   elif [ $HADOOP_TYPE == "cdh" ]; then
     TACHYON_DIST="tachyon-${version}-cdh4-bin.tar.gz"
   fi
- fi
- sudo yum install -y -q wget
- wget -q https://github.com/amplab/tachyon/releases/download/v${version}/${TACHYON_DIST} -P /vagrant/shared
- if [ $? -eq 0 ]; then
-    tar xzf /vagrant/shared/$TACHYON_DIST -C /tachyon --strip-components 1
- else
-    echo "ERROR: Your choice of UFS ${UFS}-${HADOOP_TYPE}-${HADOOP_VERSION} doesn't have a proper targeted Tachyon release download."
-    echo "Please choose Tachyon Github Type with desired branch."
- fi
 fi
 
+DIST=/vagrant/shared/$TACHYON_DIST
+
+if [ ! -f $DIST ]; then
+ sudo yum install -y -q wget
+ wget -q https://github.com/amplab/tachyon/releases/download/v${version}/${TACHYON_DIST} -P /vagrant/shared
+ rc=$?
+fi
+
+if [ $rc -eq 0 ]; then
+    tar xzf $DIST -C /tachyon --strip-components 1
+ else
+    echo "ERROR: Your choice of UFS ${UFS}-${HADOOP_TYPE}-${HADOOP_VERSION} doesn't have a proper targeted Tachyon v${version} release download."
+    echo "Please choose Tachyon Github Type with desired branch."
+ fi

--- a/deploy/vagrant/provision/roles/tachyon/tasks/download_release.yml
+++ b/deploy/vagrant/provision/roles/tachyon/tasks/download_release.yml
@@ -3,8 +3,17 @@
 
 - name: download tachyon release
   script: down_release.sh
+  register: download_release
   environment:
     TACHYON_DIST: "{{ tachyon_dist }}"
+    UFS:  "{{ ufs }}"
+    HADOOP_TYPE:  "{{ hadoop_type }}"
+    HADOOP_VERSION: "{{ hadoop_version }}"
   ignore_errors: yes # tachyon dist is tared by bsdtar, when untar using gnutar, return code will be 1
-
+- name: display download script output
+  debug: var=download_release.stdout_lines
+  when: download_release.stdout.find('ERROR') != -1
+- name: fail the play if download failed
+  fail: msg="Can't find a proper targeted Tachyon release download. Please choose Tachyon Github Type with desired branch."
+  when: download_release.stdout.find('ERROR') != -1
 # vim :set filetype=ansible.yaml:

--- a/deploy/vagrant/provision/roles/tachyon/tasks/download_release.yml
+++ b/deploy/vagrant/provision/roles/tachyon/tasks/download_release.yml
@@ -10,9 +10,11 @@
     HADOOP_TYPE:  "{{ hadoop_type }}"
     HADOOP_VERSION: "{{ hadoop_version }}"
   ignore_errors: yes # tachyon dist is tared by bsdtar, when untar using gnutar, return code will be 1
+
 - name: display download script output
   debug: var=download_release.stdout_lines
   when: download_release.stdout.find('ERROR') != -1
+
 - name: fail the play if download failed
   fail: msg="Can't find a proper targeted Tachyon release download. Please choose Tachyon Github Type with desired branch."
   when: download_release.stdout.find('ERROR') != -1


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-737

Tachyon download_release task and script are modified to determine which tachyon binary to download based on the user's understorage options. If the targeted binary release is not available, the ansible playbook will fail and display error msg guiding the user to use tachyon github type with a proper branch. 