### PR TITLE
[TACHYON-1097] Better logic in S3UnderFileSystem#stripPerfixIfPresent

### DIFF
--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -534,7 +534,6 @@ public class S3UnderFileSystem extends UnderFileSystem {
     if (key.startsWith(PATH_SEPARATOR)) {
       return key.substring(PATH_SEPARATOR.length());
     }
-    LOG.warn("Attempted to strip key with invalid prefix: " + key);
     return key;
   }
 }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -520,15 +520,19 @@ public class S3UnderFileSystem extends UnderFileSystem {
   }
 
   /**
-   * Strips the s3 bucket prefix from the key if it is present. For example, for input key
-   * s3n://my-bucket-name/my-path/file, the output would be my-path/file. This method will leave
-   * keys without a prefix unaltered, ie. my-path/file returns my-path/file.
+   * Strips the s3 bucket prefix or the preceding path separator from the key if it is present.
+   * For example, for input key s3n://my-bucket-name/my-path/file, the output would be my-path/file.
+   * If key is an absolute path like /my-path/file, the output would be my-path/file.
+   * This method will leave keys without a prefix unaltered, ie. my-path/file returns my-path/file.
    * @param key the key to strip
    * @return the key without the s3 bucket prefix
    */
   private String stripPrefixIfPresent(String key) {
     if (key.startsWith(mBucketPrefix)) {
       return key.substring(mBucketPrefix.length());
+    }
+    if (key.startsWith(PATH_SEPARATOR)) {
+      return key.substring(PATH_SEPARATOR.length());
     }
     LOG.warn("Attempted to strip key with invalid prefix: " + key);
     return key;

--- a/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderFileSystemTest.java
+++ b/underfs/s3/src/test/java/tachyon/underfs/s3/S3UnderFileSystemTest.java
@@ -122,25 +122,28 @@ public class S3UnderFileSystemTest {
 
   @Test
   public void stripPrefixIfPresentTest() throws Exception {
-    String input1 = "s3n://test-bucket";
-    String input2 = "s3n://test-bucket/";
-    String input3 = "s3n://test-bucket/file";
-    String input4 = "s3n://test-bucket/dir/file";
-    String input5 = "s3n://test-bucket-wrong/dir/file";
-    String input6 = "dir/file";
-    String result1 = Whitebox.invokeMethod(mMockS3UnderFileSystem, "stripPrefixIfPresent", input1);
-    String result2 = Whitebox.invokeMethod(mMockS3UnderFileSystem, "stripPrefixIfPresent", input2);
-    String result3 = Whitebox.invokeMethod(mMockS3UnderFileSystem, "stripPrefixIfPresent", input3);
-    String result4 = Whitebox.invokeMethod(mMockS3UnderFileSystem, "stripPrefixIfPresent", input4);
-    String result5 = Whitebox.invokeMethod(mMockS3UnderFileSystem, "stripPrefixIfPresent", input5);
-    String result6 = Whitebox.invokeMethod(mMockS3UnderFileSystem, "stripPrefixIfPresent", input6);
-
-    Assert.assertEquals("s3n://test-bucket", result1);
-    Assert.assertEquals("", result2);
-    Assert.assertEquals("file", result3);
-    Assert.assertEquals("dir/file", result4);
-    Assert.assertEquals("s3n://test-bucket-wrong/dir/file", result5);
-    Assert.assertEquals("dir/file", result6);
+    String[] inputs = new String[]{
+        "s3n://test-bucket",
+        "s3n://test-bucket/",
+        "s3n://test-bucket/file",
+        "s3n://test-bucket/dir/file",
+        "s3n://test-bucket-wrong/dir/file",
+        "dir/file",
+        "/dir/file",
+    };
+    String[] results = new String[]{
+        "s3n://test-bucket",
+        "",
+        "file",
+        "dir/file",
+        "s3n://test-bucket-wrong/dir/file",
+        "dir/file",
+        "dir/file",
+    };
+    for (int i = 0; i < inputs.length; i ++) {
+      Assert.assertEquals(results[i], Whitebox.invokeMethod(mMockS3UnderFileSystem,
+          "stripPrefixIfPresent", inputs[i]));
+    }
   }
 
 }


### PR DESCRIPTION
This PR fixes https://tachyon.atlassian.net/browse/TACHYON-1097. 

Also, before this PR, consider that we have an instance of `S3UnderFileSystem` `ufs`, then call `ufs.create("s3n://a/b/")`, and then call `ufs.exists("/a/b")`, the last call will return false, I think this behavior is not what we want, since a client of ufs may call `create` with uri containing scheme, it may also call it with just the absolute path.  This PR fixes this misbehavior too.