### PR TITLE
[SMALLFIX] Make SpaceReserverTest single thread

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/SpaceReserver.java
+++ b/servers/src/main/java/tachyon/worker/block/SpaceReserver.java
@@ -29,6 +29,8 @@ import tachyon.exception.BlockAlreadyExistsException;
 import tachyon.exception.BlockDoesNotExistException;
 import tachyon.exception.InvalidWorkerStateException;
 import tachyon.exception.WorkerOutOfSpaceException;
+import tachyon.test.Testable;
+import tachyon.test.Tester;
 import tachyon.util.CommonUtils;
 import tachyon.worker.WorkerContext;
 
@@ -36,7 +38,7 @@ import tachyon.worker.WorkerContext;
  * SpaceReserver periodically checks if there is enough space reserved on each storage tier, if
  * there is no enough free space on some tier, free space from it.
  */
-public class SpaceReserver implements Runnable {
+public class SpaceReserver implements Runnable, Testable<SpaceReserver> {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   private final BlockDataManager mBlockManager;
   /** Mapping from tier alias to space size to be reserved on the tier */
@@ -81,24 +83,7 @@ public class SpaceReserver implements Runnable {
       } else {
         LOG.warn("Space reserver took: " + lastIntervalMs + ", expected: " + mCheckIntervalMs);
       }
-      for (int tierIdx = mBytesToReserveOnTiers.size() - 1; tierIdx >= 0 ; tierIdx --) {
-        Pair<Integer, Long> bytesReservedOnTier = mBytesToReserveOnTiers.get(tierIdx);
-        int tierAlias = bytesReservedOnTier.getFirst();
-        long bytesReserved = bytesReservedOnTier.getSecond();
-        try {
-          mBlockManager.freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, bytesReserved, tierAlias);
-        } catch (WorkerOutOfSpaceException e) {
-          LOG.warn(e.getMessage());
-        } catch (BlockDoesNotExistException e) {
-          LOG.warn(e.getMessage());
-        } catch (BlockAlreadyExistsException e) {
-          LOG.warn(e.getMessage());
-        } catch (InvalidWorkerStateException e) {
-          LOG.warn(e.getMessage());
-        } catch (IOException e) {
-          LOG.warn(e.getMessage());
-        }
-      }
+      reserveSpace();
     }
   }
 
@@ -108,5 +93,40 @@ public class SpaceReserver implements Runnable {
   public void stop() {
     LOG.info("Space reserver exits!");
     mRunning = false;
+  }
+
+  @Override
+  public void grantAccess(Tester<SpaceReserver> tester) {
+    tester.receiveAccess(new PrivateAccess());
+  }
+
+  private void reserveSpace() {
+    for (int tierIdx = mBytesToReserveOnTiers.size() - 1; tierIdx >= 0 ; tierIdx --) {
+      Pair<Integer, Long> bytesReservedOnTier = mBytesToReserveOnTiers.get(tierIdx);
+      int tierAlias = bytesReservedOnTier.getFirst();
+      long bytesReserved = bytesReservedOnTier.getSecond();
+      try {
+        mBlockManager.freeSpace(Sessions.MIGRATE_DATA_SESSION_ID, bytesReserved, tierAlias);
+      } catch (WorkerOutOfSpaceException e) {
+        LOG.warn(e.getMessage());
+      } catch (BlockDoesNotExistException e) {
+        LOG.warn(e.getMessage());
+      } catch (BlockAlreadyExistsException e) {
+        LOG.warn(e.getMessage());
+      } catch (InvalidWorkerStateException e) {
+        LOG.warn(e.getMessage());
+      } catch (IOException e) {
+        LOG.warn(e.getMessage());
+      }
+    }
+  }
+
+  /** Grants access to private members to testers of this class. */
+  class PrivateAccess {
+    private PrivateAccess() {}
+
+    public void reserveSpace() {
+      SpaceReserver.this.reserveSpace();
+    }
   }
 }

