### PR TITLE
[SMALLFIX] Fix vagrant deployment when cloning local repo to EC2

### DIFF
--- a/deploy/vagrant/provision/roles/tachyon/tasks/clone_local_repo.yml
+++ b/deploy/vagrant/provision/roles/tachyon/tasks/clone_local_repo.yml
@@ -11,12 +11,14 @@
     rsync_opts: >
       --exclude=.git,
       --exclude=.gitignore,
-      --exclude=core/target,
+      --exclude=clients/target,
+      --exclude=servers/target,
+      --exclude=integration-tests/target,
+      --exclude=integration/target,
       --exclude=assembly/target,
       --exclude=client/target,
       --exclude=deploy,
       --exclude=docs,
-      --exclude=journal,
       --exclude=logs,
       --exclude=underFSStorage
 

--- a/deploy/vagrant/provision/roles/tachyon/tasks/clone_local_repo.yml
+++ b/deploy/vagrant/provision/roles/tachyon/tasks/clone_local_repo.yml
@@ -1,4 +1,7 @@
 # Rsync local Tachyon repo(suppose it's under the relative path: playbook.yml/../../../)
+#
+# TODO(binfan): $TACHYON_HOME/journal is temporarily removed from the exclude lists, due to a naming collision
+# with java files in package tachyon.master.journal. Try to find a better way to exclude files.
 ---
 
 - name: mkdir /tachyon


### PR DESCRIPTION
${TACHYON_HOME}/journal is excluded by rsync when cloning the local source repo. However, a source folder also named as "journal" was skipped too due to this exclusion. Remove the rsync filtering rule for now. Leave a TODO to better address this problem.