### PR TITLE
[SMALLFIX] Remove unnecessary throws clause in checkIfClosed

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/block/LocalBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/block/LocalBlockInStream.java
@@ -157,7 +157,7 @@ public final class LocalBlockInStream extends BlockInStream {
     return ret;
   }
 
-  private void checkIfClosed() throws IOException {
+  private void checkIfClosed() {
     Preconditions.checkState(!mClosed, "Cannot do operations on a closed BlockInStream");
   }
 }


### PR DESCRIPTION
It no longer throws IOException.