### PR TITLE
[SMALLFIX] Fix NPE when getTotalBytesOnTiers is called before workerR…

### DIFF
--- a/servers/src/main/java/tachyon/master/block/meta/MasterWorkerInfo.java
+++ b/servers/src/main/java/tachyon/master/block/meta/MasterWorkerInfo.java
@@ -63,13 +63,15 @@ public final class MasterWorkerInfo {
   private Set<Long> mToRemoveBlocks;
 
   public MasterWorkerInfo(long id, NetAddress address) {
-    mId = id;
     mWorkerAddress = Preconditions.checkNotNull(address);
+    mId = id;
     mStartTimeMs = System.currentTimeMillis();
     mLastUpdatedTimeMs = System.currentTimeMillis();
+    mIsRegistered = false;
+    mTotalBytesOnTiers = Collections.emptyList();
+    mUsedBytesOnTiers = Collections.emptyList();
     mBlocks = new HashSet<Long>();
     mToRemoveBlocks = new HashSet<Long>();
-    mIsRegistered = false;
   }
 
   /**


### PR DESCRIPTION
…egister

If getTotalBytesOnTiers is called after blockMaster.getWorkerId and before
blockMaster.workerRegister, worker.getTotalBytesOnTiers() will be null, so
the for (int i = 0; i < worker.getTotalBytesOnTiers().size(); i ++) { will
throw an NPE.

To fix this we should only add the worker's bytes if getTotalBytesOnTiers
is not null, which will be the case after the worker has registered.