### PR TITLE
[SMALLFIX] Use workercontext to get conf for PinListSync and BlockMasterSync

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
@@ -53,8 +53,6 @@ public final class BlockMasterSync implements Runnable {
   private final BlockDataManager mBlockDataManager;
   /** The net address of the worker */
   private final NetAddress mWorkerAddress;
-  /** The configuration values */
-  private final TachyonConf mTachyonConf;
   /** Milliseconds between each heartbeat */
   private final int mHeartbeatIntervalMs;
   /** Milliseconds between heartbeats before a timeout */
@@ -81,10 +79,10 @@ public final class BlockMasterSync implements Runnable {
       WorkerBlockMasterClient masterClient) {
     mBlockDataManager = blockDataManager;
     mWorkerAddress = workerAddress;
-    mTachyonConf = WorkerContext.getConf();
+    TachyonConf conf = WorkerContext.getConf();
     mMasterClient = masterClient;
-    mHeartbeatIntervalMs = mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
-    mHeartbeatTimeoutMs = mTachyonConf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS);
+    mHeartbeatIntervalMs = conf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    mHeartbeatTimeoutMs = conf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS);
 
     mRunning = true;
     mWorkerId = 0;

--- a/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
@@ -31,6 +31,7 @@ import tachyon.exception.NotFoundException;
 import tachyon.thrift.Command;
 import tachyon.thrift.NetAddress;
 import tachyon.util.CommonUtils;
+import tachyon.worker.WorkerContext;
 
 /**
  * Task that carries out the necessary block worker to master communications, including register and
@@ -69,11 +70,18 @@ public final class BlockMasterSync implements Runnable {
   private final ExecutorService mFixedExecutionService =
       Executors.newFixedThreadPool(DEFAULT_BLOCK_REMOVER_POOL_SIZE);
 
-  BlockMasterSync(BlockDataManager blockDataManager, TachyonConf tachyonConf,
-      NetAddress workerAddress, WorkerBlockMasterClient masterClient) {
+  /**
+   * Constructor for BlockMasterSync
+   *
+   * @param blockDataManager the blockDataManager this syncer is updating to
+   * @param workerAddress the net address of the worker
+   * @param masterClient the Tachyon master client
+   */
+  BlockMasterSync(BlockDataManager blockDataManager, NetAddress workerAddress,
+      WorkerBlockMasterClient masterClient) {
     mBlockDataManager = blockDataManager;
     mWorkerAddress = workerAddress;
-    mTachyonConf = tachyonConf;
+    mTachyonConf = WorkerContext.getConf();
     mMasterClient = masterClient;
     mHeartbeatIntervalMs = mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
     mHeartbeatTimeoutMs = mTachyonConf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS);

--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -211,14 +211,14 @@ public final class BlockWorker {
     mSyncExecutorService =
         Executors.newFixedThreadPool(3, ThreadFactoryUtils.build("worker-heartbeat-%d", true));
 
-    mBlockMasterSync = new BlockMasterSync(mBlockDataManager, mTachyonConf, mWorkerNetAddress,
+    mBlockMasterSync = new BlockMasterSync(mBlockDataManager, mWorkerNetAddress,
             mBlockMasterClient);
     // Get the worker id
     // TODO(calvin): Do this at TachyonWorker.
     mBlockMasterSync.setWorkerId();
 
     // Setup PinListSyncer
-    mPinListSync = new PinListSync(mBlockDataManager, mTachyonConf, mFileSystemMasterClient);
+    mPinListSync = new PinListSync(mBlockDataManager, mFileSystemMasterClient);
 
     // Setup session cleaner
     mSessionCleanerThread = new SessionCleaner(mBlockDataManager);

--- a/servers/src/main/java/tachyon/worker/block/PinListSync.java
+++ b/servers/src/main/java/tachyon/worker/block/PinListSync.java
@@ -38,8 +38,6 @@ public final class PinListSync implements Runnable {
 
   /** Block data manager responsible for interacting with Tachyon and UFS storage */
   private final BlockDataManager mBlockDataManager;
-  /** The configuration values */
-  private final TachyonConf mTachyonConf;
   /** Milliseconds between each sync */
   private final int mSyncIntervalMs;
   /** Milliseconds between syncs before a timeout */
@@ -58,11 +56,11 @@ public final class PinListSync implements Runnable {
    */
   public PinListSync(BlockDataManager blockDataManager, WorkerFileSystemMasterClient masterClient) {
     mBlockDataManager = blockDataManager;
-    mTachyonConf = WorkerContext.getConf();
+    TachyonConf conf = WorkerContext.getConf();
     
     mMasterClient = masterClient;
-    mSyncIntervalMs = mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
-    mSyncTimeoutMs = mTachyonConf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS);
+    mSyncIntervalMs = conf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
+    mSyncTimeoutMs = conf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS);
 
     mRunning = true;
   }

--- a/servers/src/main/java/tachyon/worker/block/PinListSync.java
+++ b/servers/src/main/java/tachyon/worker/block/PinListSync.java
@@ -24,6 +24,7 @@ import tachyon.Constants;
 import tachyon.client.WorkerFileSystemMasterClient;
 import tachyon.conf.TachyonConf;
 import tachyon.util.CommonUtils;
+import tachyon.worker.WorkerContext;
 
 /**
  * PinListSync periodically syncs the set of pinned inodes from master,
@@ -53,13 +54,12 @@ public final class PinListSync implements Runnable {
    * Constructor for PinListSync
    *
    * @param blockDataManager the blockDataManager this syncer is updating to
-   * @param tachyonConf the configuration values to be used
    * @param masterClient the Tachyon master client
    */
-  public PinListSync(BlockDataManager blockDataManager, TachyonConf tachyonConf,
-      WorkerFileSystemMasterClient masterClient) {
+  public PinListSync(BlockDataManager blockDataManager, WorkerFileSystemMasterClient masterClient) {
     mBlockDataManager = blockDataManager;
-    mTachyonConf = tachyonConf;
+    mTachyonConf = WorkerContext.getConf();
+    
     mMasterClient = masterClient;
     mSyncIntervalMs = mTachyonConf.getInt(Constants.WORKER_TO_MASTER_HEARTBEAT_INTERVAL_MS);
     mSyncTimeoutMs = mTachyonConf.getInt(Constants.WORKER_HEARTBEAT_TIMEOUT_MS);


### PR DESCRIPTION
PinListSync and BlockMasterSync should use workercontext to get tachyonconf now. Also add a javadoc comment for BlocalMasterSync