### PR TITLE
[TACHYON-1098] Stripping path from TachyonURI

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/lineage/AbstractLineageClient.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/AbstractLineageClient.java
@@ -47,6 +47,10 @@ public abstract class AbstractLineageClient implements LineageClient {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   protected LineageContext mContext;
 
+  public AbstractLineageClient() {
+    mContext = LineageContext.INSTANCE;
+  }
+
   @Override
   public long createLineage(List<TachyonURI> inputFiles, List<TachyonURI> outputFiles, Job job,
       CreateLineageOptions options)

--- a/clients/unshaded/src/main/java/tachyon/client/lineage/AbstractLineageClient.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/AbstractLineageClient.java
@@ -16,14 +16,13 @@
 package tachyon.client.lineage;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
@@ -95,17 +94,16 @@ public abstract class AbstractLineageClient implements LineageClient {
   }
 
   /**
-   * Transfors the list of @{link TachyonURI} in a new list of Strings,
-   * where each string is @{link TachyonURI#getPath()}
-   * @param uris
-   * @return
+   * Transforms the list of {@link TachyonURI} in a new list of Strings,
+   * where each string is {@link TachyonURI#getPath()}
+   * @param uris the list of {@link TacyonUri}s to be stripped 
+   * @return a new list of strings mapping the input URIs to theri path component
    */
   private List<String> stripURIList(List<TachyonURI> uris) {
-    return Lists.transform(uris, new Function<TachyonURI, String>() {
-      @Override
-      public String apply(TachyonURI input) {
-        return input.getPath();
-      }
-    });
+    final List<String> pathStrings = new ArrayList<String>(uris.size());
+    for (final TachyonURI uri : uris) {
+      pathStrings.add(uri.getPath());
+    }
+    return pathStrings;
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/lineage/LineageMasterClient.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/LineageMasterClient.java
@@ -105,7 +105,7 @@ public final class LineageMasterClient extends MasterClientBase {
     throw new IOException("Failed after " + retry + " retries.");
   }
 
-  public synchronized long reintializeFile(String path, long blockSizeBytes, long ttl)
+  public synchronized long reinitializeFile(String path, long blockSizeBytes, long ttl)
       throws IOException, TachyonException {
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {

--- a/clients/unshaded/src/main/java/tachyon/client/lineage/LineageMasterClient.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/LineageMasterClient.java
@@ -69,23 +69,14 @@ public final class LineageMasterClient extends MasterClientBase {
     mClient = new LineageMasterService.Client(mProtocol);
   }
 
-  public synchronized long createLineage(List<TachyonURI> inputFiles, List<TachyonURI> outputFiles,
+  public synchronized long createLineage(List<String> inputFiles, List<String> outputFiles,
       CommandLineJob job) throws IOException, TachyonException {
     // prepare for RPC
-    List<String> inputFileStrings = Lists.newArrayList();
-    for (TachyonURI inputFile : inputFiles) {
-      inputFileStrings.add(inputFile.toString());
-    }
-    List<String> outputFileStrings = Lists.newArrayList();
-    for (TachyonURI outputFile : outputFiles) {
-      outputFileStrings.add(outputFile.toString());
-    }
-
     int retry = 0;
     while (!mClosed && (retry ++) <= RPC_MAX_NUM_RETRY) {
       connect();
       try {
-        return mClient.createLineage(inputFileStrings, outputFileStrings,
+        return mClient.createLineage(inputFiles, outputFiles,
             job.generateCommandLineJobInfo());
       } catch (TachyonTException e) {
         throw new TachyonException(e);

--- a/clients/unshaded/src/main/java/tachyon/client/lineage/TachyonLineageFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/TachyonLineageFileSystem.java
@@ -66,7 +66,7 @@ public class TachyonLineageFileSystem extends TachyonFileSystem {
     LineageMasterClient masterClient = mContext.acquireMasterClient();
     try {
       long fileId =
-          masterClient.reintializeFile(path.getPath(), options.getBlockSize(), options.getTTL());
+          masterClient.reinitializeFile(path.getPath(), options.getBlockSize(), options.getTTL());
       return fileId;
     } catch (TachyonException e) {
       TachyonException.unwrap(e, LineageDoesNotExistException.class);

--- a/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
@@ -255,7 +255,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
 
     LOG.debug("createPath {}", FormatUtils.parametersToString(path));
 
-    String[] pathComponents = PathUtils.getPathComponents(path.toString());
+    String[] pathComponents = PathUtils.getPathComponents(path.getPath());
     String name = path.getName();
 
     String[] parentPath = new String[pathComponents.length - 1];


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1098

- Now AbstractLineageClient passes just the path part to
  LineageMasterClient#createLineage, which, in turn, has been updated
  accordingly.
- InodeTree#createPath passes the correct path part of the TachyoURI to
  PathUtils#getPathComponents