### PR TITLE
[SMALLFIX] Handle stream operations when at the end of the file.

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/file/FileInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/FileInStream.java
@@ -257,9 +257,12 @@ public final class FileInStream extends InputStream implements BoundedStream, Se
   }
 
   /**
-   * @return the current block id based on mPos
+   * @return the current block id based on mPos, -1 if at the end of the file
    */
   private long getBlockCurrentBlockId() {
+    if (mPos == mFileLength) {
+      return -1;
+    }
     int index = (int) (mPos / mBlockSize);
     Preconditions.checkState(index < mBlockIds.size(), "Current block index exceeds max index.");
     return mBlockIds.get(index);

--- a/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
@@ -274,6 +274,29 @@ public class FileInStreamIntegrationTest {
   }
 
   /**
+   * Test <code>void seek(long pos)</code> when at the end of a file at the block boundary.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void eofSeekTest() throws IOException {
+    String uniqPath = PathUtils.uniqPath();
+    int length = BLOCK_SIZE * 3;
+    for (ClientOptions op : getOptionSet()) {
+      TachyonFile f =
+          TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + op, op, length);
+      FileInStream is = sTfs.getInStream(f, op);
+      byte[] data = new byte[length];
+      is.read(data, 0, length);
+      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(length, data));
+      is.seek(0);
+      is.read(data, 0, length);
+      Assert.assertTrue(BufferUtils.equalIncreasingByteArray(length, data));
+      is.close();
+    }
+  }
+
+  /**
    * Test <code>long skip(long len)</code>.
    */
   @Test

--- a/integration-tests/src/test/java/tachyon/hadoop/fs/DFSIOIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/fs/DFSIOIntegrationTest.java
@@ -265,7 +265,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.analyzeResult(fs, TestType.TEST_TYPE_READ, execTime);
   }
 
-  //@Test(timeout = 25000)
+  @Test(timeout = 25000)
   public void testReadRandom() throws Exception {
     FileSystem fs = FileSystem.get(sLocalTachyonClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
@@ -275,7 +275,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.analyzeResult(fs, TestType.TEST_TYPE_READ_RANDOM, execTime);
   }
 
-  //@Test(timeout = 25000)
+  @Test(timeout = 25000)
   public void testReadBackward() throws Exception {
     FileSystem fs = FileSystem.get(sLocalTachyonClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();
@@ -285,7 +285,7 @@ public class DFSIOIntegrationTest implements Tool {
     sBench.analyzeResult(fs, TestType.TEST_TYPE_READ_BACKWARD, execTime);
   }
 
-  //@Test(timeout = 25000)
+  @Test(timeout = 25000)
   public void testReadSkip() throws Exception {
     FileSystem fs = FileSystem.get(sLocalTachyonClusterUri, sBench.getConf());
     long tStart = System.currentTimeMillis();

--- a/servers/src/main/java/tachyon/Users.java
+++ b/servers/src/main/java/tachyon/Users.java
@@ -119,8 +119,7 @@ public class Users {
       if (mUsers.containsKey(userId)) {
         mUsers.get(userId).heartbeat();
       } else {
-        int userTimeoutMs =
-            mTachyonConf.getInt(Constants.WORKER_USER_TIMEOUT_MS);
+        int userTimeoutMs = mTachyonConf.getInt(Constants.WORKER_USER_TIMEOUT_MS);
         mUsers.put(userId, new UserInfo(userId, userTimeoutMs));
       }
     }


### PR DESCRIPTION
Upon reaching the end of the file, we should still allow seek operations. This fixes the bug that was breaking the dfsio tests.