### PR TITLE
[SMALLFIX] Handle license collisions in assembly jar

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -92,6 +92,9 @@
                 <filter>
                   <artifact>*:* </artifact>
                   <excludes>
+                    <!-- Excluding licenses in order to avoid case-insensitive collisions when unpacking with case-insensitive HFS+ -->
+                    <exclude>LICENSE</exclude>
+                    <exclude>META-INF/LICENSE</exclude>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -86,15 +86,14 @@
             <configuration>
               <finalName>${project.artifactId}-${project.version}-jar-with-dependencies</finalName>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
               </transformers>
               <filters>
                 <filter>
                   <artifact>*:* </artifact>
                   <excludes>
-                    <!-- Excluding licenses in order to avoid case-insensitive collisions when unpacking with case-insensitive HFS+ -->
-                    <exclude>LICENSE</exclude>
-                    <exclude>META-INF/LICENSE</exclude>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>


### PR DESCRIPTION
For case insensitive file systems (ie. HFS+ for osx) a collision will occur if the license/notice transformer is not included.