### PR TITLE
[SMALLFIX] Change YARN setting in deployment not to check virtual memory

### DIFF
--- a/deploy/vagrant/provision/roles/ufs_hadoop2/files/config.sh
+++ b/deploy/vagrant/provision/roles/ufs_hadoop2/files/config.sh
@@ -87,5 +87,9 @@ cat > /hadoop/etc/hadoop/yarn-site.xml << EOF
 <name>yarn.nodemanager.aux-services</name>
 <value>mapreduce_shuffle</value>
 </property>
+<property>
+<name>yarn.nodemanager.vmem-check-enabled</name>
+<value>false</value>
+</property>
 </configuration>
 EOF


### PR DESCRIPTION
by default YARN gives each container 2GB virtual memory (not physical memory). And Tachyon master on initialization requires close to 5 GB virtual memory space (though only 100 MB physical memory used). This PR removes the check on YARN site if YARN is deployed using our vagrant script to avoid YARN killing Tachyon Master unnecessarily. 