### PR TITLE
[SMALLFIX] Follow up small change for TACHYON-937

### DIFF
--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -47,6 +47,7 @@ public enum ExceptionMessage {
 
   // tieredBlockStore
   BLOCK_ID_FOR_DIFFERENT_SESSION("BlockId {0} is owned by sessionId {1} not {2}"),
+  BLOCK_NOT_FOUND_AT_LOCATION("Block {0} not found at location: {1}"),
   MOVE_UNCOMMITTED_BLOCK("Cannot move uncommitted block {0}"),
   NO_BLOCK_ID_FOUND("BlockId {0} not found"),
   NO_EVICTION_PLAN_TO_FREE_SPACE("No eviction plan by evictor to free space"),
@@ -55,7 +56,6 @@ public enum ExceptionMessage {
   REMOVE_UNCOMMITTED_BLOCK("Cannot remove uncommitted block {0}"),
   TEMP_BLOCK_ID_COMMITTED("Temp blockId {0} is not available, because it is already committed"),
   TEMP_BLOCK_ID_EXISTS("Temp blockId {0} is not available, because it already exists"),
-  BLOCK_NOT_FOUND_AT_LOCATION("Block {0} not found at location: {1}"),
 
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -55,6 +55,7 @@ public enum ExceptionMessage {
   REMOVE_UNCOMMITTED_BLOCK("Cannot remove uncommitted block {0}"),
   TEMP_BLOCK_ID_COMMITTED("Temp blockId {0} is not available, because it is already committed"),
   TEMP_BLOCK_ID_EXISTS("Temp blockId {0} is not available, because it already exists"),
+  BLOCK_NOT_FOUND_AT_LOCATION("Block {0} not found at location: {1}"),
 
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -755,7 +755,7 @@ public final class TieredBlockStore implements BlockStore {
         mMetadataReadLock.unlock();
       }
 
-      if (!oldLocation.equals(srcLocation) && !oldLocation.equals(BlockStoreLocation.anyTier())) {
+      if (!srcLocation.belongTo(oldLocation)) {
         throw new NotFoundException("Block " + blockId + " not found at location: " + oldLocation);
       }
       TempBlockMeta dstTempBlock =
@@ -819,8 +819,7 @@ public final class TieredBlockStore implements BlockStore {
         mMetadataReadLock.unlock();
       }
 
-      if (!location.equals(blockMeta.getBlockLocation())
-          && !location.equals(BlockStoreLocation.anyTier())) {
+      if (!blockMeta.getBlockLocation().belongTo(location)) {
         throw new NotFoundException("Block " + blockId + " not found at location: " + location);
       }
       // Heavy IO is guarded by block lock but not metadata lock. This may throw IOException.

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -756,7 +756,8 @@ public final class TieredBlockStore implements BlockStore {
       }
 
       if (!srcLocation.belongTo(oldLocation)) {
-        throw new NotFoundException("Block " + blockId + " not found at location: " + oldLocation);
+        throw new NotFoundException(ExceptionMessage.BLOCK_NOT_FOUND_AT_LOCATION, blockId,
+            oldLocation);
       }
       TempBlockMeta dstTempBlock =
           createBlockMetaInternal(sessionId, blockId, newLocation, blockSize, false);
@@ -820,7 +821,8 @@ public final class TieredBlockStore implements BlockStore {
       }
 
       if (!blockMeta.getBlockLocation().belongTo(location)) {
-        throw new NotFoundException("Block " + blockId + " not found at location: " + location);
+        throw new NotFoundException(ExceptionMessage.BLOCK_NOT_FOUND_AT_LOCATION, blockId,
+            location);
       }
       // Heavy IO is guarded by block lock but not metadata lock. This may throw IOException.
       FileUtils.delete(filePath);

--- a/servers/src/test/java/tachyon/worker/block/TieredBlockStoreTests.java
+++ b/servers/src/test/java/tachyon/worker/block/TieredBlockStoreTests.java
@@ -50,11 +50,14 @@ public final class TieredBlockStoreTests {
   private static final long TEMP_BLOCK_ID = 1003;
   private static final long BLOCK_SIZE = 512;
   private static final StorageLevelAlias FIRST_TIER_ALIAS = TieredBlockStoreTestUtils.TIER_ALIAS[0];
+  private static final StorageLevelAlias SECOND_TIER_ALIAS =
+      TieredBlockStoreTestUtils.TIER_ALIAS[1];
   private TieredBlockStore mBlockStore;
   private BlockMetadataManager mMetaManager;
   private BlockLockManager mLockManager;
   private StorageDir mTestDir1;
   private StorageDir mTestDir2;
+  private StorageDir mTestDir3;
   private Evictor mEvictor;
 
   @Rule
@@ -82,6 +85,7 @@ public final class TieredBlockStoreTests {
 
     mTestDir1 = mMetaManager.getTier(FIRST_TIER_ALIAS.getValue()).getDir(0);
     mTestDir2 = mMetaManager.getTier(FIRST_TIER_ALIAS.getValue()).getDir(1);
+    mTestDir3 = mMetaManager.getTier(SECOND_TIER_ALIAS.getValue()).getDir(1);
   }
 
   // Different sessions can concurrently grab block locks on different blocks
@@ -176,6 +180,34 @@ public final class TieredBlockStoreTests {
     Assert.assertTrue(mBlockStore.hasBlockMeta(BLOCK_ID1));
     Assert.assertFalse(FileUtils.exists(BlockMeta.commitPath(mTestDir1, BLOCK_ID1)));
     Assert.assertTrue(FileUtils.exists(BlockMeta.commitPath(mTestDir2, BLOCK_ID1)));
+
+    // Move block from the specific Dir
+    TieredBlockStoreTestUtils.cache(SESSION_ID2, BLOCK_ID2, BLOCK_SIZE, mTestDir1, mMetaManager,
+        mEvictor);
+    // Move block from wrong Dir
+    mThrown.expect(NotFoundException.class);
+    mThrown.expectMessage(ExceptionMessage.BLOCK_NOT_FOUND_AT_LOCATION.getMessage(BLOCK_ID2,
+        mTestDir2.toBlockStoreLocation()));
+    mBlockStore.moveBlock(SESSION_ID2, BLOCK_ID2, mTestDir2.toBlockStoreLocation(),
+        mTestDir3.toBlockStoreLocation());
+    // Move block from right Dir
+    mBlockStore.moveBlock(SESSION_ID2, BLOCK_ID2, mTestDir1.toBlockStoreLocation(),
+        mTestDir3.toBlockStoreLocation());
+    Assert.assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID2));
+    Assert.assertTrue(mTestDir3.hasBlockMeta(BLOCK_ID2));
+    Assert.assertTrue(mBlockStore.hasBlockMeta(BLOCK_ID2));
+    Assert.assertFalse(FileUtils.exists(BlockMeta.commitPath(mTestDir1, BLOCK_ID2)));
+    Assert.assertTrue(FileUtils.exists(BlockMeta.commitPath(mTestDir3, BLOCK_ID2)));
+
+    // Move block from the specific tier
+    mBlockStore.moveBlock(SESSION_ID2, BLOCK_ID2,
+        BlockStoreLocation.anyDirInTier(mTestDir1.getParentTier().getTierAlias()),
+        mTestDir3.toBlockStoreLocation());
+    Assert.assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID2));
+    Assert.assertTrue(mTestDir3.hasBlockMeta(BLOCK_ID2));
+    Assert.assertTrue(mBlockStore.hasBlockMeta(BLOCK_ID2));
+    Assert.assertFalse(FileUtils.exists(BlockMeta.commitPath(mTestDir1, BLOCK_ID2)));
+    Assert.assertTrue(FileUtils.exists(BlockMeta.commitPath(mTestDir3, BLOCK_ID2)));
   }
 
   @Test
@@ -186,6 +218,29 @@ public final class TieredBlockStoreTests {
     Assert.assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID1));
     Assert.assertFalse(mBlockStore.hasBlockMeta(BLOCK_ID1));
     Assert.assertFalse(FileUtils.exists(BlockMeta.commitPath(mTestDir1, BLOCK_ID1)));
+
+    // Remove block from specific Dir
+    TieredBlockStoreTestUtils.cache(SESSION_ID2, BLOCK_ID2, BLOCK_SIZE, mTestDir1, mMetaManager,
+        mEvictor);
+    // Remove block from wrong Dir
+    mThrown.expect(NotFoundException.class);
+    mThrown.expectMessage(ExceptionMessage.BLOCK_NOT_FOUND_AT_LOCATION.getMessage(BLOCK_ID2,
+        mTestDir2.toBlockStoreLocation()));
+    mBlockStore.removeBlock(SESSION_ID2, BLOCK_ID2, mTestDir2.toBlockStoreLocation());
+    // Remove block from right Dir
+    mBlockStore.removeBlock(SESSION_ID2, BLOCK_ID2, mTestDir1.toBlockStoreLocation());
+    Assert.assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID2));
+    Assert.assertFalse(mBlockStore.hasBlockMeta(BLOCK_ID2));
+    Assert.assertFalse(FileUtils.exists(BlockMeta.commitPath(mTestDir1, BLOCK_ID2)));
+
+    // Remove block from the specific tier
+    TieredBlockStoreTestUtils.cache(SESSION_ID2, BLOCK_ID2, BLOCK_SIZE, mTestDir1, mMetaManager,
+        mEvictor);
+    mBlockStore.removeBlock(SESSION_ID2, BLOCK_ID2,
+        BlockStoreLocation.anyDirInTier(mTestDir1.getParentTier().getTierAlias()));
+    Assert.assertFalse(mTestDir1.hasBlockMeta(BLOCK_ID2));
+    Assert.assertFalse(mBlockStore.hasBlockMeta(BLOCK_ID2));
+    Assert.assertFalse(FileUtils.exists(BlockMeta.commitPath(mTestDir1, BLOCK_ID2)));
   }
 
   @Test


### PR DESCRIPTION
for PR: https://github.com/amplab/tachyon/pull/1498

if user wants to delete some block in certain layer, the old logic doesn't work,
Use belongTo to compare the current location and the location specified.

