### PR TITLE
[SMALLFIX] Sleep before waiting for spot instances

### DIFF
--- a/deploy/vagrant/bin/spot_request.py
+++ b/deploy/vagrant/bin/spot_request.py
@@ -118,6 +118,9 @@ def submit_request(conn, ec2_conf):
     request_ids = [r.id for r in requests]
     save_request_ids(request_ids)
 
+    # sleep before waiting for spot instances to be fulfilled.
+    time.sleep(5)
+
     # block, waiting for all requests to be fulfilled
     requests = wait_until_fulfilled(request_ids, conn)
 


### PR DESCRIPTION
Sometimes, waiting for spot instances fails because it can't find the spot instance id. Sleeping seems to solve that error.