### PR TITLE
[TACHYON-947] Fix failed security integration test after merging master with PR #1464

### DIFF
--- a/common/src/main/java/tachyon/MasterClientBase.java
+++ b/common/src/main/java/tachyon/MasterClientBase.java
@@ -35,6 +35,7 @@ import com.google.common.base.Throwables;
 import tachyon.conf.TachyonConf;
 import tachyon.retry.ExponentialBackoffRetry;
 import tachyon.retry.RetryPolicy;
+import tachyon.security.authentication.AuthenticationFactory;
 import tachyon.util.network.NetworkAddressUtils;
 
 /**
@@ -118,8 +119,8 @@ public abstract class MasterClientBase implements Closeable {
       LOG.info("Tachyon client (version " + Version.VERSION + ") is trying to connect with "
           + getServiceName() + " master @ " + mMasterAddress);
 
-      TProtocol binaryProtocol = new TBinaryProtocol(new TFramedTransport(
-          new TSocket(NetworkAddressUtils.getFqdnHost(mMasterAddress), mMasterAddress.getPort())));
+      TProtocol binaryProtocol = new TBinaryProtocol(new AuthenticationFactory(mTachyonConf)
+          .getClientTransport(mMasterAddress));
       mProtocol = new TMultiplexedProtocol(binaryProtocol, getServiceName());
       try {
         mProtocol.getTransport().open();

--- a/common/src/test/java/tachyon/security/LoginUserTest.java
+++ b/common/src/test/java/tachyon/security/LoginUserTest.java
@@ -74,6 +74,9 @@ public class LoginUserTest {
 
     Assert.assertNotNull(loginUser);
     Assert.assertEquals(loginUser.getName(), "tachyon-user");
+
+    // clean up
+    System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "");
   }
 
   /**
@@ -128,6 +131,9 @@ public class LoginUserTest {
 
     Assert.assertNotNull(loginUser);
     Assert.assertEquals(loginUser.getName(), "tachyon-user");
+
+    // clean up
+    System.setProperty(Constants.TACHYON_SECURITY_USERNAME, "");
   }
 
   /**

--- a/integration-tests/src/test/java/tachyon/security/MasterClientAuthenticationIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/security/MasterClientAuthenticationIntegrationTest.java
@@ -40,7 +40,6 @@ import tachyon.security.authentication.AuthenticationProvider;
  * Though its name indicates that it provides the tests for Tachyon authentication. This class is
  * likely to test four authentication modes: NOSASL, SIMPLE, CUSTOM, KERBEROS.
  */
-@Ignore
 public class MasterClientAuthenticationIntegrationTest {
   private LocalTachyonCluster mLocalTachyonCluster = null;
   private ExecutorService mExecutorService = null;

--- a/integration-tests/src/test/java/tachyon/security/WorkerClientAuthenticationIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/security/WorkerClientAuthenticationIntegrationTest.java
@@ -38,7 +38,6 @@ import tachyon.worker.WorkerClient;
  * Test RPC authentication between worker and its client, in four modes: NOSASL, SIMPLE, CUSTOM,
  * KERBEROS.
  */
-@Ignore
 public class WorkerClientAuthenticationIntegrationTest {
   private LocalTachyonCluster mLocalTachyonCluster;
   private ExecutorService mExecutorService;


### PR DESCRIPTION
JIRA: https://tachyon.atlassian.net/browse/TACHYON-947

Fix the failed test `WorkerClientAuthenticationIntegrationTest` and `MasterClientAuthenticationIntegrationTest` by using `AuthenticationFactory` to create the transport in `MasterClientBase`

@apc999 , @ooq , @shenguoquan , @sundapeng , could you please take a look? Thanks