### PR TITLE
[SMALLFIX] Module name rewording.

### DIFF
--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -10,8 +10,8 @@
 
   <artifactId>tachyon-minicluster</artifactId>
   <packaging>jar</packaging>
-  <name>Tachyon Mock Cluster</name>
-  <description>Tachyon Mock Cluster for testing</description>
+  <name>Tachyon MiniCluster</name>
+  <description>Tachyon MiniCluster for testing</description>
 
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -10,8 +10,8 @@
 
   <artifactId>tachyon-minicluster</artifactId>
   <packaging>jar</packaging>
-  <name>Mock Tachyon Cluster</name>
-  <description>Mock Tachyon Cluster for testing</description>
+  <name>Tachyon Mock Cluster</name>
+  <description>Tachyon Mock Cluster for testing</description>
 
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>


### PR DESCRIPTION
This PR changes the minicluster project name from "Mock Tachyon Cluster" to "Tachyon Mock Cluster". This is purely a cosmetic change for consistency with other modules, all of which have names starting with Tachyon.