### PR TITLE
[SMALLFIX] Wait for leader to be selected in deploy/create 

### DIFF
--- a/deploy/vagrant/create
+++ b/deploy/vagrant/create
@@ -176,7 +176,8 @@ fi
 masters=($(echo $masters | tr '\n' ' ' | tr -d '\r'))
 
 if [[ "$TACHYON_MASTERS" -gt 1 ]]; then
-  info ">>> Tachyon is in Fault Tolerant mode, all Tachyon masters: <<<"
+  info ">>> Tachyon is in Fault Tolerant mode, waiting 5 seconds for leader to be selected and web UI to be available <<<"
+  sleep 5
 fi
 for master in ${masters[@]}; do
   info "Tachyon master: ${master}"


### PR DESCRIPTION
In practice, when Tachyon is in fault tolerant mode, I find that without waiting for sometime, the leader may not have been selected, so all `curl` to web UI will fail, then user needs to manually try to load web UI of different masters to determine current leader, not user-friendly.