### PR TITLE
[TACHYON-995] Fix Log message in LocalBlockOutStream to not include parenthesis

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/block/LocalBlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/block/LocalBlockOutStream.java
@@ -66,7 +66,7 @@ public final class LocalBlockOutStream extends BufferedBlockOutStream {
       RandomAccessFile localFile = mCloser.register(new RandomAccessFile(blockPath, "rw"));
       mLocalFileChannel = mCloser.register(localFile.getChannel());
       // Change the permission of the temporary file in order that the worker can move it.
-      LOG.info("LocalBlockOutStream created new file block, block path: (" + blockPath + ")");
+      LOG.info("LocalBlockOutStream created new file block, block path: " + blockPath);
     } catch (IOException ioe) {
       mContext.releaseWorkerClient(mWorkerClient);
       throw ioe;


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-995