--- a/servers/src/test/java/tachyon/worker/block/SpaceReserverTest.java
+++ b/servers/src/test/java/tachyon/worker/block/SpaceReserverTest.java
@@ -34,24 +34,26 @@ import tachyon.Constants;
 import tachyon.StorageLevelAlias;
 import tachyon.client.WorkerBlockMasterClient;
 import tachyon.client.WorkerFileSystemMasterClient;
+import tachyon.test.Tester;
 import tachyon.util.CommonUtils;
 import tachyon.worker.WorkerContext;
 import tachyon.worker.WorkerSource;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({WorkerFileSystemMasterClient.class, WorkerBlockMasterClient.class})
-public class SpaceReserverTest {
+public class SpaceReserverTest implements Tester<SpaceReserver> {
   private static final long SESSION_ID = 1;
-  private static final long BLOCK_SIZE = 300;
+  private static final long BLOCK_SIZE = 100;
 
   private static final int[] TIER_LEVEL = {0, 1};
-  private static final StorageLevelAlias[] TIER_ALIAS = {StorageLevelAlias.MEM,
-      StorageLevelAlias.HDD};
+  private static final StorageLevelAlias[] TIER_ALIAS =
+      {StorageLevelAlias.MEM, StorageLevelAlias.HDD};
   private static final String[][] TIER_PATH = {{"/ramdisk"}, {"/disk1"}};
-  private static final long[][] TIER_CAPACITY_BYTES = {{1000}, {3000}};
+  private static final long[][] TIER_CAPACITY_BYTES = {{400}, {1000}};
+
   private BlockStore mBlockStore;
   private SpaceReserver mSpaceReserver;
-  private ExecutorService mExecutorService = Executors.newFixedThreadPool(1);
+  private SpaceReserver.PrivateAccess mPrivateAccess;
 
   @Rule
   public TemporaryFolder mTempFolder = new TemporaryFolder();
@@ -59,7 +61,6 @@ public class SpaceReserverTest {
   @After
   public void after() {
     mSpaceReserver.stop();
-    mExecutorService.shutdown();
   }
 
   @Before
@@ -72,17 +73,21 @@ public class SpaceReserverTest {
     TieredBlockStoreTestUtils.setupTachyonConfWithMultiTier(baseDir, TIER_LEVEL, TIER_ALIAS,
         TIER_PATH, TIER_CAPACITY_BYTES, null);
     mBlockStore = new TieredBlockStore();
-    BlockDataManager blockDataManager =
-        new BlockDataManager(workerSource, blockMasterClient, workerFileSystemMasterClient,
-            mBlockStore);
+    BlockDataManager blockDataManager = new BlockDataManager(workerSource, blockMasterClient,
+        workerFileSystemMasterClient, mBlockStore);
     String reserveRatioProp =
         String.format(Constants.WORKER_TIERED_STORAGE_LEVEL_RESERVED_RATIO_FORMAT, 0);
     WorkerContext.getConf().set(reserveRatioProp, "0.2");
     reserveRatioProp =
         String.format(Constants.WORKER_TIERED_STORAGE_LEVEL_RESERVED_RATIO_FORMAT, 1);
-    WorkerContext.getConf().set(reserveRatioProp, "0.2");
+    WorkerContext.getConf().set(reserveRatioProp, "0.3");
     mSpaceReserver = new SpaceReserver(blockDataManager);
-    mExecutorService.submit(mSpaceReserver);
+    mSpaceReserver.grantAccess(this);
+  }
+
+  @Override
+  public void receiveAccess(Object access) {
+    mPrivateAccess = (SpaceReserver.PrivateAccess) access;
   }
 
   @Test
@@ -90,30 +95,47 @@ public class SpaceReserverTest {
     // Reserve on top tier
     long blockId = 100;
     BlockStoreLocation tier0 = BlockStoreLocation.anyDirInTier(StorageLevelAlias.MEM.getValue());
-    for (int i = 0; i < 3; i ++) {
-      TieredBlockStoreTestUtils.cache(SESSION_ID, blockId ++, BLOCK_SIZE, mBlockStore,
-          tier0);
+    for (int i = 0; i < 4; i ++) {
+      TieredBlockStoreTestUtils.cache(SESSION_ID, blockId ++, BLOCK_SIZE, mBlockStore, tier0);
     }
-    CommonUtils
-        .sleepMs(2 * WorkerContext.getConf().getLong(Constants.WORKER_SPACE_RESERVER_INTERVAL_MS));
+
     BlockStoreMeta storeMeta = mBlockStore.getBlockStoreMeta();
-    Assert.assertEquals(3 * BLOCK_SIZE, storeMeta.getUsedBytes());
     List<Long> usedBytesOnTiers = storeMeta.getUsedBytesOnTiers();
-    Assert.assertEquals(2 * BLOCK_SIZE,
+    Assert.assertEquals(4 * BLOCK_SIZE, storeMeta.getUsedBytes());
+    Assert.assertEquals(4 * BLOCK_SIZE,
         (long) usedBytesOnTiers.get(StorageLevelAlias.MEM.getValue() - 1));
-    Assert.assertEquals(BLOCK_SIZE,
+    Assert.assertEquals(0, (long) usedBytesOnTiers.get(StorageLevelAlias.HDD.getValue() - 1));
+
+    // Reserver kicks in, expect evicting one block from MEM to HHD
+    mPrivateAccess.reserveSpace();
+
+    storeMeta = mBlockStore.getBlockStoreMeta();
+    usedBytesOnTiers = storeMeta.getUsedBytesOnTiers();
+    Assert.assertEquals(4 * BLOCK_SIZE, storeMeta.getUsedBytes());
+    Assert.assertEquals(3 * BLOCK_SIZE,
+        (long) usedBytesOnTiers.get(StorageLevelAlias.MEM.getValue() - 1));
+    Assert.assertEquals(1 * BLOCK_SIZE,
         (long) usedBytesOnTiers.get(StorageLevelAlias.HDD.getValue() - 1));
 
     // Reserve on under tier
-    for (int i = 0; i < 7; i ++) {
+    for (int i = 0; i < 10; i ++) {
       TieredBlockStoreTestUtils.cache(SESSION_ID, blockId ++, BLOCK_SIZE, mBlockStore, tier0);
     }
-    CommonUtils
-        .sleepMs(2 * WorkerContext.getConf().getLong(Constants.WORKER_SPACE_RESERVER_INTERVAL_MS));
     storeMeta = mBlockStore.getBlockStoreMeta();
-    Assert.assertEquals(9 * BLOCK_SIZE, storeMeta.getUsedBytes());
     usedBytesOnTiers = storeMeta.getUsedBytesOnTiers();
-    Assert.assertEquals(2 * BLOCK_SIZE,
+    Assert.assertEquals(14 * BLOCK_SIZE, storeMeta.getUsedBytes());
+    Assert.assertEquals(4 * BLOCK_SIZE,
+        (long) usedBytesOnTiers.get(StorageLevelAlias.MEM.getValue() - 1));
+    Assert.assertEquals(10 * BLOCK_SIZE,
+        (long) usedBytesOnTiers.get(StorageLevelAlias.HDD.getValue() - 1));
+
+    // Reserver kicks in again, expect evicting one block from MEM to HHD and four blocks from HHD
+    mPrivateAccess.reserveSpace();
+
+    storeMeta = mBlockStore.getBlockStoreMeta();
+    usedBytesOnTiers = storeMeta.getUsedBytesOnTiers();
+    Assert.assertEquals(10 * BLOCK_SIZE, storeMeta.getUsedBytes());
+    Assert.assertEquals(3 * BLOCK_SIZE,
         (long) usedBytesOnTiers.get(StorageLevelAlias.MEM.getValue() - 1));
     Assert.assertEquals(7 * BLOCK_SIZE,
         (long) usedBytesOnTiers.get(StorageLevelAlias.HDD.getValue() - 1));


### PR DESCRIPTION
Simplify SpaceReserverTest by removing multiple-threading.
Unit tests are meant to be simple and isolated.
This test used to be flaky.