### PR TITLE
[SMALLFIX] Exclude LICENSE file in assemly jar. 

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -94,6 +94,7 @@
                 <filter>
                   <artifact>*:* </artifact>
                   <excludes>
+                    <exclude>LICENSE</exclude>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>


### PR DESCRIPTION
The reason is to avod conflicting filenames in filesytems that are not insensitive for filename case like MacOS filesystem. e.g., using yarn running the assembly jar on MacOS meets this problem