### PR TITLE
[SMALLFIX] Standardized duplicate error messages in master

### DIFF
--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -57,6 +57,13 @@ public enum ExceptionMessage {
   TEMP_BLOCK_ID_COMMITTED("Temp blockId {0} is not available, because it is already committed"),
   TEMP_BLOCK_ID_EXISTS("Temp blockId {0} is not available, because it already exists"),
 
+  // file system master
+  UNEXPECETD_JOURNAL_ENTRY("Unexpected entry in journal: {0}"),
+  FILEID_MUST_BE_FILE("File id {0} must be a file"),
+  JOURNAL_WRITE_AFTER_CLOSE("Cannot write entry after closing the stream"),
+  RAW_TABLE_ID_DOES_NOT_EXIST("Raw table with id {0} does not exist"),
+  UNKNOWN_ENTRY_TYPE("Unknown entry type: {0}"),
+
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;
 

--- a/servers/src/main/java/tachyon/master/block/BlockMaster.java
+++ b/servers/src/main/java/tachyon/master/block/BlockMaster.java
@@ -39,10 +39,11 @@ import org.slf4j.LoggerFactory;
 import tachyon.Constants;
 import tachyon.HeartbeatExecutor;
 import tachyon.HeartbeatThread;
+import tachyon.IndexedSet;
 import tachyon.StorageDirId;
 import tachyon.StorageLevelAlias;
 import tachyon.conf.TachyonConf;
-import tachyon.IndexedSet;
+import tachyon.exception.ExceptionMessage;
 import tachyon.master.MasterBase;
 import tachyon.master.MasterContext;
 import tachyon.master.block.journal.BlockContainerIdGeneratorEntry;
@@ -164,7 +165,7 @@ public final class BlockMaster extends MasterBase implements ContainerIdGenerabl
       mBlocks.put(blockInfoEntry.getBlockId(),
           new MasterBlockInfo(blockInfoEntry.getBlockId(), blockInfoEntry.getLength()));
     } else {
-      throw new IOException("unexpected entry in journal: " + entry);
+      throw new IOException(ExceptionMessage.UNEXPECETD_JOURNAL_ENTRY.getMessage(entry));
     }
   }
 

--- a/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
@@ -35,6 +35,7 @@ import tachyon.PrefixList;
 import tachyon.StorageLevelAlias;
 import tachyon.TachyonURI;
 import tachyon.conf.TachyonConf;
+import tachyon.exception.ExceptionMessage;
 import tachyon.master.MasterBase;
 import tachyon.master.MasterContext;
 import tachyon.master.block.BlockId;
@@ -166,7 +167,7 @@ public final class FileSystemMaster extends MasterBase {
     } else if (entry instanceof InodeDirectoryIdGeneratorEntry) {
       mDirectoryIdGenerator.fromJournalEntry((InodeDirectoryIdGeneratorEntry) entry);
     } else {
-      throw new IOException("unexpected entry in journal: " + entry);
+      throw new IOException(ExceptionMessage.UNEXPECETD_JOURNAL_ENTRY.getMessage(entry));
     }
   }
 
