### PR TITLE
Providing executor dependencies from URI.

### DIFF
--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -116,6 +116,10 @@ public final class Constants {
   public static final String MAX_TABLE_METADATA_BYTE = "tachyon.max.table.metadata.byte";
   public static final String METRICS_CONF_FILE = "tachyon.metrics.conf.file";
   public static final String FORMAT_FILE_PREFIX = "_format_";
+  public static final String EXECUTOR_DEPENDENCY_PATH
+      = "tachyon.integration.mesos.executor.dependency.path";
+  public static final String JRE_URL = "tachyon.integration.mesos.jre.url";
+  public static final String JRE_VERSION = "tachyon.integration.mesos.jre.version";
 
   public static final String MASTER_FORMAT_FILE_PREFIX = "tachyon.master.format.file_prefix";
   public static final String MASTER_HOSTNAME_LISTENING = "tachyon.master.hostname.listening";

--- a/common/src/main/resources/tachyon-default.properties
+++ b/common/src/main/resources/tachyon-default.properties
@@ -38,6 +38,10 @@ tachyon.max.columns=1000
 tachyon.test.mode=false
 tachyon.max.table.metadata.byte=5MB
 tachyon.host.resolution.timeout.ms=5000
+#Path where executors will load their dependencies. must be path in S3, HDFS etc..
+tachyon.integration.mesos.executor.dependency.path=https://s3.amazonaws.com/tachyon-mesos
+tachyon.integration.mesos.jre.url=https://s3.amazonaws.com/tachyon-mesos/jre-7u79-linux-x64.tar.gz
+tachyon.integration.mesos.jre.version=jre1.7.0_79
 
 # Security properties
 tachyon.security.authentication.type=NOSASL

--- a/integration/mesos/src/main/java/tachyon/mesos/TachyonFramework.java
+++ b/integration/mesos/src/main/java/tachyon/mesos/TachyonFramework.java
@@ -22,12 +22,11 @@ import java.util.Set;
 
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.CommandInfo;
-
-import com.google.common.collect.Lists;
-
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
 import org.apache.mesos.MesosSchedulerDriver;
+
+import com.google.common.collect.Lists;
 
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-990

In current version, assuming tachyon binaries and java is installed and are already in mesos slaves but may not be in practice. Executor dependencies provided from distributed file system or some server.