### PR TITLE
[TACHYON-1101] Integrating tachyon mesos framework with Mesos-DNS for service discovery

### DIFF
--- a/integration/mesos/src/main/java/tachyon/mesos/TachyonFramework.java
+++ b/integration/mesos/src/main/java/tachyon/mesos/TachyonFramework.java
@@ -275,7 +275,7 @@ public class TachyonFramework {
     // Start Mesos master. Setting the user to an empty string will prompt Mesos to set it to the
     // current user.
     Protos.FrameworkInfo framework =
-        Protos.FrameworkInfo.newBuilder().setUser("").setName("Tachyon Framework")
+        Protos.FrameworkInfo.newBuilder().setUser("").setName("tachyon").setCheckpoint(true)
             .setPrincipal("tachyon-framework").build();
 
     Scheduler scheduler = new TachyonScheduler();


### PR DESCRIPTION
When a task starts RUNNING, new entry is automatically registered to mesos-dns  and format will be “taskname.frameworkname.mesos”. 
In tachyon framework, I set frame name as “tachyon” and our master task name is “masternode”, then our dns entry will be “masternode.tachyon.mesos”. Mesos-DNS installation that configured to Mesos master will be enough to test it.
