### PR TITLE
Made TachyonFileSystem methods throw better exceptions

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
@@ -17,8 +17,6 @@ package tachyon.client;
 
 import java.io.IOException;
 
-import org.apache.thrift.TException;
-
 import tachyon.Constants;
 import tachyon.TachyonURI;
 import tachyon.client.file.TachyonFileSystem;

--- a/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/AbstractTachyonFS.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -16,6 +16,8 @@
 package tachyon.client;
 
 import java.io.IOException;
+
+import org.apache.thrift.TException;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -651,8 +651,9 @@ public class TachyonFS extends AbstractTachyonFS {
    * @return the FileInfo of the file. null if the file does not exist.
    * @throws IOException if the underlying master RPC fails
    */
-  public synchronized FileInfo getFileStatus(
-          long fileId, TachyonURI path, boolean useCachedMetadata) throws IOException {
+  public synchronized FileInfo getFileStatus(long fileId, TachyonURI path,
+                                             boolean useCachedMetadata)
+      throws IOException {
     if (fileId == -1) {
       try {
         fileId = mFSMasterClient.getFileId(path.getPath());

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -652,8 +652,7 @@ public class TachyonFS extends AbstractTachyonFS {
    * @throws IOException if the underlying master RPC fails
    */
   public synchronized FileInfo getFileStatus(long fileId, TachyonURI path,
-                                             boolean useCachedMetadata)
-      throws IOException {
+      boolean useCachedMetadata) throws IOException {
     if (fileId == -1) {
       try {
         fileId = mFSMasterClient.getFileId(path.getPath());

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,9 +42,12 @@ import tachyon.client.file.FileSystemContext;
 import tachyon.client.file.TachyonFileSystem;
 import tachyon.client.table.RawTable;
 import tachyon.conf.TachyonConf;
+import tachyon.thrift.DependencyDoesNotExistException;
 import tachyon.thrift.DependencyInfo;
 import tachyon.thrift.FileBlockInfo;
+import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.FileInfo;
+import tachyon.thrift.InvalidPathException;
 import tachyon.thrift.WorkerInfo;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.util.ThreadFactoryUtils;
@@ -268,7 +272,11 @@ public class TachyonFS extends AbstractTachyonFS {
    * @throws IOException if the underlying master RPC fails
    */
   synchronized void completeFile(long fid) throws IOException {
-    mFSMasterClient.completeFile(fid);
+    try {
+      mFSMasterClient.completeFile(fid);
+    } catch (TException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -330,11 +338,15 @@ public class TachyonFS extends AbstractTachyonFS {
   public synchronized long createFile(TachyonURI path, TachyonURI ufsPath, long blockSizeByte,
       boolean recursive) throws IOException {
     validateUri(path);
-    if (blockSizeByte > 0) {
-      return mFSMasterClient.createFile(path.getPath(), blockSizeByte, recursive);
-    } else {
-      return mFSMasterClient.loadFileInfoFromUfs(path.getPath(), ufsPath.toString(),
-          blockSizeByte, recursive);
+    try {
+      if (blockSizeByte > 0) {
+        return mFSMasterClient.createFile(path.getPath(), blockSizeByte, recursive);
+      } else {
+        return mFSMasterClient.loadFileInfoFromUfs(path.getPath(), ufsPath.toString(),
+                                                   blockSizeByte, recursive);
+      }
+    } catch (TException e) {
+      throw new IOException(e);
     }
   }
 
@@ -390,9 +402,17 @@ public class TachyonFS extends AbstractTachyonFS {
       throws IOException {
     validateUri(path);
     if (fileId == -1) {
-      fileId = mFSMasterClient.getFileId(path.getPath());
+      try {
+        fileId = mFSMasterClient.getFileId(path.getPath());
+      } catch (InvalidPathException e) {
+        throw new IOException(e);
+      }
     }
-    return mFSMasterClient.deleteFile(fileId, recursive);
+    try {
+      return mFSMasterClient.deleteFile(fileId, recursive);
+    } catch (TException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -432,7 +452,11 @@ public class TachyonFS extends AbstractTachyonFS {
       return info.blockIds.get(blockIndex);
     }
 
-    return mFSMasterClient.getFileBlockInfo(fileId, blockIndex).blockInfo.getBlockId();
+    try {
+      return mFSMasterClient.getFileBlockInfo(fileId, blockIndex).blockInfo.getBlockId();
+    } catch (TException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -548,7 +572,11 @@ public class TachyonFS extends AbstractTachyonFS {
   public synchronized List<FileBlockInfo> getFileBlocks(long fid) throws IOException {
     // TODO(haoyuan) Should read from mClientFileInfos if possible.
     // TODO(haoyuan) Should add timeout to improve this.
-    return mFSMasterClient.getFileBlockInfoList(fid);
+    try {
+      return mFSMasterClient.getFileBlockInfoList(fid);
+    } catch (FileDoesNotExistException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -588,13 +616,21 @@ public class TachyonFS extends AbstractTachyonFS {
     }
 
     if (fileId == -1) {
-      fileId = mFSMasterClient.getFileId(path);
+      try {
+        fileId = mFSMasterClient.getFileId(path);
+      } catch (InvalidPathException e) {
+        throw new IOException(e);
+      }
     }
     if (fileId == -1) {
       cache.remove(key);
       return null;
     }
-    info = mFSMasterClient.getFileInfo(fileId);
+    try {
+      info = mFSMasterClient.getFileInfo(fileId);
+    } catch (FileDoesNotExistException e) {
+      throw new IOException(e);
+    }
     path = info.getPath();
 
     // TODO(haoyuan): LRU
@@ -615,10 +651,14 @@ public class TachyonFS extends AbstractTachyonFS {
    * @return the FileInfo of the file. null if the file does not exist.
    * @throws IOException if the underlying master RPC fails
    */
-  public synchronized FileInfo getFileStatus(long fileId, TachyonURI path,
-      boolean useCachedMetadata) throws IOException {
+  public synchronized FileInfo getFileStatus(
+          long fileId, TachyonURI path, boolean useCachedMetadata) throws IOException {
     if (fileId == -1) {
-      fileId = mFSMasterClient.getFileId(path.getPath());
+      try {
+        fileId = mFSMasterClient.getFileId(path.getPath());
+      } catch (InvalidPathException e) {
+        throw new IOException(e);
+      }
     }
     return getFileStatus(mIdToClientFileInfo, fileId, fileId, TachyonURI.EMPTY_URI.getPath(),
         useCachedMetadata);
@@ -788,7 +828,11 @@ public class TachyonFS extends AbstractTachyonFS {
   @Override
   public synchronized List<FileInfo> listStatus(TachyonURI path) throws IOException {
     validateUri(path);
-    return mFSMasterClient.getFileInfoList(getFileStatus(-1, path).getFileId());
+    try {
+      return mFSMasterClient.getFileInfoList(getFileStatus(-1, path).getFileId());
+    } catch (FileDoesNotExistException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -836,7 +880,11 @@ public class TachyonFS extends AbstractTachyonFS {
   @Override
   public synchronized boolean mkdirs(TachyonURI path, boolean recursive) throws IOException {
     validateUri(path);
-    return mFSMasterClient.createDirectory(path.getPath(), recursive);
+    try {
+      return mFSMasterClient.createDirectory(path.getPath(), recursive);
+    } catch (TException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -865,9 +913,17 @@ public class TachyonFS extends AbstractTachyonFS {
       throws IOException {
     validateUri(path);
     if (fileId == -1) {
-      fileId = mFSMasterClient.getFileId(path.getPath());
+      try {
+        fileId = mFSMasterClient.getFileId(path.getPath());
+      } catch (InvalidPathException e) {
+        throw new IOException(e);
+      }
     }
-    return mFSMasterClient.free(fileId, recursive);
+    try {
+      return mFSMasterClient.free(fileId, recursive);
+    } catch (FileDoesNotExistException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -900,9 +956,17 @@ public class TachyonFS extends AbstractTachyonFS {
     validateUri(srcPath);
     validateUri(dstPath);
     if (fileId == -1) {
-      fileId = mFSMasterClient.getFileId(srcPath.getPath());
+      try {
+        fileId = mFSMasterClient.getFileId(srcPath.getPath());
+      } catch (InvalidPathException e) {
+        throw new IOException(e);
+      }
     }
-    return mFSMasterClient.renameFile(fileId, dstPath.getPath());
+    try {
+      return mFSMasterClient.renameFile(fileId, dstPath.getPath());
+    } catch (FileDoesNotExistException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -912,7 +976,11 @@ public class TachyonFS extends AbstractTachyonFS {
    * @throws IOException if the underlying master RPC fails
    */
   public synchronized void reportLostFile(long fileId) throws IOException {
-    mFSMasterClient.reportLostFile(fileId);
+    try {
+      mFSMasterClient.reportLostFile(fileId);
+    } catch (FileDoesNotExistException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -922,7 +990,11 @@ public class TachyonFS extends AbstractTachyonFS {
    * @throws IOException if the underlying master RPC fails
    */
   public synchronized void requestFilesInDependency(int depId) throws IOException {
-    mFSMasterClient.requestFilesInDependency(depId);
+    try {
+      mFSMasterClient.requestFilesInDependency(depId);
+    } catch (DependencyDoesNotExistException e) {
+      throw new IOException(e);
+    }
   }
 
   /**
@@ -961,7 +1033,11 @@ public class TachyonFS extends AbstractTachyonFS {
    * @throws IOException if the underlying master RPC fails
    */
   public synchronized void setPinned(long fid, boolean pinned) throws IOException {
-    mFSMasterClient.setPinned(fid, pinned);
+    try {
+      mFSMasterClient.setPinned(fid, pinned);
+    } catch (FileDoesNotExistException e) {
+      throw new IOException(e);
+    }
   }
 
   /**

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFSTestUtils.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFSTestUtils.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
@@ -31,7 +31,9 @@ import tachyon.client.file.TachyonFileSystem;
 import tachyon.conf.TachyonConf;
 import tachyon.thrift.BlockLocation;
 import tachyon.thrift.FileBlockInfo;
+import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.FileInfo;
+import tachyon.thrift.InvalidPathException;
 import tachyon.thrift.NetAddress;
 
 /**
@@ -171,7 +173,13 @@ public class TachyonFile implements Comparable<TachyonFile> {
     } else {
       optionsBuilder.setTachyonStoreType(TachyonStorageType.NO_STORE);
     }
-    return mTFS.getInStream(mTFS.open(uri), optionsBuilder.build());
+    try {
+      return mTFS.getInStream(mTFS.open(uri), optionsBuilder.build());
+    } catch (InvalidPathException e) {
+      throw new IOException(e.getMessage());
+    } catch (FileDoesNotExistException e) {
+      throw new IOException(e.getMessage());
+    }
   }
 
   /**

--- a/clients/unshaded/src/main/java/tachyon/client/file/FileOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/FileOutStream.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import com.google.common.base.Preconditions;
 
+import org.apache.thrift.TException;
+
 import tachyon.annotation.PublicApi;
 import tachyon.client.Cancelable;
 import tachyon.client.ClientContext;
@@ -148,6 +150,8 @@ public final class FileOutStream extends OutputStream implements Cancelable {
       FileSystemMasterClient masterClient = mContext.acquireMasterClient();
       try {
         masterClient.completeFile(mFileId);
+      } catch (TException e) {
+        throw new IOException(e);
       } finally {
         mContext.releaseMasterClient(masterClient);
       }
@@ -238,6 +242,8 @@ public final class FileOutStream extends OutputStream implements Cancelable {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.getNewBlockIdForFile(mFileId);
+    } catch (TException e) {
+      throw new IOException(e);
     } finally {
       mContext.releaseMasterClient(masterClient);
     }

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFSCore.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFSCore.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFSCore.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFSCore.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -20,7 +20,10 @@ import java.util.List;
 
 import tachyon.TachyonURI;
 import tachyon.annotation.PublicApi;
+import tachyon.thrift.FileAlreadyExistException;
+import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.FileInfo;
+import tachyon.thrift.InvalidPathException;
 
 /**
  * User facing interface for the Tachyon File System client APIs. File refers to any type of inode,
@@ -33,27 +36,30 @@ interface TachyonFSCore {
    * Deletes a file. If the file is a folder, its contents will be deleted recursively.
    *
    * @param file the handler of the file to delete.
+   * @throws FileDoesNotExistException if the given file does not exist
    * @throws IOException if the master is unable to delete the file
    */
-  void delete(TachyonFile file) throws IOException;
+  void delete(TachyonFile file) throws IOException, FileDoesNotExistException;
 
   /**
    * Removes the file from Tachyon Storage. The underlying under storage system file will not be
    * removed. If the file is a folder, its contents will be freed recursively.
    *
    * @param file the handler for the file
-   * @throws IOException if the master is unable to free the file
+   * @throws FileDoesNotExistException if the file does not exist
+   * @throws IOException if the master is unable to free the file for some other reason
    */
-  void free(TachyonFile file) throws IOException;
+  void free(TachyonFile file) throws IOException, FileDoesNotExistException;
 
   /**
    * Gets the FileInfo object that represents the Tachyon file
    *
    * @param file the handler for the file.
    * @return the FileInfo of the file, null if the file does not exist.
-   * @throws IOException if the master is unable to obtain the file's metadata
+   * @throws FileDoesNotExistException if the file does not exist
+   * @throws IOException if the master cannot retrieve the file's metadata for some other reason
    */
-  FileInfo getInfo(TachyonFile file) throws IOException;
+  FileInfo getInfo(TachyonFile file) throws IOException, FileDoesNotExistException;
 
   /**
    * If the file is a folder, returns the {@link FileInfo} of all the direct entries in it.
@@ -61,18 +67,22 @@ interface TachyonFSCore {
    *
    * @param file the handler for the file
    * @return a list of FileInfos representing the files which are children of the given file
-   * @throws IOException if the file does not exist
+   * @throws FileDoesNotExistException if the file does not exist
+   * @throws IOException if the master cannot retrieve the file status for some other reason
    */
-  List<FileInfo> listStatus(TachyonFile file) throws IOException;
+  List<FileInfo> listStatus(TachyonFile file) throws IOException, FileDoesNotExistException;
 
   /**
    * Creates a folder. If the parent folders do not exist, they will be created automatically.
    *
    * @param path the handler for the file
    * @return true if the folder is created successfully or already existing, false otherwise.
+   * @throws InvalidPathException if the provided path is invalid
+   * @throws FileAlreadyExistException if there is already a file at the given path
    * @throws IOException if the master cannot create the folder under the specified path
    */
-  boolean mkdirs(TachyonURI path) throws IOException;
+  boolean mkdirs(TachyonURI path) throws IOException, InvalidPathException,
+      FileAlreadyExistException;
 
   /**
    * Resolves a {@link TachyonURI} to a {@link TachyonFile} which is used as the file handler for
@@ -80,9 +90,10 @@ interface TachyonFSCore {
    *
    * @param path the path of the file, this should be in Tachyon space
    * @return a TachyonFile which acts as a file handler for the path
+   * @throws InvalidPathException if the provided path is invalid
    * @throws IOException if the path does not exist in Tachyon space
    */
-  TachyonFile open(TachyonURI path) throws IOException;
+  TachyonFile open(TachyonURI path) throws IOException, InvalidPathException;
 
   /**
    * Renames an existing file in Tachyon space to another path in Tachyon space.
@@ -90,9 +101,10 @@ interface TachyonFSCore {
    * @param src The file handler for the source file
    * @param dst The path of the destination file, this path should not exist
    * @return true if successful, false otherwise
+   * @throws FileDoesNotExistException if the source file does not exist
    * @throws IOException if the destination already exists or is invalid
    */
-  boolean rename(TachyonFile src, TachyonURI dst) throws IOException;
+  boolean rename(TachyonFile src, TachyonURI dst) throws IOException, FileDoesNotExistException;
 
 
   /**
@@ -103,5 +115,5 @@ interface TachyonFSCore {
    * @param pinned true to pin the file, false to unpin it
    * @throws IOException if an error occurs during the pin operation
    */
-  void setPin(TachyonFile file, boolean pinned) throws IOException;
+  void setPin(TachyonFile file, boolean pinned) throws IOException, FileDoesNotExistException;
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFSCore.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFSCore.java
@@ -56,10 +56,9 @@ interface TachyonFSCore {
    *
    * @param file the handler for the file.
    * @return the FileInfo of the file, null if the file does not exist.
-   * @throws FileDoesNotExistException if the file does not exist
    * @throws IOException if the master cannot retrieve the file's metadata for some other reason
    */
-  FileInfo getInfo(TachyonFile file) throws IOException, FileDoesNotExistException;
+  FileInfo getInfo(TachyonFile file) throws IOException;
 
   /**
    * If the file is a folder, returns the {@link FileInfo} of all the direct entries in it.

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -23,7 +23,12 @@ import tachyon.TachyonURI;
 import tachyon.annotation.PublicApi;
 import tachyon.client.ClientOptions;
 import tachyon.client.FileSystemMasterClient;
+import tachyon.thrift.BlockInfoException;
+import tachyon.thrift.DependencyDoesNotExistException;
+import tachyon.thrift.FileAlreadyExistException;
+import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.FileInfo;
+import tachyon.thrift.InvalidPathException;
 
 /**
  * Tachyon File System client. This class is the entry point for all file level operations on
@@ -67,17 +72,13 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Deletes a file. If the file is a folder, its contents will be deleted recursively. The delete
-   * will abort on a failure, but previous deletes that occurred will still be effective. The delete
-   * will only synchronously be propagated to the master. The file metadata will not be available
-   * after this call, but the data in Tachyon or under storage space may still reside until the
-   * delete is propagated.
-   *
-   * @param file the handler of the file to delete.
-   * @throws IOException if the master is unable to delete the file
+   * {@inheritDoc} The delete will abort on a failure, but previous deletes that occurred will still
+   * be effective. The delete will only synchronously be propagated to the master. The file metadata
+   * will not be available after this call, but the data in Tachyon or under storage space may still
+   * reside until the delete is propagated.
    */
   @Override
-  public void delete(TachyonFile file) throws IOException {
+  public void delete(TachyonFile file) throws IOException, FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       masterClient.deleteFile(file.getFileId(), true);
@@ -87,15 +88,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Removes the file from Tachyon Storage. The underlying under storage system file will not be
-   * removed. If the file is a folder, its contents will be freed recursively. This method is
-   * asynchronous and will be propagated to the workers through their heartbeats.
-   *
-   * @param file the handler for the file
-   * @throws IOException if the master is unable to free the file
+   * {@inheritDoc} This method is asynchronous and will be propagated to the workers through their
+   * heartbeats.
    */
   @Override
-  public void free(TachyonFile file) throws IOException {
+  public void free(TachyonFile file) throws IOException, FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       masterClient.free(file.getFileId(), true);
@@ -105,21 +102,15 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Gets the FileInfo object that represents the Tachyon file. The file info is a snapshot of the
-   * file metadata, and the locations, last modified time, and path are possibly inconsistent.
-   *
-   * @param file the handler for the file.
-   * @return the FileInfo of the file, null if the file does not exist.
-   * @throws IOException if the master is unable to obtain the file's metadata
+   * {@inheritDoc} The file info is a snapshot of the file metadata, and the locations, last
+   * modified time, and path are possibly inconsistent.
    */
   // TODO(calvin): Consider FileInfo caching.
   @Override
-  public FileInfo getInfo(TachyonFile file) throws IOException {
+  public FileInfo getInfo(TachyonFile file) throws IOException, FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.getFileInfo(file.getFileId());
-    } catch (IOException e) {
-      return null;
     } finally {
       mContext.releaseMasterClient(masterClient);
     }
@@ -133,9 +124,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
    * @param file the handler for the file.
    * @param options the set of options specific to this operation.
    * @return an input stream to read the file
-   * @throws IOException if the file does not exist or the stream cannot be opened
+   * @throws FileDoesNotExistException if the file does not exist
+   * @throws IOException if the stream cannot be opened for some other reason
    */
-  public FileInStream getInStream(TachyonFile file, ClientOptions options) throws IOException {
+  public FileInStream getInStream(TachyonFile file, ClientOptions options) throws IOException,
+      FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       // TODO(calvin): Make sure the file is not a folder.
@@ -157,9 +150,13 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
    * @param path the Tachyon path of the file
    * @param options the set of options specific to this operation
    * @return an output stream to write the file
+   * @throws InvalidPathException if the provided path is invalid
+   * @throws FileAlreadyExistException if the file being written to already exists
+   * @throws BlockInfoException if the provided block size is invalid
    * @throws IOException if the file already exists or if the stream cannot be opened
    */
-  public FileOutStream getOutStream(TachyonURI path, ClientOptions options) throws IOException {
+  public FileOutStream getOutStream(TachyonURI path, ClientOptions options) throws IOException,
+      InvalidPathException, FileAlreadyExistException, BlockInfoException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       long fileId = masterClient.createFile(path.getPath(), options.getBlockSize(), true);
@@ -176,16 +173,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * If the file is a folder, return the {@link FileInfo} of all the direct entries in it. Otherwise
-   * return the FileInfo for the file. The file infos are snapshots of the file metadata, and the
-   * locations, last modified time, and path are possibly inconsistent.
-   *
-   * @param file the handler for the file
-   * @return a list of FileInfos representing the files which are children of the given file
-   * @throws IOException if the file does not exist
+   * {@inheritDoc} The file infos are snapshots of the file metadata, and the locations, last
+   * modified time, and path are possibly inconsistent.
    */
   @Override
-  public List<FileInfo> listStatus(TachyonFile file) throws IOException {
+  public List<FileInfo> listStatus(TachyonFile file) throws IOException, FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.getFileInfoList(file.getFileId());
@@ -203,10 +195,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
    * @param ufsPath the under storage system path of the file that will back the Tachyon file
    * @param recursive if true, the parent directories to the file in Tachyon will be created
    * @return the file id of the resulting file in Tachyon
+   * @throws FileDoesNotExistException if there is no file at the given path
    * @throws IOException if the Tachyon path is invalid or the ufsPath does not exist
    */
   public long loadFileInfoFromUfs(TachyonURI path, TachyonURI ufsPath, boolean recursive)
-      throws IOException {
+      throws IOException, FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.loadFileInfoFromUfs(path.getPath(), ufsPath.toString(), -1L, recursive);
@@ -216,14 +209,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Creates a folder. If the parent folders do not exist, they will be created automatically.
-   *
-   * @param path the handler for the file
-   * @return true if the folder is created successfully or already existing, false otherwise.
-   * @throws IOException if the master cannot create the folder under the specified path
+   * {@inheritDoc}
    */
   @Override
-  public boolean mkdirs(TachyonURI path) throws IOException {
+  public boolean mkdirs(TachyonURI path) throws IOException, InvalidPathException,
+      FileAlreadyExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       // TODO: Change this RPC's arguments
@@ -234,15 +224,10 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Resolves a {@link TachyonURI} to a {@link TachyonFile} which is used as the file handler for
-   * non-create operations.
-   *
-   * @param path the path of the file, this should be in Tachyon space
-   * @return a TachyonFile which acts as a file handler for the path
-   * @throws IOException if the path does not exist in Tachyon space
+   * {@inheritDoc}
    */
   @Override
-  public TachyonFile open(TachyonURI path) throws IOException {
+  public TachyonFile open(TachyonURI path) throws IOException, InvalidPathException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return new TachyonFile(masterClient.getFileId(path.getPath()));
@@ -257,10 +242,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
    *
    * @param file the file handler for the file to pin
    * @param pinned true to pin the file, false to unpin it
+   * @throws FileDoesNotExistException if the file does not exist
    * @throws IOException if an error occurs during the pin operation
    */
-  @Override
-  public void setPin(TachyonFile file, boolean pinned) throws IOException {
+  public void setPin(TachyonFile file, boolean pinned) throws IOException,
+      FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       masterClient.setPinned(file.getFileId(), pinned);
@@ -270,15 +256,11 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
   }
 
   /**
-   * Renames an existing file in Tachyon space to another path in Tachyon space.
-   *
-   * @param src The file handler for the source file
-   * @param dst The path of the destination file, this path should not exist
-   * @return true if successful, false otherwise
-   * @throws IOException if the destination already exists or is invalid
+   * {@inheritDoc}
    */
   @Override
-  public boolean rename(TachyonFile src, TachyonURI dst) throws IOException {
+  public boolean rename(TachyonFile src, TachyonURI dst) throws IOException,
+      FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.renameFile(src.getFileId(), dst.getPath());
@@ -287,7 +269,7 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
     }
   }
 
-  public void reportLostFile(TachyonFile file) throws IOException {
+  public void reportLostFile(TachyonFile file) throws IOException, FileDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       masterClient.reportLostFile(file.getFileId());
@@ -296,7 +278,8 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
     }
   }
 
-  public void requestFilesInDependency(int depId) throws IOException {
+  public void requestFilesInDependency(int depId) throws IOException,
+      DependencyDoesNotExistException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       masterClient.requestFilesInDependency(depId);

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
@@ -107,10 +107,12 @@ public class TachyonFileSystem implements Closeable, TachyonFSCore {
    */
   // TODO(calvin): Consider FileInfo caching.
   @Override
-  public FileInfo getInfo(TachyonFile file) throws IOException, FileDoesNotExistException {
+  public FileInfo getInfo(TachyonFile file) throws IOException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       return masterClient.getFileInfo(file.getFileId());
+    } catch (FileDoesNotExistException e) {
+      return null;
     } finally {
       mContext.releaseMasterClient(masterClient);
     }

--- a/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -382,7 +382,6 @@ abstract class AbstractTFS extends FileSystem {
    * @see org.apache.hadoop.fs.FileSystem#createFileSystem(java.net.URI,
    *      org.apache.hadoop.conf.Configuration)
    */
-  @Override
   public abstract String getScheme();
 
   /**

--- a/common/src/main/java/tachyon/client/FileSystemMasterClient.java
+++ b/common/src/main/java/tachyon/client/FileSystemMasterClient.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -81,14 +81,14 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @return the file id for the given path
    * @throws IOException if an I/O error occurs
    */
-  public synchronized long getFileId(String path) throws IOException {
+  public synchronized long getFileId(String path) throws IOException, InvalidPathException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.getFileId(path);
       } catch (InvalidPathException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -102,16 +102,15 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @return the file info for the given file id
    * @throws IOException if an I/O error occurs
    */
-  public synchronized FileInfo getFileInfo(long fileId) throws IOException {
+  public synchronized FileInfo getFileInfo(long fileId) throws IOException,
+      FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.getFileInfo(fileId);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
-      } catch (InvalidPathException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -125,16 +124,15 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @return the list of file information for the given file id
    * @throws IOException if an I/O error occurs
    */
-  public synchronized List<FileInfo> getFileInfoList(long fileId) throws IOException {
+  public synchronized List<FileInfo> getFileInfoList(long fileId) throws IOException,
+      FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.getFileInfoList(fileId);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
-      } catch (InvalidPathException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -151,16 +149,16 @@ public final class FileSystemMasterClient extends MasterClientBase {
    */
   // TODO: Not sure if this is necessary
   public synchronized FileBlockInfo getFileBlockInfo(long fileId, int fileBlockIndex)
-      throws IOException {
+      throws IOException, FileDoesNotExistException, BlockInfoException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.getFileBlockInfo(fileId, fileBlockIndex);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (BlockInfoException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -175,14 +173,15 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @throws IOException if an I/O error occurs
    */
   // TODO: Not sure if this is necessary
-  public synchronized List<FileBlockInfo> getFileBlockInfoList(long fileId) throws IOException {
+  public synchronized List<FileBlockInfo> getFileBlockInfoList(long fileId) throws IOException,
+      FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.getFileBlockInfoList(fileId);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -196,14 +195,15 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @return a new block id for the given file id
    * @throws IOException if an I/O error occurs.
    */
-  public synchronized long getNewBlockIdForFile(long fileId) throws IOException {
+  public synchronized long getNewBlockIdForFile(long fileId) throws IOException,
+      FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.getNewBlockIdForFile(fileId);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -216,14 +216,14 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @return the set of pinned file ids
    * @throws IOException if an I/O error occurs
    */
-  public synchronized Set<Long> getPinList() throws IOException {
+  public synchronized Set<Long> getPinList() throws IOException, InvalidPathException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.workerGetPinIdList();
       } catch (InvalidPathException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -260,18 +260,18 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @throws IOException if an I/O error occurs
    */
   public synchronized long createFile(String path, long blockSizeBytes, boolean recursive)
-      throws IOException {
+      throws IOException, BlockInfoException, InvalidPathException, FileAlreadyExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.createFile(path, blockSizeBytes, recursive);
       } catch (BlockInfoException e) {
-        throw new IOException(e);
+        throw e;
       } catch (InvalidPathException e) {
-        throw new IOException(e);
+        throw e;
       } catch (FileAlreadyExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -291,14 +291,14 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @throws IOException if an I/O error occurs
    */
   public synchronized long loadFileInfoFromUfs(String path, String ufsPath, long blockSizeByte,
-      boolean recursive) throws IOException {
+      boolean recursive) throws IOException, FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.loadFileInfoFromUfs(path, ufsPath, blockSizeByte, recursive);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -313,7 +313,8 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @param fileId the file id
    * @throws IOException if an I/O error occurs
    */
-  public synchronized void completeFile(long fileId) throws IOException {
+  public synchronized void completeFile(long fileId) throws IOException, FileDoesNotExistException,
+      SuspectedFileSizeException, BlockInfoException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
@@ -321,11 +322,11 @@ public final class FileSystemMasterClient extends MasterClientBase {
         mClient.completeFile(fileId);
         return;
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (SuspectedFileSizeException e) {
-        throw new IOException(e);
+        throw e;
       } catch (BlockInfoException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -342,14 +343,15 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @return whether operation succeeded or not
    * @throws IOException if an I/O error occurs
    */
-  public synchronized boolean deleteFile(long fileId, boolean recursive) throws IOException {
+  public synchronized boolean deleteFile(long fileId, boolean recursive) throws IOException,
+      FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.deleteFile(fileId, recursive);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -366,14 +368,15 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @return whether operation succeeded or not
    * @throws IOException if an I/O error occurs
    */
-  public synchronized boolean renameFile(long fileId, String dstPath) throws IOException {
+  public synchronized boolean renameFile(long fileId, String dstPath) throws IOException,
+      FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.renameFile(fileId, dstPath);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -389,7 +392,8 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @param pinned the pinned status to use
    * @throws IOException if an I/O error occurs
    */
-  public synchronized void setPinned(long fileId, boolean pinned) throws IOException {
+  public synchronized void setPinned(long fileId, boolean pinned) throws IOException,
+      FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
@@ -397,7 +401,7 @@ public final class FileSystemMasterClient extends MasterClientBase {
         mClient.setPinned(fileId, pinned);
         return;
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -414,16 +418,17 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @return whether operation succeeded or not
    * @throws IOException if an I/O error occurs
    */
-  public synchronized boolean createDirectory(String path, boolean recursive) throws IOException {
+  public synchronized boolean createDirectory(String path, boolean recursive) throws IOException,
+      FileAlreadyExistException, InvalidPathException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.createDirectory(path, recursive);
-      } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
       } catch (InvalidPathException e) {
-        throw new IOException(e);
+        throw e;
+      } catch (FileAlreadyExistException e) {
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -440,16 +445,15 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @return whether operation succeeded or not
    * @throws IOException if an I/O error occurs
    */
-  public synchronized boolean free(long fileId, boolean recursive) throws IOException {
+  public synchronized boolean free(long fileId, boolean recursive) throws IOException,
+      FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.free(fileId, recursive);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
-      } catch (InvalidPathException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -469,14 +473,14 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @throws IOException if an I/O error occurs
    */
   public synchronized boolean addCheckpoint(long workerId, long fileId, long length,
-      String checkpointPath) throws IOException {
+      String checkpointPath) throws IOException, FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         return mClient.addCheckpoint(workerId, fileId, length, checkpointPath);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -491,14 +495,15 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @param fileId the file id
    * @throws IOException if an I/O error occurs
    */
-  public synchronized void reportLostFile(long fileId) throws IOException {
+  public synchronized void reportLostFile(long fileId) throws IOException,
+      FileDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         mClient.reportLostFile(fileId);
       } catch (FileDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;
@@ -513,14 +518,15 @@ public final class FileSystemMasterClient extends MasterClientBase {
    * @param depId the dependency id
    * @throws IOException if an I/O error occurs
    */
-  public synchronized void requestFilesInDependency(int depId) throws IOException {
+  public synchronized void requestFilesInDependency(int depId) throws IOException,
+      DependencyDoesNotExistException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
         mClient.requestFilesInDependency(depId);
       } catch (DependencyDoesNotExistException e) {
-        throw new IOException(e);
+        throw e;
       } catch (TException e) {
         LOG.error(e.getMessage(), e);
         mConnected = false;

--- a/common/src/main/java/tachyon/util/OSUtils.java
+++ b/common/src/main/java/tachyon/util/OSUtils.java
@@ -18,13 +18,13 @@ package tachyon.util;
 import org.apache.commons.lang3.SystemUtils;
 
 /**
- * OS related utility functions 
+ * OS related utility functions
  */
 public final class OSUtils {
   private OSUtils() {}
 
   /**
-   * @return true if current OS is Windows 
+   * @return true if current OS is Windows
    */
   public static boolean isWindows() {
     return SystemUtils.IS_OS_WINDOWS;

--- a/common/src/main/java/tachyon/worker/WorkerClient.java
+++ b/common/src/main/java/tachyon/worker/WorkerClient.java
@@ -83,7 +83,6 @@ public final class WorkerClient implements Closeable {
    * @param workerNetAddress to worker's location
    * @param executorService the executor service
    * @param conf Tachyon configuration
-   * @param sessionId the id of the session
    * @param clientMetrics metrics of the lcient.
    */
   public WorkerClient(NetAddress workerNetAddress, ExecutorService executorService,

--- a/examples/src/main/java/tachyon/examples/BasicCheckpoint.java
+++ b/examples/src/main/java/tachyon/examples/BasicCheckpoint.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,7 +99,7 @@ public class BasicCheckpoint implements Callable<Boolean> {
     return pass;
   }
 
-  private void writeFile(TachyonFS tachyonClient) throws IOException {
+  private void writeFile(TachyonFS tachyonClient) throws IOException, TException {
     for (int i = 0; i < mNumFiles; i ++) {
       ByteBuffer buf = ByteBuffer.allocate(80);
       buf.order(ByteOrder.nativeOrder());

--- a/integration-tests/src/test/java/tachyon/client/BlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/BlockInStreamIntegrationTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -76,7 +77,7 @@ public class BlockInStreamIntegrationTest {
    * Test <code>void read()</code>.
    */
   @Test
-  public void readTest1() throws IOException {
+  public void readTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -106,7 +107,7 @@ public class BlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>.
    */
   @Test
-  public void readTest2() throws IOException {
+  public void readTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -132,7 +133,7 @@ public class BlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code>.
    */
   @Test
-  public void readTest3() throws IOException {
+  public void readTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -159,7 +160,7 @@ public class BlockInStreamIntegrationTest {
    * Test <code>long skip(long len)</code>.
    */
   @Test
-  public void skipTest() throws IOException {
+  public void skipTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {

--- a/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -81,7 +82,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>void read()</code> across block boundary.
    */
   @Test
-  public void readTest1() throws IOException {
+  public void readTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -123,7 +124,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>.
    */
   @Test
-  public void readTest2() throws IOException {
+  public void readTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -149,7 +150,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code>.
    */
   @Test
-  public void readTest3() throws IOException {
+  public void readTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -175,7 +176,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code> for end of file.
    */
   @Test
-  public void readEndOfFileTest() throws IOException {
+  public void readEndOfFileTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -203,9 +204,10 @@ public class FileInStreamIntegrationTest {
    * position.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekExceptionTest1() throws IOException {
+  public void seekExceptionTest1() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
@@ -230,7 +232,7 @@ public class FileInStreamIntegrationTest {
    * @throws IOException
    */
   @Test
-  public void seekExceptionTest2() throws IOException {
+  public void seekExceptionTest2() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
@@ -252,9 +254,10 @@ public class FileInStreamIntegrationTest {
    * Test <code>void seek(long pos)</code>.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekTest() throws IOException {
+  public void seekTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -279,7 +282,7 @@ public class FileInStreamIntegrationTest {
    * @throws IOException
    */
   @Test
-  public void eofSeekTest() throws IOException {
+  public void eofSeekTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     int length = BLOCK_SIZE * 3;
     for (ClientOptions op : getOptionSet()) {
@@ -300,7 +303,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>long skip(long len)</code>.
    */
   @Test
-  public void skipTest() throws IOException {
+  public void skipTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {

--- a/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -71,9 +72,9 @@ public class FileOutStreamIntegrationTest {
   public static Collection<Object[]> data() {
     List<Object[]> list = new ArrayList<Object[]>();
     // Enable local writes.
-    list.add(new Object[] { true });
+    list.add(new Object[] {true});
     // Disable local writes.
-    list.add(new Object[] { false });
+    list.add(new Object[] {false});
     return list;
   }
 
@@ -122,9 +123,8 @@ public class FileOutStreamIntegrationTest {
    * @param increasingByteArrayLen expected length of increasing bytes written in the file
    * @throws IOException
    */
-  private void checkWrite(TachyonURI filePath, UnderStorageType underStorageType, int fileLen, int
-      increasingByteArrayLen)
-      throws IOException {
+  private void checkWrite(TachyonURI filePath, UnderStorageType underStorageType, int fileLen,
+      int increasingByteArrayLen) throws IOException, TException {
     for (ClientOptions op : getOptionSet()) {
       TachyonFile file = mTfs.open(filePath);
       FileInfo info = mTfs.getInfo(file);
@@ -159,7 +159,7 @@ public class FileOutStreamIntegrationTest {
    * Test <code>void write(int b)</code>.
    */
   @Test
-  public void writeTest1() throws IOException {
+  public void writeTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -168,7 +168,8 @@ public class FileOutStreamIntegrationTest {
     }
   }
 
-  private void writeTest1Util(TachyonURI filePath, ClientOptions op, int len) throws IOException {
+  private void writeTest1Util(TachyonURI filePath, ClientOptions op, int len) throws IOException,
+    TException {
     FileOutStream os = mTfs.getOutStream(filePath, op);
     for (int k = 0; k < len; k ++) {
       os.write((byte) k);
@@ -181,7 +182,7 @@ public class FileOutStreamIntegrationTest {
    * Test <code>void write(byte[] b)</code>.
    */
   @Test
-  public void writeTest2() throws IOException {
+  public void writeTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -190,7 +191,8 @@ public class FileOutStreamIntegrationTest {
     }
   }
 
-  private void writeTest2Util(TachyonURI filePath, ClientOptions op, int len) throws IOException {
+  private void writeTest2Util(TachyonURI filePath, ClientOptions op, int len) throws IOException,
+    TException {
     FileOutStream os = mTfs.getOutStream(filePath, op);
     os.write(BufferUtils.getIncreasingByteArray(len));
     os.close();
@@ -201,7 +203,7 @@ public class FileOutStreamIntegrationTest {
    * Test <code>void write(byte[] b, int off, int len)</code>.
    */
   @Test
-  public void writeTest3() throws IOException {
+  public void writeTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -210,7 +212,8 @@ public class FileOutStreamIntegrationTest {
     }
   }
 
-  private void writeTest3Util(TachyonURI filePath, ClientOptions op, int len) throws IOException {
+  private void writeTest3Util(TachyonURI filePath, ClientOptions op, int len) throws IOException,
+    TException {
     FileOutStream os = mTfs.getOutStream(filePath, op);
     os.write(BufferUtils.getIncreasingByteArray(0, len / 2), 0, len / 2);
     os.write(BufferUtils.getIncreasingByteArray(len / 2, len / 2), 0, len / 2);
@@ -226,7 +229,7 @@ public class FileOutStreamIntegrationTest {
    * @throws InterruptedException
    */
   @Test
-  public void longWriteChangesSessionId() throws IOException, InterruptedException {
+  public void longWriteChangesSessionId() throws IOException, InterruptedException, TException {
     TachyonURI filePath = new TachyonURI(PathUtils.uniqPath());
     int len = 2;
     FileOutStream os = mTfs.getOutStream(filePath, sWriteUnderStore);
@@ -239,13 +242,13 @@ public class FileOutStreamIntegrationTest {
 
   /**
    * Tests if out-of-order writes are possible. Writes could be out-of-order when the following are
-   * both true:
-   * - a "large" write (over half the internal buffer size) follows a smaller write.
-   * - the "large" write does not cause the internal buffer to overflow.
+   * both true: - a "large" write (over half the internal buffer size) follows a smaller write. -
+   * the "large" write does not cause the internal buffer to overflow.
+   *
    * @throws IOException
    */
   @Test
-  public void outOfOrderWriteTest() throws IOException {
+  public void outOfOrderWriteTest() throws IOException, TException {
     TachyonURI filePath = new TachyonURI(PathUtils.uniqPath());
     FileOutStream os = mTfs.getOutStream(filePath, sWriteTachyon);
 

--- a/integration-tests/src/test/java/tachyon/client/IsolatedTachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/IsolatedTachyonFileSystemIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/client/IsolatedTachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/IsolatedTachyonFileSystemIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -75,7 +76,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void lockBlockTest1() throws IOException {
+  public void lockBlockTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     int numOfFiles = 5;
     int fileSize = WORKER_CAPACITY_BYTES / numOfFiles;
@@ -86,8 +87,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
     for (int k = 0; k < numOfFiles; k ++) {
       Assert.assertTrue(mTfs.getInfo(files.get(k)).getInMemoryPercentage() == 100);
     }
-    files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + numOfFiles,
-        mWriteBoth, fileSize));
+    files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + numOfFiles, mWriteBoth, fileSize));
 
     CommonUtils.sleepMs(mWorkerToMasterHeartbeatIntervalMs);
 
@@ -98,7 +98,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void lockBlockTest2() throws IOException {
+  public void lockBlockTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile tFile = null;
     FileInStream is = null;
@@ -129,7 +129,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void lockBlockTest3() throws IOException {
+  public void lockBlockTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile tFile = null;
     FileInStream is = null;
@@ -165,7 +165,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void unlockBlockTest1() throws IOException {
+  public void unlockBlockTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile tFile = null;
     FileInStream is = null;
@@ -196,7 +196,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void unlockBlockTest2() throws IOException {
+  public void unlockBlockTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile tFile = null;
     FileInStream is = null;
@@ -230,7 +230,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void unlockBlockTest3() throws IOException {
+  public void unlockBlockTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile tFile = null;
     FileInStream is = null;
@@ -240,8 +240,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
     int fileSize = WORKER_CAPACITY_BYTES / numOfFiles;
     List<TachyonFile> files = new ArrayList<TachyonFile>();
     for (int k = 0; k < numOfFiles; k ++) {
-      files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + k, mWriteBoth,
-          fileSize));
+      files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + k, mWriteBoth, fileSize));
     }
     for (int k = 0; k < numOfFiles; k ++) {
       FileInfo info = mTfs.getInfo(files.get(k));

--- a/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -83,7 +84,7 @@ public class LocalBlockInStreamIntegrationTest {
    * Test <code>void read()</code>.
    */
   @Test
-  public void readTest1() throws IOException {
+  public void readTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -127,7 +128,7 @@ public class LocalBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>.
    */
   @Test
-  public void readTest2() throws IOException {
+  public void readTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -155,7 +156,7 @@ public class LocalBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code>.
    */
   @Test
-  public void readTest3() throws IOException {
+  public void readTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -184,9 +185,10 @@ public class LocalBlockInStreamIntegrationTest {
    * position.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekExceptionTest1() throws IOException {
+  public void seekExceptionTest1() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("Seek position is negative: -1");
     String uniqPath = PathUtils.uniqPath();
@@ -211,9 +213,10 @@ public class LocalBlockInStreamIntegrationTest {
    * that is past buffer limit.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekExceptionTest2() throws IOException {
+  public void seekExceptionTest2() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("Seek position is past EOF: 1, fileSize = 0");
 
@@ -237,9 +240,10 @@ public class LocalBlockInStreamIntegrationTest {
    * Test <code>void seek(long pos)</code>.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekTest() throws IOException {
+  public void seekTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {
@@ -263,7 +267,7 @@ public class LocalBlockInStreamIntegrationTest {
    * Test <code>long skip(long len)</code>.
    */
   @Test
-  public void skipTest() throws IOException {
+  public void skipTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       for (ClientOptions op : getOptionSet()) {

--- a/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/RemoteBlockInStreamIntegrationTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -131,7 +132,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read()</code>. Read from underfs.
    */
   @Test
-  public void readTest1() throws IOException {
+  public void readTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -192,7 +193,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>. Read from underfs.
    */
   @Test
-  public void readTest2() throws IOException {
+  public void readTest2() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -229,7 +230,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code>. Read from underfs.
    */
   @Test
-  public void readTest3() throws IOException {
+  public void readTest3() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -266,7 +267,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read()</code>. Read from remote data server.
    */
   @Test
-  public void readTest4() throws IOException {
+  public void readTest4() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -297,7 +298,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>. Read from remote data server.
    */
   @Test
-  public void readTest5() throws IOException {
+  public void readTest5() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -324,7 +325,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b, int off, int len)</code>. Read from remote data server.
    */
   @Test
-  public void readTest6() throws IOException {
+  public void readTest6() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -351,7 +352,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void read(byte[] b)</code>. Read from underfs.
    */
   @Test
-  public void readTest7() throws IOException {
+  public void readTest7() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -372,9 +373,10 @@ public class RemoteBlockInStreamIntegrationTest {
    * position.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekExceptionTest1() throws IOException {
+  public void seekExceptionTest1() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("Seek position is negative: -1");
     String uniqPath = PathUtils.uniqPath();
@@ -396,9 +398,10 @@ public class RemoteBlockInStreamIntegrationTest {
    * that is past block size.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekExceptionTest2() throws IOException {
+  public void seekExceptionTest2() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("Seek position is past EOF: 1, fileSize = 0");
     String uniqPath = PathUtils.uniqPath();
@@ -419,9 +422,10 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>void seek(long pos)</code>.
    *
    * @throws IOException
+   * @throws TException
    */
   @Test
-  public void seekTest() throws IOException {
+  public void seekTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -444,7 +448,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Test <code>long skip(long len)</code>.
    */
   @Test
-  public void skipTest() throws IOException {
+  public void skipTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       TachyonFile f =
@@ -473,7 +477,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Tests that reading a file the whole way through with the STORE ReadType will recache it
    */
   @Test
-  public void completeFileReadTriggersRecache() throws IOException {
+  public void completeFileReadTriggersRecache() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     int len = 2;
     TachyonFile f =
@@ -492,7 +496,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * recache
    */
   @Test
-  public void incompleteFileReadCancelsRecache() throws IOException {
+  public void incompleteFileReadCancelsRecache() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonFile f =
         TachyonFSTestUtils.createByteFile(mTfs, uniqPath, mWriteUnderStore, 2);
@@ -509,7 +513,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Tests that reading a file consisting of more than one block from the underfs works
    */
   @Test
-  public void readMultiBlockFile() throws IOException {
+  public void readMultiBlockFile() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     int blockSizeByte = 10;
     int numBlocks = 10;
@@ -534,7 +538,7 @@ public class RemoteBlockInStreamIntegrationTest {
    * Tests that seeking around a file cached locally works.
    */
   @Test
-  public void seekAroundLocalBlock() throws IOException {
+  public void seekAroundLocalBlock() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     // The number of bytes per remote block read should be set to 100 in the before function
     TachyonFile f = TachyonFSTestUtils.createByteFile(mTfs, uniqPath, mWriteTachyon, 200);

--- a/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -17,6 +17,7 @@ package tachyon.client;
 
 import java.io.IOException;
 
+import org.apache.thrift.TException;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -54,7 +55,7 @@ public class TachyonFileSystemIntegrationTest {
   public ExpectedException mThrown = ExpectedException.none();
 
   @Before
-  public final void before() throws IOException {
+  public final void before() throws IOException, TException {
     mMasterTachyonConf = sLocalTachyonCluster.getMasterTachyonConf();
     mMasterTachyonConf.set(Constants.MAX_COLUMNS, "257");
     mWorkerTachyonConf = sLocalTachyonCluster.getWorkerTachyonConf();
@@ -68,8 +69,8 @@ public class TachyonFileSystemIntegrationTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
     System.setProperty(Constants.USER_FILE_BUFFER_BYTES, Integer.toString(USER_QUOTA_UNIT_BYTES));
-    sLocalTachyonCluster = new LocalTachyonCluster(WORKER_CAPACITY_BYTES, USER_QUOTA_UNIT_BYTES,
-        Constants.GB);
+    sLocalTachyonCluster =
+        new LocalTachyonCluster(WORKER_CAPACITY_BYTES, USER_QUOTA_UNIT_BYTES, Constants.GB);
     sLocalTachyonCluster.start();
     sTfs = sLocalTachyonCluster.getClient();
     sHost = sLocalTachyonCluster.getMasterHostname();
@@ -83,12 +84,12 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void getRootTest() throws IOException {
+  public void getRootTest() throws IOException, TException {
     Assert.assertEquals(0, sTfs.getInfo(sTfs.open(new TachyonURI("/"))).getFileId());
   }
 
   @Test
-  public void createFileTest() throws IOException {
+  public void createFileTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = 1; k < 5; k ++) {
       TachyonURI uri = new TachyonURI(uniqPath + k);
@@ -98,7 +99,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test(expected = IOException.class)
-  public void createFileWithFileAlreadyExistExceptionTest() throws IOException {
+  public void createFileWithFileAlreadyExistExceptionTest() throws IOException, TException {
     TachyonURI uri = new TachyonURI(PathUtils.uniqPath());
     sTfs.getOutStream(uri, sWriteBoth).close();
     Assert.assertNotNull(sTfs.getInfo(sTfs.open(uri)));
@@ -108,7 +109,7 @@ public class TachyonFileSystemIntegrationTest {
   // TODO: Validate the URI
   @Ignore
   @Test
-  public void createFileWithInvalidPathExceptionTest() throws IOException {
+  public void createFileWithInvalidPathExceptionTest() throws IOException, TException {
     mThrown.expect(IllegalArgumentException.class);
     mThrown.expectMessage("URI must be absolute, unless it's empty.");
     sTfs.getOutStream(new TachyonURI("root/testFile1"), sWriteBoth);
@@ -118,13 +119,12 @@ public class TachyonFileSystemIntegrationTest {
 
   // TODO: Check worker capacity?
   @Test
-  public void deleteFileTest() throws IOException {
+  public void deleteFileTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
 
     for (int k = 0; k < 5; k ++) {
       TachyonURI fileURI = new TachyonURI(uniqPath + k);
-      TachyonFile f =
-          TachyonFSTestUtils.createByteFile(sTfs, fileURI.getPath(), sWriteBoth, k);
+      TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, fileURI.getPath(), sWriteBoth, k);
       Assert.assertTrue(sTfs.getInfo(f).getInMemoryPercentage() == 100);
       Assert.assertNotNull(sTfs.getInfo(f));
     }
@@ -138,7 +138,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void getFileStatusTest() throws IOException {
+  public void getFileStatusTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     int writeBytes = USER_QUOTA_UNIT_BYTES * 2;
     TachyonURI uri = new TachyonURI(uniqPath);
@@ -150,7 +150,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void mkdirTest() throws IOException {
+  public void mkdirTest() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     for (int k = 0; k < 10; k ++) {
       Assert.assertTrue(sTfs.mkdirs(new TachyonURI(uniqPath + k)));
@@ -159,7 +159,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void renameFileTest1() throws IOException {
+  public void renameFileTest1() throws IOException, TException {
     String uniqPath = PathUtils.uniqPath();
     TachyonURI path1 = new TachyonURI(uniqPath + 1);
     sTfs.getOutStream(path1, sWriteBoth).close();
@@ -177,7 +177,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   @Test
-  public void renameFileTest2() throws IOException {
+  public void renameFileTest2() throws IOException, TException {
     TachyonURI uniqUri = new TachyonURI(PathUtils.uniqPath());
     sTfs.getOutStream(uniqUri, sWriteBoth).close();
     TachyonFile f = sTfs.open(uniqUri);

--- a/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
@@ -33,6 +33,7 @@ import tachyon.client.file.TachyonFile;
 import tachyon.client.file.TachyonFileSystem;
 import tachyon.conf.TachyonConf;
 import tachyon.master.LocalTachyonCluster;
+import tachyon.thrift.FileAlreadyExistException;
 import tachyon.thrift.FileInfo;
 import tachyon.util.io.PathUtils;
 
@@ -98,7 +99,7 @@ public class TachyonFileSystemIntegrationTest {
     }
   }
 
-  @Test(expected = IOException.class)
+  @Test(expected = FileAlreadyExistException.class)
   public void createFileWithFileAlreadyExistExceptionTest() throws IOException, TException {
     TachyonURI uri = new TachyonURI(PathUtils.uniqPath());
     sTfs.getOutStream(uri, sWriteBoth).close();

--- a/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -18,6 +18,7 @@ package tachyon.client;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -61,7 +62,7 @@ public class UfsUtilsIntegrationTest {
   }
 
   @Test
-  public void loadUnderFsTest() throws IOException {
+  public void loadUnderFsTest() throws IOException, TException {
     String[] exclusions = {"/tachyon", "/exclusions"};
     String[] inclusions = {"/inclusions/sub-1", "/inclusions/sub-2"};
     for (String exclusion : exclusions) {

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractDeleteIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractDeleteIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractDeleteIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractDeleteIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/master/FileSystemMasterClientIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/FileSystemMasterClientIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/master/FileSystemMasterClientIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/FileSystemMasterClientIntegrationTest.java
@@ -72,7 +72,7 @@ public class FileSystemMasterClientIntegrationTest {
     fsMasterClient.close();
   }
 
-  @Test(timeout = 3000, expected = IOException.class)
+  @Test(timeout = 3000, expected = FileDoesNotExistException.class)
   public void user_getClientBlockInfoReturnsOnError() throws IOException,
           FileDoesNotExistException {
     // This test was created to show that an infinite loop occurs.

--- a/integration-tests/src/test/java/tachyon/master/FileSystemMasterClientIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/FileSystemMasterClientIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -28,6 +28,7 @@ import org.junit.Test;
 import tachyon.Constants;
 import tachyon.client.FileSystemMasterClient;
 import tachyon.conf.TachyonConf;
+import tachyon.thrift.FileDoesNotExistException;
 
 /**
  * Test the internal implementation of tachyon Master via a
@@ -55,8 +56,9 @@ public class FileSystemMasterClientIntegrationTest {
 
   @Test
   public void openCloseTest() throws TException, IOException {
-    FileSystemMasterClient fsMasterClient = new FileSystemMasterClient(
-        mLocalTachyonCluster.getMaster().getAddress(), mExecutorService, mMasterTachyonConf);
+    FileSystemMasterClient fsMasterClient =
+        new FileSystemMasterClient(mLocalTachyonCluster.getMaster().getAddress(), mExecutorService,
+            mMasterTachyonConf);
     Assert.assertFalse(fsMasterClient.isConnected());
     fsMasterClient.connect();
     Assert.assertTrue(fsMasterClient.isConnected());
@@ -71,12 +73,14 @@ public class FileSystemMasterClientIntegrationTest {
   }
 
   @Test(timeout = 3000, expected = IOException.class)
-  public void user_getClientBlockInfoReturnsOnError() throws IOException {
+  public void user_getClientBlockInfoReturnsOnError() throws IOException,
+          FileDoesNotExistException {
     // This test was created to show that an infinite loop occurs.
     // The timeout will protect against this, and the change was to throw a IOException
     // in the cases we don't want to disconnect from master
-    FileSystemMasterClient fsMasterClient = new FileSystemMasterClient(
-        mLocalTachyonCluster.getMaster().getAddress(), mExecutorService, mMasterTachyonConf);
+    FileSystemMasterClient fsMasterClient =
+        new FileSystemMasterClient(mLocalTachyonCluster.getMaster().getAddress(), mExecutorService,
+            mMasterTachyonConf);
     fsMasterClient.getFileInfo(Long.MAX_VALUE);
     fsMasterClient.close();
   }

--- a/integration-tests/src/test/java/tachyon/master/MasterFaultToleranceIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/MasterFaultToleranceIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/master/MasterFaultToleranceIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/MasterFaultToleranceIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -67,7 +68,7 @@ public class MasterFaultToleranceIntegrationTest {
    * @throws IOException if an error occurs creating the file
    */
   private void faultTestDataCreation(TachyonURI folderName, List<Pair<Long, TachyonURI>> answer)
-      throws IOException {
+      throws IOException, TException {
     mTfs.mkdirs(folderName);
     answer.add(new Pair<Long, TachyonURI>(mTfs.open(folderName).getFileId(), folderName));
 
@@ -85,7 +86,8 @@ public class MasterFaultToleranceIntegrationTest {
    * @param answer the correct results
    * @throws IOException if an error occurs opening the file
    */
-  private void faultTestDataCheck(List<Pair<Long, TachyonURI>> answer) throws IOException {
+  private void faultTestDataCheck(List<Pair<Long, TachyonURI>> answer) throws IOException,
+      TException {
     List<String> files = TachyonFSTestUtils.listFiles(mTfs, TachyonURI.SEPARATOR);
     Collections.sort(files);
     Assert.assertEquals(answer.size(), files.size());
@@ -98,7 +100,7 @@ public class MasterFaultToleranceIntegrationTest {
   }
 
   @Test
-  public void faultTest() throws IOException {
+  public void faultTest() throws IOException, TException {
     int clients = 10;
     List<Pair<Long, TachyonURI>> answer = Lists.newArrayList();
     for (int k = 0; k < clients; k ++) {
@@ -115,7 +117,7 @@ public class MasterFaultToleranceIntegrationTest {
   }
 
   @Test
-  public void createFilesTest() throws IOException {
+  public void createFilesTest() throws IOException, TException {
     int clients = 10;
     ClientOptions option = new ClientOptions.Builder(new TachyonConf()).setBlockSize(1024)
         .setUnderStorageType(UnderStorageType.PERSIST).build();

--- a/integration-tests/src/test/java/tachyon/master/PinIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/PinIntegrationTest.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -148,7 +149,8 @@ public class PinIntegrationTest {
         Sets.newHashSet(file0.getFileId(), file3.getFileId()));
   }
 
-  private TachyonFile createEmptyFile(TachyonURI fileURI) throws IOException {
+  private TachyonFile createEmptyFile(TachyonURI fileURI) throws IOException,
+    TException {
     ClientOptions options =
         new ClientOptions.Builder(new TachyonConf()).setTachyonStoreType(TachyonStorageType.STORE)
             .setUnderStorageType(UnderStorageType.NO_PERSIST).build();

--- a/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/DataServerIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -85,8 +86,8 @@ public class DataServerIntegrationTest {
   private final String mDataServerClass;
   private final String mNettyTransferType;
   private final String mBlockReader;
-  private final ExecutorService mExecutorService =
-      Executors.newFixedThreadPool(2, ThreadFactoryUtils.build("test-executor-%d", true));
+  private final ExecutorService mExecutorService = Executors.newFixedThreadPool(2,
+      ThreadFactoryUtils.build("test-executor-%d", true));
 
   private LocalTachyonCluster mLocalTachyonCluster = null;
   private TachyonFileSystem mTFS = null;
@@ -159,7 +160,7 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void lengthTooSmall() throws IOException {
+  public void lengthTooSmall() throws IOException, TException {
     final int length = 20;
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", TachyonStorageType.STORE,
@@ -170,7 +171,7 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void multiReadTest() throws IOException {
+  public void multiReadTest() throws IOException, TException {
     final int length = 20;
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTFS, "/multiReadTest", TachyonStorageType.STORE,
@@ -183,7 +184,7 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void negativeOffset() throws IOException {
+  public void negativeOffset() throws IOException, TException {
     final int length = 10;
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", TachyonStorageType.STORE,
@@ -194,7 +195,7 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void readMultiFiles() throws IOException {
+  public void readMultiFiles() throws IOException, TException {
     final int length = WORKER_CAPACITY_BYTES / 2 + 1;
     TachyonFile file1 =
         TachyonFSTestUtils.createByteFile(mTFS, "/readFile1", TachyonStorageType.STORE,
@@ -210,16 +211,16 @@ public class DataServerIntegrationTest {
     DataServerMessage recvMsg2 = request(block2);
     assertValid(recvMsg2, length, block2.getBlockId(), 0, length);
 
-    CommonUtils.sleepMs(
-        mWorkerTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS) * 2 + 10);
+    CommonUtils
+        .sleepMs(mWorkerTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS) * 2
+                + 10);
 
     FileInfo fileInfo = mTFS.getInfo(mTFS.open(new TachyonURI("/readFile1")));
     Assert.assertEquals(0, fileInfo.inMemoryPercentage);
   }
 
   @Test
-  public void readPartialTest1() throws InvalidPathException, FileAlreadyExistException,
-      IOException {
+  public void readPartialTest1() throws TException, IOException {
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTFS, "/testFile", TachyonStorageType.STORE,
             UnderStorageType.NO_PERSIST, 10);
@@ -231,8 +232,7 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void readPartialTest2() throws InvalidPathException, FileAlreadyExistException,
-      IOException {
+  public void readPartialTest2() throws TException, IOException {
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTFS, "/testFile", TachyonStorageType.STORE,
             UnderStorageType.NO_PERSIST, 10);
@@ -245,7 +245,7 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void readTest() throws InvalidPathException, FileAlreadyExistException, IOException {
+  public void readTest() throws IOException, TException {
     final int length = 10;
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTFS, "/testFile", TachyonStorageType.STORE,
@@ -256,8 +256,7 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void readThroughClientTest()
-      throws InvalidPathException, FileAlreadyExistException, IOException {
+  public void readThroughClientTest() throws IOException, TException {
     final int length = 10;
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTFS, "/testFile", TachyonStorageType.STORE,
@@ -276,8 +275,7 @@ public class DataServerIntegrationTest {
 
   // TODO: Make this work with the new BlockReader
   // @Test
-  public void readThroughClientNonExistentTest()
-      throws InvalidPathException, FileAlreadyExistException, IOException {
+  public void readThroughClientNonExistentTest() throws IOException, TException {
     final int length = 10;
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTFS, "/testFile", TachyonStorageType.STORE,
@@ -304,7 +302,7 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void readTooLarge() throws IOException {
+  public void readTooLarge() throws IOException, TException {
     final int length = 20;
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", TachyonStorageType.STORE,
@@ -315,7 +313,7 @@ public class DataServerIntegrationTest {
   }
 
   @Test
-  public void tooLargeOffset() throws IOException {
+  public void tooLargeOffset() throws IOException, TException {
     final int length = 10;
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTFS, "/readTooLarge", TachyonStorageType.STORE,
@@ -328,7 +326,7 @@ public class DataServerIntegrationTest {
   /**
    * Requests a block from the server. This call will read the full block.
    */
-  private DataServerMessage request(final BlockInfo block) throws IOException {
+  private DataServerMessage request(final BlockInfo block) throws IOException, TException {
     return request(block, 0, -1);
   }
 
@@ -337,7 +335,7 @@ public class DataServerIntegrationTest {
    * response from the server.
    */
   private DataServerMessage request(final BlockInfo block, final long offset, final long length)
-      throws IOException {
+      throws IOException, TException {
     DataServerMessage sendMsg =
         DataServerMessage.createBlockRequestMessage(block.blockId, offset, length);
     SocketChannel socketChannel = SocketChannel
@@ -367,8 +365,9 @@ public class DataServerIntegrationTest {
    * @param tachyonFile the file to get the first MasterBlockInfro for
    * @return the MasterBlockInfo of the first block in the file
    * @throws IOException if the block does not exist
+   * @throws TException
    */
-  private BlockInfo getFirstBlockInfo(TachyonFile tachyonFile) throws IOException {
+  private BlockInfo getFirstBlockInfo(TachyonFile tachyonFile) throws IOException, TException {
     FileInfo fileInfo = mTFS.getInfo(tachyonFile);
     return mBlockMasterClient.getBlockInfo(fileInfo.blockIds.get(0));
   }

--- a/integration-tests/src/test/java/tachyon/worker/block/meta/CapacityUsageIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/block/meta/CapacityUsageIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/integration-tests/src/test/java/tachyon/worker/block/meta/CapacityUsageIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/block/meta/CapacityUsageIntegrationTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,13 +70,14 @@ public class CapacityUsageIntegrationTest {
         new LocalTachyonCluster(MEM_CAPACITY_BYTES, USER_QUOTA_UNIT_BYTES, MEM_CAPACITY_BYTES / 2);
     mLocalTachyonCluster.start();
 
-    mLocalTachyonCluster.getWorkerTachyonConf()
-        .set(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS, HEARTBEAT_INTERVAL_MS + "");
+    mLocalTachyonCluster.getWorkerTachyonConf().set(
+        Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS, HEARTBEAT_INTERVAL_MS + "");
     mTFS = mLocalTachyonCluster.getClient();
   }
 
-  private TachyonFile createAndWriteFile(TachyonURI filePath, TachyonStorageType tachyonStorageType,
-      UnderStorageType underStorageType, int len) throws IOException {
+  private TachyonFile createAndWriteFile(TachyonURI filePath,
+      TachyonStorageType tachyonStorageType, UnderStorageType underStorageType, int len)
+      throws IOException, TException {
     ByteBuffer buf = ByteBuffer.allocate(len);
     buf.order(ByteOrder.nativeOrder());
     for (int k = 0; k < len; k ++) {
@@ -91,18 +93,20 @@ public class CapacityUsageIntegrationTest {
     return mTFS.open(filePath);
   }
 
-  private void deleteDuringEviction(int i) throws IOException {
+  private void deleteDuringEviction(int i) throws IOException, TException {
     final String fileName1 = "/file" + i + "_1";
     final String fileName2 = "/file" + i + "_2";
-    TachyonFile file1 = createAndWriteFile(new TachyonURI(fileName1), TachyonStorageType.STORE,
-        UnderStorageType.PERSIST, MEM_CAPACITY_BYTES);
+    TachyonFile file1 =
+        createAndWriteFile(new TachyonURI(fileName1), TachyonStorageType.STORE,
+            UnderStorageType.PERSIST, MEM_CAPACITY_BYTES);
     FileInfo fileInfo1 = mTFS.getInfo(file1);
     Assert.assertTrue(fileInfo1.getInMemoryPercentage() == 100);
     // Deleting file1, command will be sent by master to worker asynchronously
     mTFS.delete(file1);
     // Meanwhile creating file2. If creation arrives earlier than deletion, it will evict file1
-    TachyonFile file2 = createAndWriteFile(new TachyonURI(fileName2), TachyonStorageType.STORE,
-        UnderStorageType.PERSIST, MEM_CAPACITY_BYTES / 4);
+    TachyonFile file2 =
+        createAndWriteFile(new TachyonURI(fileName2), TachyonStorageType.STORE,
+            UnderStorageType.PERSIST, MEM_CAPACITY_BYTES / 4);
     FileInfo fileInfo2 = mTFS.getInfo(file2);
     Assert.assertTrue(fileInfo2.getInMemoryPercentage() == 100);
     mTFS.delete(file2);
@@ -110,7 +114,7 @@ public class CapacityUsageIntegrationTest {
 
   // TODO: Rethink the approach of this test and what it should be testing
   // @Test
-  public void deleteDuringEvictionTest() throws IOException {
+  public void deleteDuringEvictionTest() throws IOException, TException {
     // This test may not trigger eviction each time, repeat it 20 times.
     for (int i = 0; i < 20; i ++) {
       deleteDuringEviction(i);

--- a/integration-tests/src/test/java/tachyon/worker/block/meta/TieredStoreIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/block/meta/TieredStoreIntegrationTest.java
@@ -37,6 +37,7 @@ import tachyon.client.file.TachyonFileSystem;
 import tachyon.client.file.TachyonFile;
 import tachyon.conf.TachyonConf;
 import tachyon.master.LocalTachyonCluster;
+import tachyon.thrift.InvalidPathException;
 import tachyon.util.CommonUtils;
 import tachyon.util.io.BufferUtils;
 
@@ -100,7 +101,7 @@ public class TieredStoreIntegrationTest {
     try {
       mTFS.open(new TachyonURI("/test1"));
       Assert.fail("file should not exist: /test1");
-    } catch (IOException ioe) {
+    } catch (InvalidPathException e) {
       // This is expected, since the file should not exist.
     }
 

--- a/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
@@ -341,7 +341,7 @@ public final class FileSystemMaster extends MasterBase {
     }
   }
 
-  private FileInfo getFileInfo(Inode inode) throws FileDoesNotExistException, InvalidPathException {
+  private FileInfo getFileInfo(Inode inode) throws FileDoesNotExistException {
     FileInfo fileInfo = inode.generateClientFileInfo(mInodeTree.getPath(inode).toString());
     fileInfo.inMemoryPercentage = getInMemoryPercentage(inode);
     return fileInfo;
@@ -358,7 +358,7 @@ public final class FileSystemMaster extends MasterBase {
    * @throws InvalidPathException
    */
   public List<FileInfo> getFileInfoList(long fileId)
-      throws FileDoesNotExistException, InvalidPathException {
+      throws FileDoesNotExistException {
     synchronized (mInodeTree) {
       Inode inode = mInodeTree.getInodeById(fileId);
 
@@ -943,11 +943,10 @@ public final class FileSystemMaster extends MasterBase {
    * @param fileId the file to free
    * @param recursive if true, and the file is a directory, all descendants will be freed
    * @return true if the file was freed
-   * @throws InvalidPathException
    * @throws FileDoesNotExistException
    */
   public boolean free(long fileId, boolean recursive)
-      throws InvalidPathException, FileDoesNotExistException {
+      throws FileDoesNotExistException {
     // TODO: metrics
     synchronized (mInodeTree) {
       Inode inode = mInodeTree.getInodeById(fileId);

--- a/servers/src/main/java/tachyon/master/file/FileSystemMasterServiceHandler.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMasterServiceHandler.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/servers/src/main/java/tachyon/master/file/FileSystemMasterServiceHandler.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMasterServiceHandler.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
-
-import org.apache.thrift.TException;
 
 import tachyon.TachyonURI;
 import tachyon.thrift.BlockInfoException;
@@ -44,12 +42,12 @@ public final class FileSystemMasterServiceHandler implements FileSystemMasterSer
   }
 
   @Override
-  public Set<Long> workerGetPinIdList() throws TException {
+  public Set<Long> workerGetPinIdList() {
     return mFileSystemMaster.getPinIdList();
   }
 
   @Override
-  public List<Integer> workerGetPriorityDependencyList() throws TException {
+  public List<Integer> workerGetPriorityDependencyList() {
     return mFileSystemMaster.getPriorityDependencyList();
   }
 
@@ -61,62 +59,60 @@ public final class FileSystemMasterServiceHandler implements FileSystemMasterSer
   }
 
   @Override
-  public long getFileId(String path) throws InvalidPathException, TException {
+  public long getFileId(String path) throws InvalidPathException {
     return mFileSystemMaster.getFileId(new TachyonURI(path));
   }
 
   @Override
-  public FileInfo getFileInfo(long fileId) throws FileDoesNotExistException, TException {
+  public FileInfo getFileInfo(long fileId) throws FileDoesNotExistException, InvalidPathException {
     return mFileSystemMaster.getFileInfo(fileId);
   }
 
   @Override
-  public List<FileInfo> getFileInfoList(long fileId) throws FileDoesNotExistException, TException {
+  public List<FileInfo> getFileInfoList(long fileId) throws FileDoesNotExistException {
     return mFileSystemMaster.getFileInfoList(fileId);
   }
 
   @Override
   public FileBlockInfo getFileBlockInfo(long fileId, int fileBlockIndex)
-      throws FileDoesNotExistException, BlockInfoException, TException {
+      throws FileDoesNotExistException, BlockInfoException {
     return mFileSystemMaster.getFileBlockInfo(fileId, fileBlockIndex);
   }
 
   @Override
-  public List<FileBlockInfo> getFileBlockInfoList(long fileId)
-      throws FileDoesNotExistException, TException {
+  public List<FileBlockInfo> getFileBlockInfoList(long fileId) throws FileDoesNotExistException {
     return mFileSystemMaster.getFileBlockInfoList(fileId);
   }
 
   @Override
-  public long getNewBlockIdForFile(long fileId)
-      throws FileDoesNotExistException, BlockInfoException, TException {
+  public long getNewBlockIdForFile(long fileId) throws FileDoesNotExistException {
     return mFileSystemMaster.getNewBlockIdForFile(fileId);
   }
 
   @Override
-  public String getUfsAddress() throws TException {
+  public String getUfsAddress() {
     return mFileSystemMaster.getUfsAddress();
   }
 
   @Override
   public long createFile(String path, long blockSizeBytes, boolean recursive)
-          throws FileAlreadyExistException, BlockInfoException, SuspectedFileSizeException,
-          TachyonException, InvalidPathException {
+      throws FileAlreadyExistException, BlockInfoException, InvalidPathException {
     return mFileSystemMaster.createFile(new TachyonURI(path), blockSizeBytes, recursive);
   }
 
   @Override
   public boolean completeFileCheckpoint(long workerId, long fileId, long length,
       String checkpointPath) throws FileDoesNotExistException, SuspectedFileSizeException,
-          BlockInfoException, TException {
-    return mFileSystemMaster.completeFileCheckpoint(workerId, fileId, length,
-        new TachyonURI(checkpointPath));
+      BlockInfoException {
+    return mFileSystemMaster.completeFileCheckpoint(workerId, fileId, length, new TachyonURI(
+        checkpointPath));
   }
 
   @Override
   public long loadFileInfoFromUfs(String path, String ufsPath, long blockSizeByte,
-      boolean recursive) throws FileAlreadyExistException, BlockInfoException,
-          SuspectedFileSizeException, TachyonException, TException {
+                                  boolean recursive)
+      throws FileAlreadyExistException, BlockInfoException, SuspectedFileSizeException,
+      TachyonException, InvalidPathException {
     if (ufsPath == null || ufsPath.isEmpty()) {
       throw new IllegalArgumentException("the underFS path is not provided");
     }
@@ -131,67 +127,66 @@ public final class FileSystemMasterServiceHandler implements FileSystemMasterSer
       return fileId;
     } catch (IOException e) {
       throw new TachyonException(e.getMessage());
+    } catch (FileDoesNotExistException e) {
+      throw new TachyonException(e.getMessage());
     }
   }
 
   @Override
-  public void completeFile(long fileId)
-      throws FileDoesNotExistException, BlockInfoException, TException {
+  public void completeFile(long fileId) throws FileDoesNotExistException, BlockInfoException {
     mFileSystemMaster.completeFile(fileId);
   }
 
   @Override
-  public boolean deleteFile(long fileId, boolean recursive) throws TachyonException, TException {
+  public boolean deleteFile(long fileId, boolean recursive) throws TachyonException,
+      FileDoesNotExistException {
     return mFileSystemMaster.deleteFile(fileId, recursive);
   }
 
   @Override
   public boolean renameFile(long fileId, String dstPath) throws FileAlreadyExistException,
-      FileDoesNotExistException, InvalidPathException, TException {
+      FileDoesNotExistException, InvalidPathException {
     return mFileSystemMaster.rename(fileId, new TachyonURI(dstPath));
   }
 
   @Override
-  public void setPinned(long fileId, boolean pinned) throws FileDoesNotExistException, TException {
+  public void setPinned(long fileId, boolean pinned) throws FileDoesNotExistException {
     mFileSystemMaster.setPinned(fileId, pinned);
   }
 
   @Override
-  public boolean createDirectory(String path, boolean recursive)
-      throws FileAlreadyExistException, InvalidPathException, TException {
+  public boolean createDirectory(String path, boolean recursive) throws FileAlreadyExistException,
+      InvalidPathException {
     mFileSystemMaster.mkdirs(new TachyonURI(path), recursive);
     return true;
   }
 
   @Override
-  public boolean free(long fileId, boolean recursive) throws FileDoesNotExistException, TException {
+  public boolean free(long fileId, boolean recursive) throws FileDoesNotExistException {
     return mFileSystemMaster.free(fileId, recursive);
   }
 
   @Override
   public int createDependency(List<String> parents, List<String> children, String commandPrefix,
       List<ByteBuffer> data, String comment, String framework, String frameworkVersion,
-      int dependencyType, long childrenBlockSizeByte)
-          throws InvalidPathException, FileDoesNotExistException, FileAlreadyExistException,
-          BlockInfoException, TachyonException, TException {
+      int dependencyType, long childrenBlockSizeByte) throws InvalidPathException,
+      FileDoesNotExistException, FileAlreadyExistException, BlockInfoException, TachyonException {
     // TODO
     return 0;
   }
 
   @Override
-  public DependencyInfo getDependencyInfo(int dependencyId)
-      throws DependencyDoesNotExistException, TException {
+  public DependencyInfo getDependencyInfo(int dependencyId) throws DependencyDoesNotExistException {
     return mFileSystemMaster.getClientDependencyInfo(dependencyId);
   }
 
   @Override
-  public void reportLostFile(long fileId) throws FileDoesNotExistException, TException {
+  public void reportLostFile(long fileId) throws FileDoesNotExistException {
     mFileSystemMaster.reportLostFile(fileId);
   }
 
   @Override
-  public void requestFilesInDependency(int depId)
-      throws DependencyDoesNotExistException, TException {
+  public void requestFilesInDependency(int depId) throws DependencyDoesNotExistException {
     mFileSystemMaster.requestFilesInDependency(depId);
   }
 

--- a/servers/src/main/java/tachyon/master/file/FileSystemMasterServiceHandler.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMasterServiceHandler.java
@@ -100,8 +100,8 @@ public final class FileSystemMasterServiceHandler implements FileSystemMasterSer
 
   @Override
   public long createFile(String path, long blockSizeBytes, boolean recursive)
-      throws FileAlreadyExistException, BlockInfoException, SuspectedFileSizeException,
-      TachyonException, TException {
+          throws FileAlreadyExistException, BlockInfoException, SuspectedFileSizeException,
+          TachyonException, InvalidPathException {
     return mFileSystemMaster.createFile(new TachyonURI(path), blockSizeBytes, recursive);
   }
 

--- a/servers/src/main/java/tachyon/web/WebInterfaceDownloadServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceDownloadServlet.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/servers/src/main/java/tachyon/web/WebInterfaceDownloadServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceDownloadServlet.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -97,7 +97,8 @@ public final class WebInterfaceDownloadServlet extends HttpServlet {
    * @throws IOException
    */
   private void downloadFile(TachyonURI path, HttpServletRequest request,
-      HttpServletResponse response) throws FileDoesNotExistException, IOException {
+      HttpServletResponse response) throws FileDoesNotExistException, IOException,
+      InvalidPathException {
     TachyonFileSystem tachyonClient = TachyonFileSystem.get();
     TachyonFile fd = tachyonClient.open(path);
     FileInfo tFile = tachyonClient.getInfo(fd);

--- a/servers/src/test/java/tachyon/master/file/meta/InodeDirectoryTest.java
+++ b/servers/src/test/java/tachyon/master/file/meta/InodeDirectoryTest.java
@@ -130,7 +130,7 @@ public final class InodeDirectoryTest extends AbstractInodeTest {
     InodeDirectory inodeDirectory = createInodeDirectory();
     // This is not perfect, since time could have passed between creation and this call.
     long createTimeMs = System.currentTimeMillis();
-    Assert.assertEquals(createTimeMs, inodeDirectory.getLastModificationTimeMs());
+    Assert.assertTrue(Math.abs(createTimeMs - inodeDirectory.getLastModificationTimeMs()) < 5);
 
     long modificationTimeMs = createTimeMs + Constants.SECOND_MS;
     inodeDirectory.setLastModificationTimeMs(modificationTimeMs);

--- a/shell/src/main/java/tachyon/shell/TFsShell.java
+++ b/shell/src/main/java/tachyon/shell/TFsShell.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/shell/src/main/java/tachyon/shell/TFsShell.java
+++ b/shell/src/main/java/tachyon/shell/TFsShell.java
@@ -972,7 +972,7 @@ public class TFsShell implements Closeable {
    * @throws IOException
    */
   private long getFileOrFolderSize(TachyonFileSystem tachyonFS, TachyonURI path)
-          throws IOException {
+      throws IOException {
     long sizeInBytes = 0;
     List<FileInfo> files = null;
     try {

--- a/shell/src/main/java/tachyon/shell/TFsShell.java
+++ b/shell/src/main/java/tachyon/shell/TFsShell.java
@@ -598,15 +598,30 @@ public class TFsShell implements Closeable {
    * @return The number of argument of the input command
    */
   public int getNumOfArgs(String cmd) {
-    if (cmd.equals("getUsedBytes") || cmd.equals("getCapacityBytes")) {
+    if (cmd.equals("getUsedBytes")
+        || cmd.equals("getCapacityBytes")) {
       return 0;
-    } else if (cmd.equals("cat") || cmd.equals("count") || cmd.equals("ls") || cmd.equals("lsr")
-        || cmd.equals("mkdir") || cmd.equals("rm") || cmd.equals("rmr") || cmd.equals("tail")
-        || cmd.equals("touch") || cmd.equals("load") || cmd.equals("fileinfo")
-        || cmd.equals("location") || cmd.equals("report") || cmd.equals("pin")
-        || cmd.equals("unpin") || cmd.equals("free") || cmd.equals("du")) {
+    } else if (cmd.equals("cat")
+        || cmd.equals("count")
+        || cmd.equals("ls")
+        || cmd.equals("lsr")
+        || cmd.equals("mkdir")
+        || cmd.equals("rm")
+        || cmd.equals("rmr")
+        || cmd.equals("tail")
+        || cmd.equals("touch")
+        || cmd.equals("load")
+        || cmd.equals("fileinfo")
+        || cmd.equals("location")
+        || cmd.equals("report")
+        || cmd.equals("pin")
+        || cmd.equals("unpin")
+        || cmd.equals("free")
+        || cmd.equals("du")) {
       return 1;
-    } else if (cmd.equals("copyFromLocal") || cmd.equals("copyToLocal") || cmd.equals("request")
+    } else if (cmd.equals("copyFromLocal")
+        || cmd.equals("copyToLocal")
+        || cmd.equals("request")
         || cmd.equals("mv")) {
       return 2;
     } else {

--- a/shell/src/main/java/tachyon/shell/TFsShell.java
+++ b/shell/src/main/java/tachyon/shell/TFsShell.java
@@ -105,9 +105,6 @@ public class TFsShell implements Closeable {
     } catch (InvalidPathException ioe) {
       System.out.println(path + " does not exist.");
       return -1;
-    } catch (FileDoesNotExistException ioe) {
-      System.out.println(path + " does not exist.");
-      return -1;
     }
 
     if (!tFile.isFolder) {
@@ -164,8 +161,6 @@ public class TFsShell implements Closeable {
     } catch (IOException ioe) {
       return -1;
     } catch (InvalidPathException e) {
-      return -1;
-    } catch (FileDoesNotExistException e) {
       return -1;
     }
 
@@ -237,8 +232,6 @@ public class TFsShell implements Closeable {
           dstPath = dstPath.join(src.getName());
         }
       } catch (InvalidPathException e) {
-        // The dstPath may already be the path of the file where src will be copied to, do nothing
-      } catch (FileDoesNotExistException e) {
         // The dstPath may already be the path of the file where src will be copied to, do nothing
       }
       Closer closer = Closer.create();
@@ -372,8 +365,6 @@ public class TFsShell implements Closeable {
     } catch (InvalidPathException e) {
       System.out.println(path + " does not exist.");
       return -1;
-    } catch (FileDoesNotExistException e) {
-      throw new IOException(e);
     }
 
     if (fInfo.isFolder) {
@@ -404,8 +395,6 @@ public class TFsShell implements Closeable {
     } catch (InvalidPathException ioe) {
       System.out.println(path + " does not exist.");
       return -1;
-    } catch (FileDoesNotExistException e) {
-      throw new IOException(e);
     }
 
     System.out.println(path + " with file id " + fd.getFileId() + " is on nodes: ");
@@ -688,8 +677,6 @@ public class TFsShell implements Closeable {
     } catch (InvalidPathException ioe) {
       System.out.println("rm: cannot remove '" + path + "': No such file or directory");
       return -1;
-    } catch (FileDoesNotExistException e) {
-      throw new IOException(e);
     }
 
     if (fInfo.isFolder) {
@@ -869,8 +856,6 @@ public class TFsShell implements Closeable {
     } catch (InvalidPathException e) {
       System.out.println(path + " does not exist.");
       return -1;
-    } catch (FileDoesNotExistException e) {
-      throw new IOException(e);
     }
 
     if (!fInfo.isFolder) {

--- a/shell/src/main/java/tachyon/shell/TFsShellUtils.java
+++ b/shell/src/main/java/tachyon/shell/TFsShellUtils.java
@@ -27,7 +27,9 @@ import tachyon.Constants;
 import tachyon.TachyonURI;
 import tachyon.client.file.TachyonFileSystem;
 import tachyon.conf.TachyonConf;
+import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.FileInfo;
+import tachyon.thrift.InvalidPathException;
 import tachyon.util.io.PathUtils;
 import tachyon.util.network.NetworkAddressUtils;
 import tachyon.util.network.NetworkAddressUtils.ServiceType;
@@ -122,7 +124,14 @@ public class TFsShellUtils {
   private static List<TachyonURI> getTachyonURIs(TachyonFileSystem tachyonClient,
       TachyonURI inputURI, TachyonURI parentDir) throws IOException {
     List<TachyonURI> res = new LinkedList<TachyonURI>();
-    List<FileInfo> files = tachyonClient.listStatus(tachyonClient.open(parentDir));
+    List<FileInfo> files = null;
+    try {
+      files = tachyonClient.listStatus(tachyonClient.open(parentDir));
+    } catch (FileDoesNotExistException e) {
+      throw new IOException(e);
+    } catch (InvalidPathException e) {
+      throw new IOException(e);
+    }
     for (FileInfo file : files) {
       TachyonURI fileURI =
           new TachyonURI(inputURI.getScheme(), inputURI.getAuthority(), file.getPath());

--- a/shell/src/test/java/tachyon/shell/TFsShellTest.java
+++ b/shell/src/test/java/tachyon/shell/TFsShellTest.java
@@ -459,14 +459,15 @@ public class TFsShellTest {
 
   @Test
   public void mkdirTest() throws IOException, TException {
-    String qualifiedPath = "tachyon://" + mLocalTachyonCluster.getMasterHostname() + ":"
-        + mLocalTachyonCluster.getMasterPort() + "/root/testFile1";
+    String qualifiedPath =
+        "tachyon://" + mLocalTachyonCluster.getMasterHostname() + ":"
+            + mLocalTachyonCluster.getMasterPort() + "/root/testFile1";
     mFsShell.run(new String[] {"mkdir", qualifiedPath});
     TachyonFile tFile = mTfs.open(new TachyonURI("/root/testFile1"));
     FileInfo fileInfo = mTfs.getInfo(tFile);
     Assert.assertNotNull(fileInfo);
-    Assert.assertEquals(getCommandOutput(new String[]{"mkdir", qualifiedPath}),
-            mOutput.toString());
+    Assert
+        .assertEquals(getCommandOutput(new String[] {"mkdir", qualifiedPath}), mOutput.toString());
     Assert.assertTrue(fileInfo.isIsFolder());
   }
 

--- a/shell/src/test/java/tachyon/shell/TFsShellTest.java
+++ b/shell/src/test/java/tachyon/shell/TFsShellTest.java
@@ -23,6 +23,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 
+import org.apache.thrift.TEnum;
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -40,6 +42,7 @@ import tachyon.client.file.TachyonFileSystem;
 import tachyon.conf.TachyonConf;
 import tachyon.master.LocalTachyonCluster;
 import tachyon.thrift.FileInfo;
+import tachyon.thrift.InvalidPathException;
 import tachyon.util.CommonUtils;
 import tachyon.util.FormatUtils;
 import tachyon.util.io.BufferUtils;
@@ -102,7 +105,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void copyFromLocalLargeTest() throws IOException {
+  public void copyFromLocalLargeTest() throws IOException, TException {
     File testFile = new File(mLocalTachyonCluster.getTachyonHome() + "/testFile");
     testFile.createNewFile();
     FileOutputStream fos = new FileOutputStream(testFile);
@@ -128,7 +131,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void loadFileTest() throws IOException {
+  public void loadFileTest() throws IOException, TException {
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTfs, "/testFile", TachyonStorageType.NO_STORE,
             UnderStorageType.PERSIST, 10);
@@ -141,7 +144,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void loadDirTest() throws IOException {
+  public void loadDirTest() throws IOException, TException {
     TachyonFile fileA = TachyonFSTestUtils.createByteFile(mTfs, "/testRoot/testFileA",
         TachyonStorageType.NO_STORE, UnderStorageType.PERSIST, 10);
     TachyonFile fileB = TachyonFSTestUtils.createByteFile(mTfs, "/testRoot/testFileB",
@@ -159,7 +162,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void copyFromLocalTest() throws IOException {
+  public void copyFromLocalTest() throws IOException, TException {
     File testDir = new File(mLocalTachyonCluster.getTachyonHome() + "/testDir");
     testDir.mkdir();
     File testDirInner = new File(mLocalTachyonCluster.getTachyonHome() + "/testDir/testDirInner");
@@ -187,7 +190,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void copyFromLocalTestWithFullURI() throws IOException {
+  public void copyFromLocalTestWithFullURI() throws IOException, TException {
     File testFile = generateFileContent("/srcFileURI", BufferUtils.getIncreasingByteArray(10));
     String tachyonURI = "tachyon://" + mLocalTachyonCluster.getMasterHostname() + ":"
         + mLocalTachyonCluster.getMasterPort() + "/destFileURI";
@@ -205,7 +208,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void copyFromLocalFileToDstPathTest() throws IOException {
+  public void copyFromLocalFileToDstPathTest() throws IOException, TException {
     String dataString = "copyFromLocalFileToDstPathTest";
     byte[] data = dataString.getBytes();
     File localDir = new File(mLocalTachyonCluster.getTachyonHome() + "/localDir");
@@ -250,7 +253,7 @@ public class TFsShellTest {
   @Test
   public void countNotExistTest() throws IOException {
     int ret = mFsShell.run(new String[] {"count", "/NotExistFile"});
-    Assert.assertEquals("/NotExistFile does not exist.\n", mOutput.toString());
+    Assert.assertEquals("Could not find path: /NotExistFile\n", mOutput.toString());
     Assert.assertEquals(-1, ret);
   }
 
@@ -360,7 +363,7 @@ public class TFsShellTest {
    * iter.next(); } Assert.assertEquals(getCommandOutput(commandParameters), mOutput.toString()); }
    */
   @Test
-  public void lsrTest() throws IOException {
+  public void lsrTest() throws IOException, TException {
     FileInfo[] files = new FileInfo[4];
 
     TachyonFile fileA = TachyonFSTestUtils.createByteFile(mTfs, "/testRoot/testFileA",
@@ -395,7 +398,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void lsTest() throws IOException {
+  public void lsTest() throws IOException, TException {
     FileInfo[] files = new FileInfo[4];
 
     TachyonFile fileA = TachyonFSTestUtils.createByteFile(mTfs, "/testRoot/testFileA",
@@ -421,7 +424,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void mkdirComplexPathTest() throws IOException {
+  public void mkdirComplexPathTest() throws IOException, TException {
     mFsShell.run(new String[] {"mkdir", "/Complex!@#$%^&*()-_=+[]{};\"'<>,.?/File"});
     TachyonFile tFile = mTfs.open(new TachyonURI("/Complex!@#$%^&*()-_=+[]{};\"'<>,.?/File"));
     FileInfo fileInfo = mTfs.getInfo(tFile);
@@ -444,7 +447,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void mkdirShortPathTest() throws IOException {
+  public void mkdirShortPathTest() throws IOException, TException {
     mFsShell.run(new String[] {"mkdir", "/root/testFile1"});
     TachyonFile tFile = mTfs.open(new TachyonURI("/root/testFile1"));
     FileInfo fileInfo = mTfs.getInfo(tFile);
@@ -455,7 +458,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void mkdirTest() throws IOException {
+  public void mkdirTest() throws IOException, TException {
     String qualifiedPath = "tachyon://" + mLocalTachyonCluster.getMasterHostname() + ":"
         + mLocalTachyonCluster.getMasterPort() + "/root/testFile1";
     mFsShell.run(new String[] {"mkdir", qualifiedPath});
@@ -463,11 +466,11 @@ public class TFsShellTest {
     FileInfo fileInfo = mTfs.getInfo(tFile);
     Assert.assertNotNull(fileInfo);
     Assert.assertEquals(getCommandOutput(new String[]{"mkdir", qualifiedPath}),
-        mOutput.toString());
+            mOutput.toString());
     Assert.assertTrue(fileInfo.isIsFolder());
   }
 
-  private byte[] readContent(TachyonFile tFile, int length) throws IOException {
+  private byte[] readContent(TachyonFile tFile, int length) throws IOException, TException {
     ClientOptions options =
         new ClientOptions.Builder(new TachyonConf()).setTachyonStoreType(
             TachyonStorageType.NO_STORE).build();
@@ -511,7 +514,7 @@ public class TFsShellTest {
     mFsShell.run(new String[] {"mkdir", "/testFolder1"});
     toCompare.append(getCommandOutput(new String[] {"mkdir", "/testFolder1"}));
     Assert.assertEquals(-1,
-        mFsShell.rename(new String[]{"rename", "/testFolder1", "/testFolder"}));
+            mFsShell.rename(new String[]{"rename", "/testFolder1", "/testFolder"}));
   }
 
   @Test
@@ -614,7 +617,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void touchTest() throws IOException {
+  public void touchTest() throws IOException, TException {
     String[] argv = new String[] {"touch", "/testFile"};
     mFsShell.run(argv);
     TachyonFile tFile = mTfs.open(new TachyonURI("/testFile"));
@@ -625,7 +628,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void touchTestWithFullURI() throws IOException {
+  public void touchTestWithFullURI() throws IOException, TException {
     String tachyonURI = "tachyon://" + mLocalTachyonCluster.getMasterHostname() + ":"
         + mLocalTachyonCluster.getMasterPort() + "/destFileURI";
     // when
@@ -640,7 +643,7 @@ public class TFsShellTest {
   }
 
   @Test
-  public void freeTest() throws IOException {
+  public void freeTest() throws IOException, TException {
     TachyonFile file =
         TachyonFSTestUtils.createByteFile(mTfs, "/testFile", TachyonStorageType.STORE,
             UnderStorageType.NO_PERSIST, 10);
@@ -662,7 +665,7 @@ public class TFsShellTest {
     String expected = "";
     // du a non-existing file
     mFsShell.run(new String[] {"du", "/testRoot/noneExisting"});
-    expected += "/testRoot/noneExisting does not exist\n";
+    expected += "Could not find path: /testRoot/noneExisting\n";
     // du a file
     mFsShell.run(new String[] {"du", "/testRoot/testFileA"});
     expected += "/testRoot/testFileA is 10 bytes\n";
@@ -678,6 +681,8 @@ public class TFsShellTest {
       mTfs.open(path);
       return true;
     } catch (IOException ioe) {
+      return false;
+    } catch (InvalidPathException e) {
       return false;
     }
   }

--- a/shell/src/test/java/tachyon/shell/TFsShellUtilsTest.java
+++ b/shell/src/test/java/tachyon/shell/TFsShellUtilsTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under

--- a/shell/src/test/java/tachyon/shell/TFsShellUtilsTest.java
+++ b/shell/src/test/java/tachyon/shell/TFsShellUtilsTest.java
@@ -4,9 +4,9 @@
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
  * copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -37,6 +38,7 @@ import tachyon.client.file.TachyonFile;
 import tachyon.client.file.TachyonFileSystem;
 import tachyon.conf.TachyonConf;
 import tachyon.master.LocalTachyonCluster;
+import tachyon.thrift.InvalidPathException;
 
 /**
  * Unit tests on tachyon.command.Utils.
@@ -63,8 +65,9 @@ public class TFsShellUtilsTest {
 
   @Test
   public void getFilePathTest() throws IOException {
-    String[] paths = new String[] {Constants.HEADER + "localhost:19998/dir",
-        Constants.HEADER_FT + "localhost:19998/dir", "/dir", "dir"};
+    String[] paths =
+        new String[] {Constants.HEADER + "localhost:19998/dir",
+            Constants.HEADER_FT + "localhost:19998/dir", "/dir", "dir"};
     String expected = "/dir";
     for (String path : paths) {
       String result = TFsShellUtils.getFilePath(path, new TachyonConf());
@@ -94,11 +97,12 @@ public class TFsShellUtilsTest {
     };
   }
 
-  public String resetTachyonFileHierarchy() throws IOException {
+  public String resetTachyonFileHierarchy() throws IOException, TException {
     return resetTachyonFileHierarchy(mTfs);
   }
 
-  public static String resetTachyonFileHierarchy(TachyonFileSystem tfs) throws IOException {
+  public static String resetTachyonFileHierarchy(TachyonFileSystem tfs) throws IOException,
+      TException {
     /**
      * Generate such local structure /testWildCards
      *                                ├── foo |
@@ -112,6 +116,8 @@ public class TFsShellUtilsTest {
     try {
       fd = tfs.open(new TachyonURI("/testWildCars"));
     } catch (IOException ioe) {
+      fd = null;
+    } catch (InvalidPathException e) {
       fd = null;
     }
     if (fd != null) {
@@ -160,7 +166,7 @@ public class TFsShellUtilsTest {
     return localTachyonCluster.getTachyonHome() + "/testWildCards";
   }
 
-  public List<String> getPaths(String path, FsType fsType) throws IOException {
+  public List<String> getPaths(String path, FsType fsType) throws IOException, TException {
     List<String> ret = null;
     if (fsType == FsType.TFS) {
       List<TachyonURI> tPaths = TFsShellUtils.getTachyonURIs(mTfs, new TachyonURI(path));
@@ -179,7 +185,7 @@ public class TFsShellUtilsTest {
     return ret;
   }
 
-  public String resetFsHierarchy(FsType fsType) throws IOException {
+  public String resetFsHierarchy(FsType fsType) throws IOException, TException {
     if (fsType == FsType.TFS) {
       return resetTachyonFileHierarchy();
     } else if (fsType == FsType.LOCAL) {
@@ -190,7 +196,7 @@ public class TFsShellUtilsTest {
   }
 
   @Test
-  public void getPathTest() throws IOException {
+  public void getPathTest() throws IOException, TException {
     for (FsType fsType : FsType.values()) {
       String rootDir = resetFsHierarchy(fsType);
 


### PR DESCRIPTION
We were turning everything into an IOException, which can make it hard
for callers to determine what went wrong in an operation. So now the
TachyonFileSystem and related classes don't wrap exceptions in an
IOException.

There are a lot of miscellaneous refactors for deprecated code and tests
to get this to compile.