### PR TITLE
[SMALLFIX] Add back underFSStorage into gitignore,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /docs/serve/
 /journal/
 /logs/
+/underFSStorage/
 dependency-reduced-pom.xml
 target/
 tests.log*


### PR DESCRIPTION
 which is the default ufs dir for local fs