### PR TITLE
[TACHYON-1043] Fix flakiness in IsolatedTachyonFileSystemIntegrationTest

### DIFF
--- a/integration-tests/src/test/java/tachyon/client/IsolatedTachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/IsolatedTachyonFileSystemIntegrationTest.java
@@ -160,14 +160,12 @@ public class IsolatedTachyonFileSystemIntegrationTest {
     }
     files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + numOfFiles, fileSize, mWriteBoth));
 
-    for (int k = 0; k <= numOfFiles; k ++) {
-      FileInfo info = mTfs.getInfo(files.get(k));
-      if (k != 0) {
-        Assert.assertTrue(info.getInMemoryPercentage() == 100);
-      } else {
-        CommonUtils.sleepMs(getSleepMs());
-        Assert.assertFalse(info.getInMemoryPercentage() == 100);
-      }
+    CommonUtils.sleepMs(getSleepMs());
+    FileInfo info = mTfs.getInfo(files.get(0));
+    Assert.assertFalse(info.getInMemoryPercentage() == 100);
+    for (int k = 1; k <= numOfFiles; k ++) {
+      info = mTfs.getInfo(files.get(k));
+      Assert.assertTrue(info.getInMemoryPercentage() == 100);
     }
   }
 

--- a/integration-tests/src/test/java/tachyon/client/IsolatedTachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/IsolatedTachyonFileSystemIntegrationTest.java
@@ -130,6 +130,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
       FileInfo info = mTfs.getInfo(files.get(k));
       Assert.assertTrue(info.getInMemoryPercentage() == 100);
     }
+    // Sleep to ensure eviction has been reported to master
     CommonUtils.sleepMs(getSleepMs());
     FileInfo info = mTfs.getInfo(files.get(numOfFiles));
     Assert.assertTrue(info.getInMemoryPercentage() == 100);
@@ -160,6 +161,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
     }
     files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + numOfFiles, fileSize, mWriteBoth));
 
+    // Sleep to ensure eviction has been reported to master
     CommonUtils.sleepMs(getSleepMs());
     FileInfo info = mTfs.getInfo(files.get(0));
     Assert.assertFalse(info.getInMemoryPercentage() == 100);
@@ -191,6 +193,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
     }
     files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + numOfFiles, fileSize, mWriteBoth));
 
+    // Sleep to ensure eviction has been reported to master
     CommonUtils.sleepMs(getSleepMs());
     FileInfo info = mTfs.getInfo(files.get(0));
     Assert.assertFalse(info.getInMemoryPercentage() == 100);
@@ -229,6 +232,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
       FileInfo info = mTfs.getInfo(files.get(k));
       Assert.assertTrue(info.getInMemoryPercentage() == 100);
     }
+    // Sleep to ensure eviction has been reported to master
     CommonUtils.sleepMs(getSleepMs());
     FileInfo info = mTfs.getInfo(files.get(numOfFiles));
     Assert.assertTrue(info.getInMemoryPercentage() == 100);
@@ -260,6 +264,7 @@ public class IsolatedTachyonFileSystemIntegrationTest {
     }
     files.add(TachyonFSTestUtils.createByteFile(mTfs, uniqPath + numOfFiles, fileSize, mWriteBoth));
 
+    // Sleep to ensure eviction has been reported to master
     CommonUtils.sleepMs(getSleepMs());
     FileInfo info = mTfs.getInfo(files.get(0));
     Assert.assertFalse(info.getInMemoryPercentage() == 100);


### PR DESCRIPTION
Fix a bug in IsolatedTachyonFileSystemIntegrationTest#unlockBlockTest3 which causes this test flaky

In the test, we should first sleep until eviction propagated to master then get `fileInfo`, while the original 
did it in the wrong order.