### PR TITLE
[SMALLFIX] Ignore license in client jar

### DIFF
--- a/clients/client/pom.xml
+++ b/clients/client/pom.xml
@@ -183,6 +183,8 @@
                 <filter>
                   <artifact>*:* </artifact>
                   <excludes>
+                    <exclude>LICENSE</exclude>
+                    <exclude>META-INF/LICENSE</exclude>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>


### PR DESCRIPTION
This prevent issues with unjar() when running hadoop with the tachyon client jar.