@@ -232,7 +233,7 @@ public final class FileSystemMaster extends MasterBase {
 
     Inode inode = mInodeTree.getInodeById(fileId);
     if (inode.isDirectory()) {
-      throw new FileDoesNotExistException("File id " + fileId + " is a directory, not a file.");
+      throw new FileDoesNotExistException(ExceptionMessage.FILEID_MUST_BE_FILE.getMessage(fileId));
     }
 
     InodeFile file = (InodeFile) inode;
@@ -329,9 +330,8 @@ public final class FileSystemMaster extends MasterBase {
    * @param fileId the file id to get the {@link FileInfo} for
    * @return the {@link FileInfo} for the given file id
    * @throws FileDoesNotExistException
-   * @throws InvalidPathException
    */
-  public FileInfo getFileInfo(long fileId) throws FileDoesNotExistException, InvalidPathException {
+  public FileInfo getFileInfo(long fileId) throws FileDoesNotExistException {
     // TODO(gene): metrics
     synchronized (mInodeTree) {
       Inode inode = mInodeTree.getInodeById(fileId);
@@ -385,7 +385,8 @@ public final class FileSystemMaster extends MasterBase {
       long opTimeMs = System.currentTimeMillis();
       Inode inode = mInodeTree.getInodeById(fileId);
       if (!inode.isFile()) {
-        throw new FileDoesNotExistException("File id " + fileId + " is not a file.");
+        throw new FileDoesNotExistException(
+                ExceptionMessage.FILEID_MUST_BE_FILE.getMessage(fileId));
       }
 
       InodeFile fileInode = (InodeFile) inode;
@@ -486,7 +487,7 @@ public final class FileSystemMaster extends MasterBase {
       inode = mInodeTree.getInodeById(fileId);
     }
     if (!inode.isFile()) {
-      throw new FileDoesNotExistException("File id " + fileId + " is not a file.");
+      throw new FileDoesNotExistException(ExceptionMessage.FILEID_MUST_BE_FILE.getMessage(fileId));
     }
 
     return ((InodeFile) inode).getNewBlockId();
@@ -592,7 +593,8 @@ public final class FileSystemMaster extends MasterBase {
     synchronized (mInodeTree) {
       Inode inode = mInodeTree.getInodeById(fileId);
       if (inode.isDirectory()) {
-        throw new FileDoesNotExistException("FileId " + fileId + " is not a file.");
+        throw new FileDoesNotExistException(
+                ExceptionMessage.FILEID_MUST_BE_FILE.getMessage(fileId));
       }
       InodeFile file = (InodeFile) inode;
       List<Long> blockIdList = new ArrayList<Long>(1);
@@ -617,7 +619,8 @@ public final class FileSystemMaster extends MasterBase {
     synchronized (mInodeTree) {
       Inode inode = mInodeTree.getInodeById(fileId);
       if (inode.isDirectory()) {
-        throw new FileDoesNotExistException("FileId " + fileId + " is not a file.");
+        throw new FileDoesNotExistException(
+                ExceptionMessage.FILEID_MUST_BE_FILE.getMessage(fileId));
       }
       InodeFile file = (InodeFile) inode;
       List<BlockInfo> blockInfoList = mBlockMaster.getBlockInfoList(file.getBlockIds());

--- a/servers/src/main/java/tachyon/master/journal/JournalWriter.java
+++ b/servers/src/main/java/tachyon/master/journal/JournalWriter.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
+import tachyon.exception.ExceptionMessage;
 import tachyon.master.MasterContext;
 import tachyon.underfs.UnderFileSystem;
 
@@ -233,7 +234,7 @@ public final class JournalWriter {
     @Override
     public synchronized void writeEntry(JournalEntry entry) throws IOException {
       if (mIsClosed) {
-        throw new IOException("Cannot write entry after closing the stream.");
+        throw new IOException(ExceptionMessage.JOURNAL_WRITE_AFTER_CLOSE.getMessage());
       }
       mJournal.getJournalFormatter().serialize(
           new SerializableJournalEntry(mNextEntrySequenceNumber ++, entry), mOutputStream);
@@ -299,7 +300,7 @@ public final class JournalWriter {
     @Override
     public synchronized void writeEntry(JournalEntry entry) throws IOException {
       if (mIsClosed) {
-        throw new IOException("Cannot write entry after closing the stream.");
+        throw new IOException(ExceptionMessage.JOURNAL_WRITE_AFTER_CLOSE.getMessage());
       }
       mJournal.getJournalFormatter().serialize(
           new SerializableJournalEntry(mNextEntrySequenceNumber ++, entry), mOutputStream);

--- a/servers/src/main/java/tachyon/master/journal/JsonJournalFormatter.java
+++ b/servers/src/main/java/tachyon/master/journal/JsonJournalFormatter.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import tachyon.TachyonURI;
+import tachyon.exception.ExceptionMessage;
 import tachyon.master.block.journal.BlockContainerIdGeneratorEntry;
 import tachyon.master.block.journal.BlockInfoEntry;
 import tachyon.master.file.journal.AddCheckpointEntry;
@@ -355,7 +356,7 @@ public final class JsonJournalFormatter implements JournalFormatter {
                 entry.getByteBuffer("metadata"));
           }
           default:
-            throw new IOException("Unknown entry type: " + entry.mType);
+            throw new IOException(ExceptionMessage.UNKNOWN_ENTRY_TYPE.getMessage(entry.mType));
         }
       }
 

--- a/servers/src/main/java/tachyon/master/journal/JsonJournalFormatter.java
+++ b/servers/src/main/java/tachyon/master/journal/JsonJournalFormatter.java
@@ -356,7 +356,7 @@ public final class JsonJournalFormatter implements JournalFormatter {
                 entry.getByteBuffer("metadata"));
           }
           default:
-            throw new IOException(ExceptionMessage.UNKNOWN_ENTRY_TYPE.getMessage(entry.mType));
+            throw new IOException("Unknown journal entry type: " + entry.mType);
         }
       }
 

--- a/servers/src/main/java/tachyon/master/rawtable/RawTableMaster.java
+++ b/servers/src/main/java/tachyon/master/rawtable/RawTableMaster.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import tachyon.Constants;
 import tachyon.TachyonURI;
 import tachyon.conf.TachyonConf;
+import tachyon.exception.ExceptionMessage;
 import tachyon.master.MasterBase;
 import tachyon.master.MasterContext;
 import tachyon.master.file.FileSystemMaster;
@@ -94,7 +95,7 @@ public class RawTableMaster extends MasterBase {
         throw new IOException(tdnee);
       }
     } else {
-      throw new IOException("Unknown entry type " + entry.getType());
+      throw new IOException(ExceptionMessage.UNKNOWN_ENTRY_TYPE.getMessage(entry.getType()));
     }
   }
 
@@ -167,7 +168,8 @@ public class RawTableMaster extends MasterBase {
   public void updateRawTableMetadata(long tableId, ByteBuffer metadata)
       throws TableDoesNotExistException, TachyonException {
     if (!mFileSystemMaster.isDirectory(tableId)) {
-      throw new TableDoesNotExistException("Table with id " + tableId + " does not exist.");
+      throw new TableDoesNotExistException(
+          ExceptionMessage.RAW_TABLE_ID_DOES_NOT_EXIST.getMessage(tableId));
     }
     mRawTables.updateMetadata(tableId, metadata);
 
@@ -213,13 +215,15 @@ public class RawTableMaster extends MasterBase {
    */
   public RawTableInfo getClientRawTableInfo(long id) throws TableDoesNotExistException {
     if (!mRawTables.contains(id)) {
-      throw new TableDoesNotExistException("Table with id " + id + " does not exist.");
+      throw new TableDoesNotExistException(
+          ExceptionMessage.RAW_TABLE_ID_DOES_NOT_EXIST.getMessage(id));
     }
 
     try {
       FileInfo fileInfo = mFileSystemMaster.getFileInfo(id);
       if (!fileInfo.isFolder) {
-        throw new TableDoesNotExistException("Table with id " + id + " does not exist.");
+        throw new TableDoesNotExistException(
+            ExceptionMessage.RAW_TABLE_ID_DOES_NOT_EXIST.getMessage(id));
       }
 
       RawTableInfo ret = new RawTableInfo();
@@ -230,9 +234,8 @@ public class RawTableMaster extends MasterBase {
       ret.metadata = mRawTables.getMetadata(ret.id);
       return ret;
     } catch (FileDoesNotExistException fne) {
-      throw new TableDoesNotExistException("Table with id " + id + " does not exist.");
-    } catch (InvalidPathException e) {
-      throw new TableDoesNotExistException("Table id " + id + " is invalid.");
+      throw new TableDoesNotExistException(
+          ExceptionMessage.RAW_TABLE_ID_DOES_NOT_EXIST.getMessage(id));
     }
   }
 

--- a/servers/src/main/java/tachyon/master/rawtable/RawTableMaster.java
+++ b/servers/src/main/java/tachyon/master/rawtable/RawTableMaster.java
@@ -95,7 +95,7 @@ public class RawTableMaster extends MasterBase {
         throw new IOException(tdnee);
       }
     } else {
-      throw new IOException(ExceptionMessage.UNKNOWN_ENTRY_TYPE.getMessage(entry.getType()));
+      throw new IOException("Unknown raw table entry type: " + entry.getType());
     }
   }
 

--- a/servers/src/main/java/tachyon/master/rawtable/meta/RawTables.java
+++ b/servers/src/main/java/tachyon/master/rawtable/meta/RawTables.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import tachyon.IndexedSet;
+import tachyon.exception.ExceptionMessage;
 import tachyon.master.journal.JournalCheckpointStreamable;
 import tachyon.master.journal.JournalOutputStream;
 import tachyon.thrift.TableDoesNotExistException;
@@ -117,7 +118,8 @@ public class RawTables implements JournalCheckpointStreamable {
     RawTable table = mTables.getFirstByField(mIdIndex, tableId);
 
     if (table == null) {
-      throw new TableDoesNotExistException("The raw table " + tableId + " does not exist.");
+      throw new TableDoesNotExistException(
+          ExceptionMessage.RAW_TABLE_ID_DOES_NOT_EXIST.getMessage(tableId));
     }
 
     table.setMetadata(metadata);


### PR DESCRIPTION
We put exception messages that are used in numerous places in the ExceptionMessage class. Other remaining error messages in the master code are not duplicated anywhere, so they didn't need to be put into ExceptionMessage