### PR TITLE
[TACHYON-993] Added openIfExists method

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
@@ -175,16 +175,8 @@ public class TachyonFile implements Comparable<TachyonFile> {
     } else {
       optionsBuilder.setTachyonStorageType(TachyonStorageType.NO_STORE);
     }
-    tachyon.client.file.TachyonFile newFile;
     try {
-      newFile = mTFS.open(uri);
-    } catch (TachyonException e) {
-      throw new IOException(e);
-    }
-    if (newFile == null) {
-      throw new IOException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(uri));
-    }
-    try {
+      tachyon.client.file.TachyonFile newFile = mTFS.open(uri);
       return mTFS.getInStream(newFile, optionsBuilder.build());
     } catch (TachyonException e) {
       throw new IOException(e);

--- a/clients/unshaded/src/main/java/tachyon/client/file/AbstractTachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/AbstractTachyonFileSystem.java
@@ -218,6 +218,17 @@ public abstract class AbstractTachyonFileSystem implements TachyonFileSystemCore
     }
   }
 
+  /**
+   * Resolves a {@link TachyonURI} to a {@link TachyonFile} which is used as the file handler for
+   * non-create operations.
+   *
+   * @param path the path of the file, this should be in Tachyon space
+   * @param openOptions method options
+   * @return a TachyonFile which acts as a file handler for the path
+   * @throws IOException if a non-Tachyon exception occurs
+   * @throws InvalidPathException if there is no file at the given path
+   * @throws TachyonException if an unexpected tachyon exception is thrown
+   */
   public TachyonFile open(TachyonURI path, OpenOptions openOptions) throws IOException,
       InvalidPathException, TachyonException {
     TachyonFile f = openIfExists(path, openOptions);

--- a/clients/unshaded/src/main/java/tachyon/client/file/AbstractTachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/AbstractTachyonFileSystem.java
@@ -218,7 +218,6 @@ public abstract class AbstractTachyonFileSystem implements TachyonFileSystemCore
     }
   }
 
-  @Override
   public TachyonFile open(TachyonURI path, OpenOptions openOptions) throws IOException,
       InvalidPathException, TachyonException {
     TachyonFile f = openIfExists(path, openOptions);

--- a/clients/unshaded/src/main/java/tachyon/client/file/AbstractTachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/AbstractTachyonFileSystem.java
@@ -37,6 +37,7 @@ import tachyon.client.file.options.OpenOptions;
 import tachyon.client.file.options.RenameOptions;
 import tachyon.client.file.options.SetStateOptions;
 import tachyon.client.file.options.UnmountOptions;
+import tachyon.exception.ExceptionMessage;
 import tachyon.exception.FileAlreadyExistsException;
 import tachyon.exception.FileDoesNotExistException;
 import tachyon.exception.InvalidPathException;
@@ -218,7 +219,18 @@ public abstract class AbstractTachyonFileSystem implements TachyonFileSystemCore
   }
 
   @Override
