### PR TITLE
[TACHYON-926] Show user info in the output when TfsShell commands"ls or lsr" run

### DIFF
--- a/shell/src/main/java/tachyon/shell/TfsShell.java
+++ b/shell/src/main/java/tachyon/shell/TfsShell.java
@@ -597,7 +597,7 @@ public class TfsShell implements Closeable {
    */
   public int ls(TachyonURI path) throws IOException {
     List<FileInfo> files = listStatusSortedByIncreasingCreationTime(path);
-    String format = "%-10s%-25s%-15s%-5s%n";
+    String format = "%-10s%-25s%-15s%-15s%-5s%n";
     for (FileInfo file : files) {
       String inMemory = "";
       if (!file.isFolder) {
@@ -608,7 +608,8 @@ public class TfsShell implements Closeable {
         }
       }
       System.out.format(format, FormatUtils.getSizeFromBytes(file.getLength()),
-          convertMsToDate(file.getCreationTimeMs()), inMemory, file.getPath());
+          convertMsToDate(file.getCreationTimeMs()), inMemory, file.getUsername(),
+          file.getPath());
     }
     return 0;
   }
@@ -628,7 +629,7 @@ public class TfsShell implements Closeable {
    */
   public int lsr(TachyonURI path) throws IOException {
     List<FileInfo> files = listStatusSortedByIncreasingCreationTime(path);
-    String format = "%-10s%-25s%-15s%-5s%n";
+    String format = "%-10s%-25s%-15s%-15s%-5s%n";
     for (FileInfo file : files) {
       String inMemory = "";
       if (!file.isFolder) {
@@ -639,7 +640,8 @@ public class TfsShell implements Closeable {
         }
       }
       System.out.format(format, FormatUtils.getSizeFromBytes(file.getLength()),
-          convertMsToDate(file.getCreationTimeMs()), inMemory, file.getPath());
+          convertMsToDate(file.getCreationTimeMs()), inMemory, file.getUsername(),
+          file.getPath());
       if (file.isFolder) {
         lsr(new TachyonURI(path.getScheme(), path.getAuthority(), file.getPath()));
       }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-926

Currently, Tachyon supports simple authentication and binds the username info into inode. This feature is very useful. It can shows who create these files. The TfsShell commands such as ls or lsr should show these info. This PR depends on #1574 