### PR TITLE
TACHYON-1082 Remove unused constants from Tachyon.Constants

### DIFF
--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -59,9 +59,6 @@ public final class Constants {
   public static final int DEFAULT_WORKER_DATA_PORT = DEFAULT_WORKER_PORT + 1;
   public static final int DEFAULT_WORKER_WEB_PORT = DEFAULT_WORKER_PORT + 2;
 
-  public static final int DEFAULT_MASTER_MAX_WORKER_THREADS = 2048;
-  public static final int DEFAULT_WORKER_MAX_WORKER_THREADS = 2048;
-
   public static final int DEFAULT_USER_FAILED_SPACE_REQUEST_LIMITS = 3;
 
   public static final boolean DEFAULT_USER_ENABLE_LOCAL_READ = true;


### PR DESCRIPTION
The description on the JIRA indicated to remove these two variables.  Note:  These variables are integers not strings as indicated in the ticket.  Please merge if the intention was to remove the integer variables.