-  public TachyonFile open(TachyonURI path, OpenOptions openOptions) throws IOException {
+  public TachyonFile open(TachyonURI path, OpenOptions openOptions) throws IOException,
+      InvalidPathException, TachyonException {
+    TachyonFile f = openIfExists(path, openOptions);
+    if (f == null) {
+      throw new InvalidPathException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
+    }
+    return f;
+  }
+
+  @Override
+  public TachyonFile openIfExists(TachyonURI path, OpenOptions openOptions) throws IOException,
+      TachyonException {
     FileSystemMasterClient masterClient = mContext.acquireMasterClient();
     try {
       long fileId = masterClient.getFileId(path.getPath());

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
@@ -214,8 +214,16 @@ public class TachyonFileSystem extends AbstractTachyonFileSystem {
   /**
    * Convenience method for {@link #open(TachyonURI, OpenOptions)} with default options.
    */
-  public TachyonFile open(TachyonURI path) throws IOException, TachyonException {
+  public TachyonFile open(TachyonURI path) throws IOException, InvalidPathException,
+      TachyonException {
     return open(path, OpenOptions.defaults());
+  }
+
+  /**
+   * Convenience method for {@link #openIfExists(TachyonURI, OpenOptions)} with default options.
+   */
+  public TachyonFile openIfExists(TachyonURI path) throws IOException, TachyonException {
+    return openIfExists(path, OpenOptions.defaults());
   }
 
   /**

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystemCore.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystemCore.java
@@ -157,11 +157,27 @@ interface TachyonFileSystemCore {
    *
    * @param path the path of the file, this should be in Tachyon space
    * @param options method options
-   * @return a TachyonFile which acts as a file handler for the path or null if path doesn't exist
+   * @return a TachyonFile which acts as a file handler for the path
+   * @throws IOException if a non-Tachyon exception occurs
+   * @throws InvalidPathException if there is no file at the given path
+   * @throws TachyonException if an unexpected tachyon exception is thrown
+   */
+  TachyonFile open(TachyonURI path, OpenOptions options) throws IOException, InvalidPathException,
+      TachyonException;
+
+  /**
+   * Resolves a {@link TachyonURI} to a {@link TachyonFile} which is used as the file handler for
+   * non-create operations.
+   *
+   * @param path the path of the file, this should be in Tachyon space
+   * @param options method options
+   * @return a TachyonFile which acts as a file handler for the path or null if there is no file at
+             the given path
    * @throws IOException if a non-Tachyon exception occurs
    * @throws TachyonException if an unexpected tachyon exception is thrown
    */
-  TachyonFile open(TachyonURI path, OpenOptions options) throws IOException, TachyonException;
+  TachyonFile openIfExists(TachyonURI path, OpenOptions options) throws IOException,
+      TachyonException;
 
   /**
    * Renames an existing Tachyon file to another Tachyon path in Tachyon.

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystemCore.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystemCore.java
@@ -157,20 +157,6 @@ interface TachyonFileSystemCore {
    *
    * @param path the path of the file, this should be in Tachyon space
    * @param options method options
-   * @return a TachyonFile which acts as a file handler for the path
-   * @throws IOException if a non-Tachyon exception occurs
-   * @throws InvalidPathException if there is no file at the given path
-   * @throws TachyonException if an unexpected tachyon exception is thrown
-   */
-  TachyonFile open(TachyonURI path, OpenOptions options) throws IOException, InvalidPathException,
-      TachyonException;
-
-  /**
-   * Resolves a {@link TachyonURI} to a {@link TachyonFile} which is used as the file handler for
-   * non-create operations.
-   *
-   * @param path the path of the file, this should be in Tachyon space
-   * @param options method options
    * @return a TachyonFile which acts as a file handler for the path or null if there is no file at
              the given path
    * @throws IOException if a non-Tachyon exception occurs

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystemUtils.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystemUtils.java
@@ -64,20 +64,18 @@ public final class TachyonFileSystemUtils {
   /**
    * Wait for a file to be marked as completed.
    *
-   * The calling thread will block for <i>at most</i> {@code timeout} time units (as specified
-   * via {@code tunit} or until the TachyonFile is reported as complete by the
-   * master. The method will return
-   * the last known completion status of the file (hence, false only if the method
-   * has timed out).  A zero value on the {@code timeout} parameter will make the calling thread
-   * check once and return; a negative value will make it block indefinitely. Note that, in
-   * this last case, if a file is never completed, the thread will block
-   * forever, so use with care.
+   * The calling thread will block for <i>at most</i> {@code timeout} time units (as specified via
+   * {@code tunit} or until the TachyonFile is reported as complete by the master. The method will
+   * return the last known completion status of the file (hence, false only if the method has timed
+   * out). A zero value on the {@code timeout} parameter will make the calling thread check once and
+   * return; a negative value will make it block indefinitely. Note that, in this last case, if a
+   * file is never completed, the thread will block forever, so use with care.
    *
-   * Note that the file whose uri is specified, might not exist at the moment this method this
-   * call. The method will deliberately block anyway for the specified amount of time, waiting
-   * for the file to be created and eventually completed. Note also that the file might be moved
-   * or deleted while it is waited upon. In such cases the method will throw the a
-   * {@link TachyonException} with the appropriate {@link tachyon.exception.TachyonExceptionType}
+   * Note that the file whose uri is specified, might not exist at the moment this method this call.
+   * The method will deliberately block anyway for the specified amount of time, waiting for the
+   * file to be created and eventually completed. Note also that the file might be moved or deleted
+   * while it is waited upon. In such cases the method will throw the a {@link TachyonException}
+   * with the appropriate {@link tachyon.exception.TachyonExceptionType}
    *
    * <i>IMPLEMENTATION NOTES</i> This method is implemented
    * by periodically polling the master about the file status. The
@@ -88,39 +86,33 @@ public final class TachyonFileSystemUtils {
    * @param uri the URI of the file whose completion status is to be watied for.
    * @param timeout maximum time the calling thread should be blocked on this call.
    * @param tunit the @{link TimeUnit} instance describing the {@code timeout} parameter
-   * @return true if the file is complete when this method returns and false
-   * if the method timed out before the file was complete.
+   * @return true if the file is complete when this method returns and false if the method timed out
+   *         before the file was complete.
    *
-   * @throws IOException in case there are problems contacting the Tachyonmaster
-   * for the file status
+   * @throws IOException in case there are problems contacting the Tachyonmaster for the file status
    * @throws TachyonException if a Tachyon Exception occurs
-   * @throws InterruptedException if the thread receives an interrupt while
-   * waiting for file completion
+   * @throws InterruptedException if the thread receives an interrupt while waiting for file
+   *         completion
    */
-  public static boolean waitCompleted(final TachyonFileSystemCore tfs,
-      final TachyonURI uri, final long timeout, final TimeUnit tunit)  throws IOException,
-      TachyonException, InterruptedException {
+  public static boolean waitCompleted(final TachyonFileSystemCore tfs, final TachyonURI uri,
+      final long timeout, final TimeUnit tunit) throws IOException, TachyonException,
+      InterruptedException {
 
     final long deadline = System.currentTimeMillis() + tunit.toMillis(timeout);
     final long pollPeriod =
         ClientContext.getConf().getLong(Constants.USER_FILE_WAITCOMPLETED_POLL_MS);
     TachyonFile file = null;
-    boolean completed = false ;
+    boolean completed = false;
     long timeleft = deadline - System.currentTimeMillis();
     long toSleep = 0;
 
     while (!completed && (timeout <= 0 || timeleft > 0)) {
 
       if (file == null) {
-        try {
-          file = tfs.open(uri, OpenOptions.defaults());
-        } catch (TachyonException e) {
-          if (e.getType() == TachyonExceptionType.INVALID_PATH) {
-            LOG.debug("The file {} being waited upon does not exist yet. Waiting for it to be "
-                + "created.", uri);
-          } else {
-            throw e;
-          }
+        file = tfs.openIfExists(uri, OpenOptions.defaults());
+        if (file == null) {
+          LOG.debug("The file {} being waited upon does not exist yet. Waiting for it to be "
+              + "created.", uri);
         }
       }
 

--- a/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
@@ -145,6 +145,7 @@ public class TachyonFileSystemIntegrationTest {
       TachyonURI fileURI = new TachyonURI(uniqPath + k);
       TachyonFile f = sTfs.open(fileURI);
       sTfs.delete(f);
+      Assert.assertNull(sTfs.openIfExists(fileURI));
       mThrown.expect(FileDoesNotExistException.class);
       sTfs.getInfo(f);
     }

--- a/integration-tests/src/test/java/tachyon/worker/block/meta/TieredStoreIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/worker/block/meta/TieredStoreIntegrationTest.java
@@ -103,7 +103,7 @@ public class TieredStoreIntegrationTest {
     CommonUtils.sleepMs(LOG, mWorkerToMasterHeartbeatIntervalMs * 3);
 
     // After the delete, the master should no longer serve the file
-    Assert.assertNull(mTFS.open(new TachyonURI("/test1")));
+    Assert.assertNull(mTFS.openIfExists(new TachyonURI("/test1")));
 
     // However, the previous read should still be able to read it as the data still exists
     byte[] res = new byte[MEM_CAPACITY_BYTES];

--- a/servers/src/main/java/tachyon/web/WebInterfaceBrowseServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceBrowseServlet.java
@@ -76,9 +76,6 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
     TachyonFileSystem tFS = TachyonFileSystemFactory.get();
     TachyonFile tFile = tFS.open(path);
     String fileData = null;
-    if (tFile == null) {
-      throw new FileDoesNotExistException(path.toString());
-    }
     FileInfo fileInfo = tFS.getInfo(tFile);
     if (fileInfo.isCompleted) {
       InStreamOptions readNoCache = new InStreamOptions.Builder(mTachyonConf)

--- a/servers/src/main/java/tachyon/web/WebInterfaceWorkerBlockInfoServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceWorkerBlockInfoServlet.java
@@ -38,6 +38,7 @@ import tachyon.client.file.TachyonFileSystem.TachyonFileSystemFactory;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.BlockDoesNotExistException;
 import tachyon.exception.FileDoesNotExistException;
+import tachyon.exception.InvalidPathException;
 import tachyon.exception.TachyonException;
 import tachyon.master.block.BlockId;
 import tachyon.thrift.FileInfo;
@@ -215,15 +216,12 @@ public final class WebInterfaceWorkerBlockInfoServlet extends HttpServlet {
    */
   private UiFileInfo getUiFileInfo(TachyonFileSystem tachyonFileSystem, long fileId,
       TachyonURI filePath) throws BlockDoesNotExistException, FileDoesNotExistException,
-          IOException, TachyonException {
+      InvalidPathException, IOException, TachyonException {
     TachyonFile file = null;
     if (fileId != -1) {
       file = new TachyonFile(fileId);
     } else {
       file = tachyonFileSystem.open(filePath);
-      if (file == null) {
-        throw new FileDoesNotExistException(filePath.toString());
-      }
     }
     FileInfo fileInfo;
     try {

--- a/shell/src/main/java/tachyon/shell/TfsShell.java
+++ b/shell/src/main/java/tachyon/shell/TfsShell.java
@@ -110,13 +110,9 @@ public class TfsShell implements Closeable {
     FileInfo tFile;
     try {
       fd = mTfs.open(path);
-      if (fd == null) {
-        System.out.print(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-        return -1;
-      }
       tFile = mTfs.getInfo(fd);
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
 
     if (!tFile.isFolder) {
@@ -168,15 +164,11 @@ public class TfsShell implements Closeable {
     FileInfo fInfo;
     try {
       fd = mTfs.open(filePath);
-      if (fd == null) {
-        System.out.print(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(filePath));
-        return -1;
-      }
       fInfo = mTfs.getInfo(fd);
     } catch (IOException ioe) {
       return -1;
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
 
     try {
@@ -240,13 +232,9 @@ public class TfsShell implements Closeable {
     FileInfo dstFileInfo;
     try {
       TachyonFile dstFd = mTfs.open(dstPath);
-      if (dstFd == null) {
-        System.out.print(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(dstPath));
-        return -1;
-      }
       dstFileInfo = mTfs.getInfo(dstFd);
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
     if (!dstFileInfo.isFolder) {
       System.out.println("The destination cannot be an existent file when the src contains "
@@ -290,7 +278,7 @@ public class TfsShell implements Closeable {
       // If the dstPath is a directory, then it should be updated to be the path of the file where
       // src will be copied to
       try {
-        TachyonFile fd = tachyonClient.open(dstPath);
+        TachyonFile fd = tachyonClient.openIfExists(dstPath);
         if (fd != null) {
           FileInfo tFile = tachyonClient.getInfo(fd);
           if (tFile.isFolder) {
@@ -298,7 +286,7 @@ public class TfsShell implements Closeable {
           }
         }
       } catch (TachyonException e) {
-        throw new IOException(e);
+        throw new IOException(e.getMessage());
       }
 
       Closer closer = Closer.create();
@@ -313,7 +301,7 @@ public class TfsShell implements Closeable {
           os.write(buf.array(), 0, buf.limit());
         }
       } catch (TachyonException e) {
-        throw new IOException(e);
+        throw new IOException(e.getMessage());
       } finally {
         closer.close();
       }
@@ -322,7 +310,7 @@ public class TfsShell implements Closeable {
       try {
         tachyonClient.mkdir(dstPath);
       } catch (TachyonException e) {
-        throw new IOException(e);
+        throw new IOException(e.getMessage());
       }
       for (String file : src.list()) {
         TachyonURI newPath = new TachyonURI(dstPath, new TachyonURI(file));
@@ -383,13 +371,9 @@ public class TfsShell implements Closeable {
     FileInfo srcFileInfo;
     try {
       srcFd = mTfs.open(srcPath);
-      if (srcFd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(srcPath));
-        return -1;
-      }
       srcFileInfo = mTfs.getInfo(srcFd);
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
 
     if (srcFileInfo.isFolder) {
@@ -435,12 +419,8 @@ public class TfsShell implements Closeable {
     TachyonFile srcFd;
     try {
       srcFd = mTfs.open(srcPath);
-      if (srcFd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(srcPath));
-        return -1;
-      }
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
 
     Closer closer = Closer.create();
@@ -484,9 +464,6 @@ public class TfsShell implements Closeable {
     FileInfo fInfo;
     try {
       fd = mTfs.open(path);
-      if (fd == null) {
-        throw new IOException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-      }
       fInfo = mTfs.getInfo(fd);
     } catch (TachyonException e) {
       throw new IOException(e.getMessage());
@@ -502,7 +479,7 @@ public class TfsShell implements Closeable {
     try {
       files = mTfs.listStatus(fd);
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
     Collections.sort(files);
     for (FileInfo file : files) {
@@ -526,13 +503,9 @@ public class TfsShell implements Closeable {
     FileInfo fInfo;
     try {
       fd = mTfs.open(path);
-      if (fd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-        return -1;
-      }
       fInfo = mTfs.getInfo(fd);
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
 
     if (fInfo.isFolder) {
@@ -559,13 +532,9 @@ public class TfsShell implements Closeable {
     FileInfo fInfo;
     try {
       fd = mTfs.open(path);
-      if (fd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-        return -1;
-      }
       fInfo = mTfs.getInfo(fd);
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
 
     System.out.println(path + " with file id " + fd.getFileId() + " is on nodes: ");
@@ -582,9 +551,6 @@ public class TfsShell implements Closeable {
     List<FileInfo> files = null;
     try {
       TachyonFile fd = mTfs.open(path);
-      if (fd == null) {
-        throw new IOException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-      }
       files = mTfs.listStatus(fd);
     } catch (TachyonException e) {
       throw new IOException(e.getMessage());
@@ -735,10 +701,6 @@ public class TfsShell implements Closeable {
   public int pin(TachyonURI path) {
     try {
       TachyonFile fd = mTfs.open(path);
-      if (fd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-        return -1;
-      }
       SetStateOptions options = new SetStateOptions.Builder(mTachyonConf).setPinned(true).build();
       mTfs.setState(fd, options);
       System.out.println("File '" + path + "' was successfully pinned.");
@@ -899,10 +861,6 @@ public class TfsShell implements Closeable {
     TachyonURI dstPath = new TachyonURI(argv[2]);
     try {
       TachyonFile fd = mTfs.open(srcPath);
-      if (fd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(srcPath));
-        return -1;
-      }
       if (mTfs.rename(fd, dstPath)) {
         System.out.println("Renamed " + srcPath + " to " + dstPath);
         return 0;
@@ -918,10 +876,6 @@ public class TfsShell implements Closeable {
   public int report(TachyonURI path) throws IOException {
     try {
       TachyonFile fd = mTfs.open(path);
-      if (fd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-        return -1;
-      }
       mTfs.reportLostFile(fd);
       System.out
           .println(path + " with file id " + fd.getFileId() + " has reported been report lost.");
@@ -944,13 +898,9 @@ public class TfsShell implements Closeable {
     FileInfo fInfo;
     try {
       fd = mTfs.open(path);
-      if (fd == null) {
-        System.out.println("rm: cannot remove '" + path + "': No such file or directory");
-        return -1;
-      }
       fInfo = mTfs.getInfo(fd);
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
 
     if (fInfo.isFolder) {
@@ -965,7 +915,7 @@ public class TfsShell implements Closeable {
     } catch (IOException ioe) {
       return -1;
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
   }
 
@@ -980,10 +930,6 @@ public class TfsShell implements Closeable {
     try {
       DeleteOptions options = new DeleteOptions.Builder(mTachyonConf).setRecursive(true).build();
       TachyonFile fd = mTfs.open(path);
-      if (fd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-        return -1;
-      }
       mTfs.delete(fd, options);
       System.out.println(path + " has been removed");
       return 0;
@@ -1169,13 +1115,9 @@ public class TfsShell implements Closeable {
     FileInfo fInfo;
     try {
       fd = mTfs.open(path);
-      if (fd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-        return -1;
-      }
       fInfo = mTfs.getInfo(fd);
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
 
     if (!fInfo.isFolder) {
@@ -1198,7 +1140,7 @@ public class TfsShell implements Closeable {
         }
         return 0;
       } catch (TachyonException e) {
-        throw new IOException(e);
+        throw new IOException(e.getMessage());
       } finally {
         is.close();
       }
@@ -1238,10 +1180,6 @@ public class TfsShell implements Closeable {
     try {
       SetStateOptions options = new SetStateOptions.Builder(mTachyonConf).setPinned(false).build();
       TachyonFile fd = mTfs.open(path);
-      if (fd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-        return -1;
-      }
       mTfs.setState(fd, options);
       System.out.println("File '" + path + "' was successfully unpinned.");
       return 0;
@@ -1263,10 +1201,6 @@ public class TfsShell implements Closeable {
     try {
       FreeOptions options = new FreeOptions.Builder(mTachyonConf).setRecursive(true).build();
       TachyonFile fd = mTfs.open(path);
-      if (fd == null) {
-        System.out.println(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-        return -1;
-      }
       mTfs.free(fd, options);
       System.out.println(path + " was successfully freed from memory.");
       return 0;
@@ -1289,9 +1223,6 @@ public class TfsShell implements Closeable {
     List<FileInfo> files;
     try {
       TachyonFile inputFile = tachyonFS.open(path);
-      if (inputFile == null) {
-        throw new IOException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(path));
-      }
       files = tachyonFS.listStatus(inputFile);
     } catch (TachyonException e) {
       throw new IOException(e.getMessage());
@@ -1335,7 +1266,7 @@ public class TfsShell implements Closeable {
     try {
       lineageId = tl.createLineage(inputFiles, outputFiles, job);
     } catch (TachyonException e) {
-      throw new IOException(e);
+      throw new IOException(e.getMessage());
     }
     System.out.println("Lineage " + lineageId + " has been created.");
     return 0;

--- a/shell/src/main/java/tachyon/shell/TfsShellUtils.java
+++ b/shell/src/main/java/tachyon/shell/TfsShellUtils.java
@@ -128,9 +128,6 @@ public class TfsShellUtils {
     List<FileInfo> files = null;
     try {
       TachyonFile parentFile = tachyonClient.open(parentDir);
-      if (parentFile == null) {
-        throw new IOException(ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage(parentDir.getPath()));
-      }
       files = tachyonClient.listStatus(parentFile);
     } catch (TachyonException e) {
       throw new IOException(e);

--- a/shell/src/test/java/tachyon/shell/TfsShellTest.java
+++ b/shell/src/test/java/tachyon/shell/TfsShellTest.java
@@ -540,7 +540,7 @@ public class TfsShellTest {
   @Test
   public void rmNotExistingFileTest() throws IOException {
     mFsShell.run(new String[] {"rm", "/testFile"});
-    String expected = "rm: cannot remove '/testFile': No such file or directory\n";
+    String expected = ExceptionMessage.PATH_DOES_NOT_EXIST.getMessage("/testFile") + "\n";
     Assert.assertEquals(expected, mOutput.toString());
   }
 

--- a/shell/src/test/java/tachyon/shell/TfsShellUtilsTest.java
+++ b/shell/src/test/java/tachyon/shell/TfsShellUtilsTest.java
@@ -95,7 +95,7 @@ public class TfsShellUtilsTest {
      */
     TachyonFile fd;
     try {
-      fd = tfs.open(new TachyonURI("/testWildCards"));
+      fd = tfs.openIfExists(new TachyonURI("/testWildCards"));
     } catch (IOException ioe) {
       fd = null;
     }


### PR DESCRIPTION
Most people expect open to throw an exception if the path does not
exist, but currently it would returns null, so that people could use it
as an exists method.

Rather than have an exists method, which introduces atomicity
problems (the file could be deleted in between checking for existence
and opening), we added an openIfExists method, which has the same
behavior as the old open method. The new open method will throw an
exception if the path does not exist.