### PR TITLE
fixes #961

### DIFF
--- a/common/src/main/java/tachyon/LeaderSelectorClient.java
+++ b/common/src/main/java/tachyon/LeaderSelectorClient.java
@@ -144,9 +144,12 @@ public class LeaderSelectorClient implements Closeable, LeaderSelectorListener {
   @Override
   public void takeLeadership(CuratorFramework client) throws Exception {
     mIsLeader.set(true);
-    if (client.checkExists().forPath(mLeaderFolder + mName) != null) {
-      client.delete().forPath(mLeaderFolder + mName);
+    List<String> childList = client.getChildren()
+            .forPath(mLeaderFolder.substring(0, mLeaderFolder.length() - 1));
+    for (String child : childList) { 
+      client.delete().forPath(mLeaderFolder + child);
     }
+
     client.create().creatingParentsIfNeeded().forPath(mLeaderFolder + mName);
     LOG.info(mName + " is now the leader.");
     try {

--- a/common/src/main/java/tachyon/LeaderSelectorClient.java
+++ b/common/src/main/java/tachyon/LeaderSelectorClient.java
@@ -143,9 +143,13 @@ public class LeaderSelectorClient implements Closeable, LeaderSelectorListener {
 
   @Override
   public void takeLeadership(CuratorFramework client) throws Exception {
+    List<String> childList = new ArrayList<String>();
     mIsLeader.set(true);
-    List<String> childList = client.getChildren()
+    if (mLeaderFolder != null && client.checkExists()
+        .forPath(mLeaderFolder.substring(0, mLeaderFolder.length() - 1)) != null) {
+      childList = client.getChildren()
             .forPath(mLeaderFolder.substring(0, mLeaderFolder.length() - 1));
+    }
     for (String child : childList) { 
       client.delete().forPath(mLeaderFolder + child);
     }


### PR DESCRIPTION
In current version, when new master takes leadership it only deletes znodes under /leader directory with the same name. Now, it will delete all previous leaders, which are not leader anymore.
https://tachyon.atlassian.net/browse/TACHYON-961