### PR TITLE
[TACHYON-897] Integrate the permission status into MasterInfo When it creates file or directory

### DIFF
--- a/common/src/main/resources/tachyon-default.properties
+++ b/common/src/main/resources/tachyon-default.properties
@@ -40,7 +40,7 @@ tachyon.max.table.metadata.byte=5MB
 tachyon.host.resolution.timeout.ms=5000
 
 # Security properties
-tachyon.security.authentication=NOSASL
+tachyon.security.authentication.type=NOSASL
 tachyon.tfs.permission.umask=022
 
 # Master properties

--- a/servers/src/test/java/tachyon/master/journal/JournalFormatterTestBase.java
+++ b/servers/src/test/java/tachyon/master/journal/JournalFormatterTestBase.java
@@ -145,7 +145,8 @@ public abstract class JournalFormatterTestBase {
     }
     entryTest(new InodeFileEntry(TEST_OP_TIME_MS, TEST_FILE_ID, TEST_FILE_NAME, TEST_FILE_ID, true,
         true, TEST_OP_TIME_MS, TEST_BLOCK_SIZE_BYTES, TEST_LENGTH_BYTES, true, true, blocks,
-        Constants.NO_TTL, PermissionStatus.getDirDefault().applyUMask(new FsPermission((short)0111))));
+        Constants.NO_TTL,
+        PermissionStatus.getDirDefault().applyUMask(new FsPermission((short)0111))));
   }
 
   @Test


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-897

Currently Tachyon uses FileSystemMaster to handler client requests. FileSystemMaster is the place to plug the permission status for authorization. FileSystemMaster sets the initialized permission for file or directory, the initialized permission should be masked. For example, default file permission is “0666”, default directory permission is “0777”, and the default umask is “0022”.So the masked file permission is “0644”, and masked directory permission is “0755”. When we create a new file or directory, the permission should be “0644” for a file, and “0755” for a directory.