### PR TITLE
[SMALLFIX] Making use of MasterContext.getConf() in the master code

### DIFF
--- a/integration-tests/src/test/java/tachyon/master/JournalIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/JournalIntegrationTest.java
@@ -79,7 +79,7 @@ public class JournalIntegrationTest {
   private void deleteFsMasterJournalLogs() throws IOException {
     String journalFolder = mLocalTachyonCluster.getMaster().getJournalFolder();
     Journal journal = new Journal(PathUtils.concatPath(journalFolder,
-        Constants.FILE_SYSTEM_MASTER_SERVICE_NAME), mMasterTachyonConf);
+        Constants.FILE_SYSTEM_MASTER_SERVICE_NAME));
     UnderFileSystem.get(journalFolder, mMasterTachyonConf).delete(journal.getCurrentLogFilePath(),
         true);
   }
@@ -173,7 +173,7 @@ public class JournalIntegrationTest {
 
     String journalFolder =
         FileSystemMaster.getJournalDirectory(mLocalTachyonCluster.getMaster().getJournalFolder());
-    Journal journal = new Journal(journalFolder, mMasterTachyonConf);
+    Journal journal = new Journal(journalFolder);
     String completedPath = journal.getCompletedDirectory();
     Assert.assertTrue(UnderFileSystem.get(completedPath,
         mMasterTachyonConf).list(completedPath).length > 1);

--- a/integration-tests/src/test/java/tachyon/master/MasterTestUtils.java
+++ b/integration-tests/src/test/java/tachyon/master/MasterTestUtils.java
@@ -27,13 +27,10 @@ public class MasterTestUtils {
   public static FileSystemMaster createFileSystemMasterFromJournal(TachyonConf tachyonConf)
       throws IOException {
     String masterJournal = tachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
-    Journal blockJournal = new Journal(BlockMaster.getJournalDirectory(masterJournal),
-        tachyonConf);
-    Journal fsJournal = new Journal(FileSystemMaster.getJournalDirectory(masterJournal),
-        tachyonConf);
-
-    BlockMaster blockMaster = new BlockMaster(tachyonConf, blockJournal);
-    FileSystemMaster fsMaster = new FileSystemMaster(tachyonConf, blockMaster, fsJournal);
+    Journal blockJournal = new Journal(BlockMaster.getJournalDirectory(masterJournal));
+    Journal fsJournal = new Journal(FileSystemMaster.getJournalDirectory(masterJournal));
+    BlockMaster blockMaster = new BlockMaster(blockJournal);
+    FileSystemMaster fsMaster = new FileSystemMaster(blockMaster, fsJournal);
     blockMaster.start(true);
     fsMaster.start(true);
     return fsMaster;

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
@@ -256,11 +256,11 @@ public final class LocalTachyonMaster {
   }
 
   public TachyonFS getOldClient() throws IOException {
-    return mOldClientPool.getClient(mTachyonMaster.getTachyonConf());
+    return mOldClientPool.getClient(MasterContext.getConf());
   }
 
   public TachyonFileSystem getClient() throws IOException {
-    return mClientPool.getClient(mTachyonMaster.getTachyonConf());
+    return mClientPool.getClient(MasterContext.getConf());
   }
 
   private static String uniquePath() throws IOException {
@@ -269,10 +269,6 @@ public final class LocalTachyonMaster {
 
   private static String path(final String parent, final String child) {
     return parent + "/" + child;
-  }
-
-  public TachyonConf getTachyonConf() {
-    return mTachyonMaster.getTachyonConf();
   }
 
   public String getJournalFolder() {

--- a/servers/src/main/java/tachyon/master/MasterBase.java
+++ b/servers/src/main/java/tachyon/master/MasterBase.java
@@ -52,12 +52,10 @@ public abstract class MasterBase implements Master {
   private JournalTailerThread mStandbyJournalTailer = null;
   /** The journal writer for when the master is the leader. */
   private JournalWriter mJournalWriter = null;
-  protected final TachyonConf mTachyonConf;
 
-  protected MasterBase(Journal journal, ExecutorService executorService, TachyonConf conf) {
+  protected MasterBase(Journal journal, ExecutorService executorService) {
     mJournal = Preconditions.checkNotNull(journal);
     mExecutorService = Preconditions.checkNotNull(executorService);
-    mTachyonConf = conf;
   }
 
   @Override
@@ -118,7 +116,7 @@ public abstract class MasterBase implements Master {
       checkpointStream.close();
     } else {
       // in standby mode. Start the journal tailer thread.
-      mStandbyJournalTailer = new JournalTailerThread(this, mJournal, mTachyonConf);
+      mStandbyJournalTailer = new JournalTailerThread(this, mJournal);
       mStandbyJournalTailer.start();
     }
   }

--- a/servers/src/main/java/tachyon/master/MasterInfo.java
+++ b/servers/src/main/java/tachyon/master/MasterInfo.java
@@ -46,16 +46,15 @@ public final class MasterInfo {
   private final FileSystemMaster mFileSystemMaster;
   private final InetSocketAddress mMasterAddress;
   private final long mStartTimeMs;
-  private final TachyonConf mTachyonConf;
   private final String mUFSDataFolder;
 
   public MasterInfo(BlockMaster blockMaster, FileSystemMaster fileSystemMaster,
       InetSocketAddress address, TachyonConf tachyonConf) {
+    TachyonConf conf = MasterContext.getConf();
     mBlockMaster = Preconditions.checkNotNull(blockMaster);
     mFileSystemMaster = Preconditions.checkNotNull(fileSystemMaster);
     mMasterAddress = Preconditions.checkNotNull(address);
-    mTachyonConf = Preconditions.checkNotNull(tachyonConf);
-    mUFSDataFolder = mTachyonConf.get(Constants.UNDERFS_DATA_FOLDER, Constants.DEFAULT_DATA_FOLDER);
+    mUFSDataFolder = conf.get(Constants.UNDERFS_DATA_FOLDER, Constants.DEFAULT_DATA_FOLDER);
     mStartTimeMs = System.currentTimeMillis();
   }
 
@@ -183,7 +182,7 @@ public final class MasterInfo {
    * @throws IOException when the operation fails
    */
   public long getUnderFsCapacityBytes() throws IOException {
-    UnderFileSystem ufs = UnderFileSystem.get(mUFSDataFolder, mTachyonConf);
+    UnderFileSystem ufs = UnderFileSystem.get(mUFSDataFolder, MasterContext.getConf());
     return ufs.getSpace(mUFSDataFolder, SpaceType.SPACE_TOTAL);
   }
 
@@ -194,7 +193,7 @@ public final class MasterInfo {
    * @throws IOException when the operation fails
    */
   public long getUnderFsFreeBytes() throws IOException {
-    UnderFileSystem ufs = UnderFileSystem.get(mUFSDataFolder, mTachyonConf);
+    UnderFileSystem ufs = UnderFileSystem.get(mUFSDataFolder, MasterContext.getConf());
     return ufs.getSpace(mUFSDataFolder, SpaceType.SPACE_FREE);
   }
 
@@ -205,7 +204,7 @@ public final class MasterInfo {
    * @throws IOException when the operation fails
    */
   public long getUnderFsUsedBytes() throws IOException {
-    UnderFileSystem ufs = UnderFileSystem.get(mUFSDataFolder, mTachyonConf);
+    UnderFileSystem ufs = UnderFileSystem.get(mUFSDataFolder, MasterContext.getConf());
     return ufs.getSpace(mUFSDataFolder, SpaceType.SPACE_USED);
   }
 

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -65,7 +65,6 @@ public class TachyonMaster {
     }
   }
 
-  protected final TachyonConf mTachyonConf;
   /** Maximum number of threads to serve the rpc server */
   private final int mMaxWorkerThreads;
   /** Minimum number of threads to serve the rpc server */
@@ -121,10 +120,10 @@ public class TachyonMaster {
   }
 
   protected TachyonMaster() {
-    mTachyonConf = MasterContext.getConf();
+    TachyonConf conf = MasterContext.getConf();
 
-    mMinWorkerThreads = mTachyonConf.getInt(Constants.MASTER_MIN_WORKER_THREADS);
-    mMaxWorkerThreads = mTachyonConf.getInt(Constants.MASTER_MAX_WORKER_THREADS);
+    mMinWorkerThreads = conf.getInt(Constants.MASTER_MIN_WORKER_THREADS);
+    mMaxWorkerThreads = conf.getInt(Constants.MASTER_MAX_WORKER_THREADS);
 
     Preconditions.checkArgument(mMaxWorkerThreads >= mMinWorkerThreads,
         Constants.MASTER_MAX_WORKER_THREADS + " can not be less than "
@@ -137,14 +136,14 @@ public class TachyonMaster {
       // In a production or any real deployment setup, port '0' should not be used as it will make
       // deployment more complicated.
       mTServerSocket = new TServerSocket(
-          NetworkAddressUtils.getBindAddress(ServiceType.MASTER_RPC, mTachyonConf));
+          NetworkAddressUtils.getBindAddress(ServiceType.MASTER_RPC, conf));
       mPort = NetworkAddressUtils.getThriftPort(mTServerSocket);
       // reset master port
-      mTachyonConf.set(Constants.MASTER_PORT, Integer.toString(mPort));
-      mMasterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, mTachyonConf);
+      conf.set(Constants.MASTER_PORT, Integer.toString(mPort));
+      mMasterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
 
       // Check the journal directory
-      String journalDirectory = mTachyonConf.get(Constants.MASTER_JOURNAL_FOLDER);
+      String journalDirectory = conf.get(Constants.MASTER_JOURNAL_FOLDER);
       if (!journalDirectory.endsWith(TachyonURI.SEPARATOR)) {
         journalDirectory += TachyonURI.SEPARATOR;
       }
@@ -152,30 +151,20 @@ public class TachyonMaster {
           "Tachyon was not formatted! The journal folder is " + journalDirectory);
 
       // Create the journals.
-      mBlockMasterJournal = new Journal(BlockMaster.getJournalDirectory(journalDirectory),
-          mTachyonConf);
-      mFileSystemMasterJournal = new Journal(FileSystemMaster.getJournalDirectory(journalDirectory),
-          mTachyonConf);
-      mRawTableMasterJournal = new Journal(RawTableMaster.getJournalDirectory(journalDirectory),
-          mTachyonConf);
+      mBlockMasterJournal = new Journal(BlockMaster.getJournalDirectory(journalDirectory));
+      mFileSystemMasterJournal =
+          new Journal(FileSystemMaster.getJournalDirectory(journalDirectory));
+      mRawTableMasterJournal = new Journal(RawTableMaster.getJournalDirectory(journalDirectory));
 
-      mBlockMaster = new BlockMaster(mTachyonConf, mBlockMasterJournal);
-      mFileSystemMaster =
-          new FileSystemMaster(mTachyonConf, mBlockMaster, mFileSystemMasterJournal);
-      mRawTableMaster = new RawTableMaster(mTachyonConf, mFileSystemMaster, mRawTableMasterJournal);
+      mBlockMaster = new BlockMaster(mBlockMasterJournal);
+      mFileSystemMaster = new FileSystemMaster(mBlockMaster, mFileSystemMasterJournal);
+      mRawTableMaster = new RawTableMaster(mFileSystemMaster, mRawTableMasterJournal);
 
       // TODO: implement metrics.
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);
       throw Throwables.propagate(e);
     }
-  }
-
-  /**
-   * @return the underlying {@link TachyonConf} instance for the master.
-   */
-  public TachyonConf getTachyonConf() {
-    return mTachyonConf;
   }
 
   /**
@@ -303,8 +292,9 @@ public class TachyonMaster {
 
   protected void startServingWebServer() {
     // start web ui
+    TachyonConf conf = MasterContext.getConf();
     mWebServer = new MasterUIWebServer(ServiceType.MASTER_WEB, NetworkAddressUtils.getBindAddress(
-        ServiceType.MASTER_WEB, mTachyonConf), this, mTachyonConf);
+        ServiceType.MASTER_WEB, conf), this, conf);
     mWebServer.startWebServer();
   }
 
@@ -348,7 +338,8 @@ public class TachyonMaster {
    * @throws IOException
    */
   private boolean isJournalFormatted(String journalDirectory) throws IOException {
-    UnderFileSystem ufs = UnderFileSystem.get(journalDirectory, mTachyonConf);
+    TachyonConf conf = MasterContext.getConf();
+    UnderFileSystem ufs = UnderFileSystem.get(journalDirectory, conf);
     if (!ufs.providesStorage()) {
       // TODO: Should the journal really be allowed on a ufs without storage?
       // This ufs doesn't provide storage. Allow the master to use this ufs for the journal.
@@ -360,7 +351,7 @@ public class TachyonMaster {
       return false;
     }
     // Search for the format file.
-    String formatFilePrefix = mTachyonConf.get(Constants.MASTER_FORMAT_FILE_PREFIX);
+    String formatFilePrefix = conf.get(Constants.MASTER_FORMAT_FILE_PREFIX);
     for (String file : files) {
       if (file.startsWith(formatFilePrefix)) {
         return true;
@@ -370,9 +361,9 @@ public class TachyonMaster {
   }
 
   private void connectToUFS() throws IOException {
-    String ufsAddress = mTachyonConf.get(Constants.UNDERFS_ADDRESS);
-    UnderFileSystem ufs = UnderFileSystem.get(ufsAddress, mTachyonConf);
-    ufs.connectFromMaster(mTachyonConf,
-        NetworkAddressUtils.getConnectHost(ServiceType.MASTER_RPC, mTachyonConf));
+    TachyonConf conf = MasterContext.getConf();
+    String ufsAddress = conf.get(Constants.UNDERFS_ADDRESS);
+    UnderFileSystem ufs = UnderFileSystem.get(ufsAddress, conf);
+    ufs.connectFromMaster(conf, NetworkAddressUtils.getConnectHost(ServiceType.MASTER_RPC, conf));
   }
 }

--- a/servers/src/main/java/tachyon/master/TachyonMasterFaultTolerant.java
+++ b/servers/src/main/java/tachyon/master/TachyonMasterFaultTolerant.java
@@ -26,6 +26,7 @@ import com.google.common.base.Throwables;
 import tachyon.Constants;
 import tachyon.LeaderSelectorClient;
 import tachyon.Version;
+import tachyon.conf.TachyonConf;
 import tachyon.master.block.BlockMaster;
 import tachyon.master.file.FileSystemMaster;
 import tachyon.master.rawtable.RawTableMaster;
@@ -43,16 +44,17 @@ final class TachyonMasterFaultTolerant extends TachyonMaster {
 
   public TachyonMasterFaultTolerant() {
     super();
-    Preconditions.checkArgument(mTachyonConf.getBoolean(Constants.USE_ZOOKEEPER));
+    TachyonConf conf = MasterContext.getConf();
+    Preconditions.checkArgument(conf.getBoolean(Constants.USE_ZOOKEEPER));
 
     // Set up zookeeper specific functionality.
     try {
       // InetSocketAddress.toString causes test issues, so build the string by hand
-      String zkName = NetworkAddressUtils.getConnectHost(ServiceType.MASTER_RPC, mTachyonConf) + ":"
+      String zkName = NetworkAddressUtils.getConnectHost(ServiceType.MASTER_RPC, conf) + ":"
           + getMasterAddress().getPort();
-      String zkAddress = mTachyonConf.get(Constants.ZOOKEEPER_ADDRESS);
-      String zkElectionPath = mTachyonConf.get(Constants.ZOOKEEPER_ELECTION_PATH);
-      String zkLeaderPath = mTachyonConf.get(Constants.ZOOKEEPER_LEADER_PATH);
+      String zkAddress = conf.get(Constants.ZOOKEEPER_ADDRESS);
+      String zkElectionPath = conf.get(Constants.ZOOKEEPER_ELECTION_PATH);
+      String zkLeaderPath = conf.get(Constants.ZOOKEEPER_LEADER_PATH);
       mLeaderSelectorClient =
           new LeaderSelectorClient(zkAddress, zkElectionPath, zkLeaderPath, zkName);
     } catch (Exception e) {
@@ -83,11 +85,9 @@ final class TachyonMasterFaultTolerant extends TachyonMaster {
 
         if (started) {
           // Transitioning from standby to master, replace readonly journal with writable journal.
-          mBlockMaster = new BlockMaster(mTachyonConf, mBlockMasterJournal);
-          mFileSystemMaster = new FileSystemMaster(mTachyonConf, mBlockMaster,
-              mFileSystemMasterJournal);
-          mRawTableMaster = new RawTableMaster(mTachyonConf, mFileSystemMaster,
-              mRawTableMasterJournal);
+          mBlockMaster = new BlockMaster(mBlockMasterJournal);
+          mFileSystemMaster = new FileSystemMaster(mBlockMaster, mFileSystemMasterJournal);
+          mRawTableMaster = new RawTableMaster(mFileSystemMaster, mRawTableMasterJournal);
         }
         startMasters(true);
         started = true;
@@ -101,11 +101,11 @@ final class TachyonMasterFaultTolerant extends TachyonMaster {
 
           // When transitioning from master to standby, recreate the masters with a readonly
           // journal.
-          mBlockMaster = new BlockMaster(mTachyonConf, mBlockMasterJournal.getReadOnlyJournal());
-          mFileSystemMaster = new FileSystemMaster(mTachyonConf, mBlockMaster,
-              mFileSystemMasterJournal.getReadOnlyJournal());
-          mRawTableMaster = new RawTableMaster(mTachyonConf, mFileSystemMaster,
-              mRawTableMasterJournal.getReadOnlyJournal());
+          mBlockMaster = new BlockMaster(mBlockMasterJournal.getReadOnlyJournal());
+          mFileSystemMaster =
+              new FileSystemMaster(mBlockMaster, mFileSystemMasterJournal.getReadOnlyJournal());
+          mRawTableMaster =
+              new RawTableMaster(mFileSystemMaster, mRawTableMasterJournal.getReadOnlyJournal());
           startMasters(false);
           started = true;
         }

--- a/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
@@ -1006,11 +1006,7 @@ public final class FileSystemMaster extends MasterBase {
    * @return the ufs address for this master.
    */
   public String getUfsAddress() {
-<<<<<<< HEAD
-    return MasterContext.getConf().get(Constants.UNDERFS_ADDRESS, "/underFSStorage");
-=======
-    return mTachyonConf.get(Constants.UNDERFS_ADDRESS);
->>>>>>> upstream/master
+    return MasterContext.getConf().get(Constants.UNDERFS_ADDRESS);
   }
 
   /**

--- a/servers/src/main/java/tachyon/master/file/FileSystemMasterServiceHandler.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMasterServiceHandler.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 
 import tachyon.TachyonURI;
+import tachyon.master.MasterContext;
 import tachyon.thrift.BlockInfoException;
 import tachyon.thrift.DependencyDoesNotExistException;
 import tachyon.thrift.DependencyInfo;
@@ -115,7 +116,7 @@ public final class FileSystemMasterServiceHandler implements FileSystemMasterSer
     if (ufsPath == null || ufsPath.isEmpty()) {
       throw new IllegalArgumentException("the underFS path is not provided");
     }
-    UnderFileSystem underfs = UnderFileSystem.get(ufsPath, mFileSystemMaster.getTachyonConf());
+    UnderFileSystem underfs = UnderFileSystem.get(ufsPath, MasterContext.getConf());
     try {
       long ufsBlockSizeByte = underfs.getBlockSizeByte(ufsPath);
       long fileSizeByte = underfs.getFileSize(ufsPath);

--- a/servers/src/main/java/tachyon/master/file/meta/Dependency.java
+++ b/servers/src/main/java/tachyon/master/file/meta/Dependency.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Sets;
 
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
+import tachyon.master.MasterContext;
 import tachyon.master.file.journal.DependencyEntry;
 import tachyon.master.journal.JournalEntry;
 import tachyon.master.journal.JournalEntryRepresentable;
@@ -62,8 +63,6 @@ public class Dependency implements JournalEntryRepresentable {
 
   private final Set<Long> mLostFileIds;
 
-  private final TachyonConf mTachyonConf;
-
   /**
    * Create a new dependency
    *
@@ -78,12 +77,10 @@ public class Dependency implements JournalEntryRepresentable {
    * @param type The type of the dependency, DependencyType.Wide or DependencyType.Narrow
    * @param parentDependencies The id of the parents' dependencies
    * @param creationTimeMs The create time of the dependency, in milliseconds
-   * @param tachyonConf The TachyonConf instance.
    */
   public Dependency(int id, List<Long> parents, List<Long> children, String commandPrefix,
       List<ByteBuffer> data, String comment, String framework, String frameworkVersion,
-      DependencyType type, Collection<Integer> parentDependencies, long creationTimeMs,
-      TachyonConf tachyonConf) {
+      DependencyType type, Collection<Integer> parentDependencies, long creationTimeMs) {
     mId = id;
     mCreationTimeMs = creationTimeMs;
 
@@ -102,7 +99,6 @@ public class Dependency implements JournalEntryRepresentable {
     mParentDependencies = Lists.newArrayList(parentDependencies);
     mChildrenDependencies = new ArrayList<Integer>(0);
     mLostFileIds = new HashSet<Long>(0);
-    mTachyonConf = tachyonConf;
   }
 
   /**
@@ -171,7 +167,7 @@ public class Dependency implements JournalEntryRepresentable {
     // TODO We should support different types of command in the future.
     // For now, assume there is only one command model.
     StringBuilder sb = new StringBuilder(parseCommandPrefix());
-    sb.append(" ").append(mTachyonConf.get(Constants.MASTER_ADDRESS));
+    sb.append(" ").append(MasterContext.getConf().get(Constants.MASTER_ADDRESS));
     sb.append(" ").append(mId);
     for (int k = 0; k < mChildrenFiles.size(); k ++) {
       long id = mChildrenFiles.get(k);

--- a/servers/src/main/java/tachyon/master/journal/Journal.java
+++ b/servers/src/main/java/tachyon/master/journal/Journal.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 
 import tachyon.TachyonURI;
 import tachyon.conf.TachyonConf;
+import tachyon.master.MasterContext;
 
 /**
  * This encapsulates the journal for a master. The journal is made up of 2 components:
@@ -40,8 +41,6 @@ public class Journal {
   private static final String CHECKPOINT_FILENAME = "checkpoint.data";
   /** The base of the entry log filenames, without the file extension. */
   private static final String ENTRY_LOG_FILENAME_BASE = "log";
-
-  private final TachyonConf mTachyonConf;
   /** The directory where this journal is stored. */
   private final String mDirectory;
   /** The formatter for this journal. */
@@ -49,16 +48,14 @@ public class Journal {
 
   /**
    * @param directory the base directory for this journal
-   * @param tachyonConf the tachyon conf
    */
-  public Journal(String directory, TachyonConf tachyonConf) {
+  public Journal(String directory) {
     if (!directory.endsWith(TachyonURI.SEPARATOR)) {
       // Ensure directory format.
       directory += TachyonURI.SEPARATOR;
     }
     mDirectory = directory;
-    mTachyonConf = Preconditions.checkNotNull(tachyonConf);
-    mJournalFormatter = JournalFormatter.Factory.createJournalFormatter(tachyonConf);
+    mJournalFormatter = JournalFormatter.Factory.createJournalFormatter(MasterContext.getConf());
   }
 
   /**
@@ -110,20 +107,20 @@ public class Journal {
    * @return a readonly version of this journal
    */
   public ReadOnlyJournal getReadOnlyJournal() {
-    return new ReadOnlyJournal(mDirectory, mTachyonConf);
+    return new ReadOnlyJournal(mDirectory);
   }
 
   /**
    * @return the writer for this journal
    */
   public JournalWriter getNewWriter() {
-    return new JournalWriter(this, mTachyonConf);
+    return new JournalWriter(this);
   }
 
   /**
    * @return the reader for this journal
    */
   public JournalReader getNewReader() {
-    return new JournalReader(this, mTachyonConf);
+    return new JournalReader(this);
   }
 }

--- a/servers/src/main/java/tachyon/master/journal/JournalReader.java
+++ b/servers/src/main/java/tachyon/master/journal/JournalReader.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
+import tachyon.master.MasterContext;
 import tachyon.underfs.UnderFileSystem;
 
 /**
@@ -38,7 +39,6 @@ public class JournalReader {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private final Journal mJournal;
-  private final TachyonConf mTachyonConf;
   private final UnderFileSystem mUfs;
   private final String mCheckpointPath;
 
@@ -53,12 +53,11 @@ public class JournalReader {
 
   /**
    * @param journal the handle to the journal
-   * @param tachyonConf the tachyon conf
    */
-  JournalReader(Journal journal, TachyonConf tachyonConf) {
+  JournalReader(Journal journal) {
     mJournal = Preconditions.checkNotNull(journal);
-    mTachyonConf = Preconditions.checkNotNull(tachyonConf);
-    mUfs = UnderFileSystem.get(mJournal.getDirectory(), mTachyonConf);
+    TachyonConf conf = MasterContext.getConf();
+    mUfs = UnderFileSystem.get(mJournal.getDirectory(), conf);
     mCheckpointPath = mJournal.getCheckpointFilePath();
   }
 

--- a/servers/src/main/java/tachyon/master/journal/JournalTailerThread.java
+++ b/servers/src/main/java/tachyon/master/journal/JournalTailerThread.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.master.Master;
+import tachyon.master.MasterContext;
 import tachyon.util.CommonUtils;
 
 public final class JournalTailerThread extends Thread {
@@ -40,11 +41,11 @@ public final class JournalTailerThread extends Thread {
   /**
    * @param master the master to apply the journal entries to
    * @param journal the journal to tail
-   * @param conf the TachyonConf to get configurable parameters from
    */
-  public JournalTailerThread(Master master, Journal journal, TachyonConf conf) {
+  public JournalTailerThread(Master master, Journal journal) {
     mMaster = Preconditions.checkNotNull(master);
     mJournal = Preconditions.checkNotNull(journal);
+    TachyonConf conf = MasterContext.getConf();
     mShutdownQuietWaitTimeMs = conf.getInt(
         Constants.MASTER_JOURNAL_TAILER_SHUTDOWN_QUIET_WAIT_TIME_MS);
     mJournalTailerSleepTimeMs = conf.getInt(Constants.MASTER_JOURNAL_TAILER_SLEEP_TIME_MS);

--- a/servers/src/main/java/tachyon/master/journal/JournalWriter.java
+++ b/servers/src/main/java/tachyon/master/journal/JournalWriter.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
+import tachyon.master.MasterContext;
 import tachyon.underfs.UnderFileSystem;
 
 /**
@@ -44,7 +45,6 @@ public final class JournalWriter {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private final Journal mJournal;
-  private final TachyonConf mTachyonConf;
   /** Absolute path to the directory storing all of the journal data. */
   private final String mJournalDirectory;
   /** Absolute path to the directory storing all completed logs. */
@@ -66,14 +66,14 @@ public final class JournalWriter {
   /** The sequence number for the next entry in the log. */
   private long mNextEntrySequenceNumber = 1;
 
-  JournalWriter(Journal journal, TachyonConf tachyonConf) {
+  JournalWriter(Journal journal) {
     mJournal = Preconditions.checkNotNull(journal);
-    mTachyonConf = Preconditions.checkNotNull(tachyonConf);
     mJournalDirectory = mJournal.getDirectory();
     mCompletedDirectory = mJournal.getCompletedDirectory();
     mTempCheckpointPath = mJournal.getCheckpointFilePath() + ".tmp";
-    mUfs = UnderFileSystem.get(mJournalDirectory, mTachyonConf);
-    mMaxLogSize = tachyonConf.getBytes(Constants.MASTER_JOURNAL_MAX_LOG_SIZE_BYTES);
+    TachyonConf conf = MasterContext.getConf();
+    mUfs = UnderFileSystem.get(mJournalDirectory, conf);
+    mMaxLogSize = conf.getBytes(Constants.MASTER_JOURNAL_MAX_LOG_SIZE_BYTES);
   }
 
   /**

--- a/servers/src/main/java/tachyon/master/journal/ReadOnlyJournal.java
+++ b/servers/src/main/java/tachyon/master/journal/ReadOnlyJournal.java
@@ -15,18 +15,15 @@
 
 package tachyon.master.journal;
 
-import tachyon.conf.TachyonConf;
-
 /**
  * The read-only version of {@link Journal}. It prevents access to a journal writer.
  */
 public class ReadOnlyJournal extends Journal {
   /**
    * @param directory the base directory for the journal
-   * @param tachyonConf the tachyon conf
    */
-  public ReadOnlyJournal(String directory, TachyonConf tachyonConf) {
-    super(directory, tachyonConf);
+  public ReadOnlyJournal(String directory) {
+    super(directory);
   }
 
   @Override

--- a/servers/src/main/java/tachyon/master/rawtable/RawTableMaster.java
+++ b/servers/src/main/java/tachyon/master/rawtable/RawTableMaster.java
@@ -27,6 +27,7 @@ import tachyon.Constants;
 import tachyon.TachyonURI;
 import tachyon.conf.TachyonConf;
 import tachyon.master.MasterBase;
+import tachyon.master.MasterContext;
 import tachyon.master.file.FileSystemMaster;
 import tachyon.master.journal.Journal;
 import tachyon.master.journal.JournalEntry;
@@ -59,13 +60,12 @@ public class RawTableMaster extends MasterBase {
     return PathUtils.concatPath(baseDirectory, Constants.RAW_TABLE_MASTER_SERVICE_NAME);
   }
 
-  public RawTableMaster(TachyonConf tachyonConf, FileSystemMaster fileSystemMaster,
-      Journal journal) {
+  public RawTableMaster(FileSystemMaster fileSystemMaster, Journal journal) {
     super(journal,
-        Executors.newFixedThreadPool(2, ThreadFactoryUtils.build("raw-table-master-%d", true)),
-        tachyonConf);
-    mMaxTableMetadataBytes = mTachyonConf.getBytes(Constants.MAX_TABLE_METADATA_BYTE);
-    mMaxColumns = mTachyonConf.getInt(Constants.MAX_COLUMNS);
+        Executors.newFixedThreadPool(2, ThreadFactoryUtils.build("raw-table-master-%d", true)));
+    TachyonConf conf = MasterContext.getConf();
+    mMaxTableMetadataBytes = conf.getBytes(Constants.MAX_TABLE_METADATA_BYTE);
+    mMaxColumns = conf.getInt(Constants.MAX_COLUMNS);
     mFileSystemMaster = fileSystemMaster;
   }
 

--- a/servers/src/main/java/tachyon/web/WebInterfaceDownloadServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceDownloadServlet.java
@@ -116,7 +116,7 @@ public final class WebInterfaceDownloadServlet extends HttpServlet {
     FileInStream is = null;
     ServletOutputStream out = null;
     try {
-      // TODO(jsimsa): Could this use MasterContext?
+      // TODO(jiri): Should we use MasterContext here instead?
       ClientOptions op = new ClientOptions.Builder(
           new TachyonConf()).setTachyonStoreType(TachyonStorageType.NO_STORE).build();
       is = tachyonClient.getInStream(fd, op);

--- a/servers/src/main/java/tachyon/web/WebInterfaceDownloadServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceDownloadServlet.java
@@ -36,6 +36,7 @@ import tachyon.client.ClientOptions;
 import tachyon.client.file.FileInStream;
 import tachyon.client.file.TachyonFile;
 import tachyon.client.file.TachyonFileSystem;
+import tachyon.conf.TachyonConf;
 import tachyon.master.file.FileSystemMaster;
 import tachyon.thrift.FileDoesNotExistException;
 import tachyon.thrift.FileInfo;
@@ -115,8 +116,9 @@ public final class WebInterfaceDownloadServlet extends HttpServlet {
     FileInStream is = null;
     ServletOutputStream out = null;
     try {
-      ClientOptions op = new ClientOptions.Builder(mFsMaster.getTachyonConf()).setTachyonStoreType(
-          TachyonStorageType.NO_STORE).build();
+      // TODO(jsimsa): Could this use MasterContext?
+      ClientOptions op = new ClientOptions.Builder(
+          new TachyonConf()).setTachyonStoreType(TachyonStorageType.NO_STORE).build();
       is = tachyonClient.getInStream(fd, op);
       out = response.getOutputStream();
       ByteStreams.copy(is, out);

--- a/servers/src/main/java/tachyon/web/WebInterfaceGeneralServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceGeneralServlet.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 import tachyon.Constants;
 import tachyon.StorageLevelAlias;
 import tachyon.Version;
+import tachyon.conf.TachyonConf;
 import tachyon.master.TachyonMaster;
 import tachyon.master.file.meta.DependencyVariables;
 import tachyon.underfs.UnderFileSystem;
@@ -176,9 +177,10 @@ public final class WebInterfaceGeneralServlet extends HttpServlet {
             FormatUtils.getSizeFromBytes(mMaster.getBlockMaster().getCapacityBytes()
                 - mMaster.getBlockMaster().getUsedBytes()));
 
-    String ufsDataFolder = mMaster.getTachyonConf().get(Constants.UNDERFS_DATA_FOLDER,
-        Constants.DEFAULT_DATA_FOLDER);
-    UnderFileSystem ufs = UnderFileSystem.get(ufsDataFolder, mMaster.getTachyonConf());
+    // TODO(jsimsa): Could this use MasterContext?
+    TachyonConf conf = new TachyonConf();
+    String ufsDataFolder = conf.get(Constants.UNDERFS_DATA_FOLDER, Constants.DEFAULT_DATA_FOLDER);
+    UnderFileSystem ufs = UnderFileSystem.get(ufsDataFolder, conf);
 
     long sizeBytes = ufs.getSpace(ufsDataFolder, UnderFileSystem.SpaceType.SPACE_TOTAL);
     if (sizeBytes >= 0) {

--- a/servers/src/test/java/tachyon/master/file/FileSystemMasterTest.java
+++ b/servers/src/test/java/tachyon/master/file/FileSystemMasterTest.java
@@ -47,7 +47,6 @@ public final class FileSystemMasterTest {
   private static final TachyonURI ROOT_FILE_URI = new TachyonURI("/file");
   private static final TachyonURI TEST_URI = new TachyonURI("/test");
 
-  private final TachyonConf mTachyonConf = new TachyonConf();
   private BlockMaster mBlockMaster;
   private FileSystemMaster mFileSystemMaster;
   private long mWorkerId;
@@ -60,11 +59,11 @@ public final class FileSystemMasterTest {
 
   @Before
   public void before() throws Exception {
-    Journal blockJournal = new Journal(mTestFolder.newFolder().getAbsolutePath(), mTachyonConf);
-    Journal fsJournal = new Journal(mTestFolder.newFolder().getAbsolutePath(), mTachyonConf);
+    Journal blockJournal = new Journal(mTestFolder.newFolder().getAbsolutePath());
+    Journal fsJournal = new Journal(mTestFolder.newFolder().getAbsolutePath());
 
-    mBlockMaster = new BlockMaster(mTachyonConf, blockJournal);
-    mFileSystemMaster = new FileSystemMaster(mTachyonConf, mBlockMaster, fsJournal);
+    mBlockMaster = new BlockMaster(blockJournal);
+    mFileSystemMaster = new FileSystemMaster(mBlockMaster, fsJournal);
 
     mBlockMaster.start(true);
     mFileSystemMaster.start(true);

--- a/servers/src/test/java/tachyon/master/file/meta/InodeTreeTest.java
+++ b/servers/src/test/java/tachyon/master/file/meta/InodeTreeTest.java
@@ -54,10 +54,9 @@ public final class InodeTreeTest {
 
   @Before
   public void before() throws IOException {
-    TachyonConf conf = new TachyonConf();
-    Journal blockJournal = new Journal(mTestFolder.newFolder().getAbsolutePath(), conf);
+    Journal blockJournal = new Journal(mTestFolder.newFolder().getAbsolutePath());
 
-    BlockMaster blockMaster = new BlockMaster(conf, blockJournal);
+    BlockMaster blockMaster = new BlockMaster(blockJournal);
     InodeDirectoryIdGenerator directoryIdGenerator = new InodeDirectoryIdGenerator(blockMaster);
     mTree = new InodeTree(blockMaster, directoryIdGenerator);
 

--- a/shell/src/test/java/tachyon/shell/TFsShellTest.java
+++ b/shell/src/test/java/tachyon/shell/TFsShellTest.java
@@ -71,7 +71,7 @@ public class TFsShellTest {
     mLocalTachyonCluster = new LocalTachyonCluster(SIZE_BYTES, 1000, Constants.GB);
     mLocalTachyonCluster.start();
     mTfs = mLocalTachyonCluster.getClient();
-    mFsShell = new TFsShell(mLocalTachyonCluster.getMasterTachyonConf());
+    mFsShell = new TFsShell(new TachyonConf());
     mOutput = new ByteArrayOutputStream();
     mNewOutput = new PrintStream(mOutput);
     mOldOutput = System.out;


### PR DESCRIPTION
This PR replaces the use of private members that store the Tachyon configuration in the master code with the use of MasterContext.