### PR TITLE
[SMALLFIX] Suppress warnings in FileUtilsTest

### DIFF
--- a/common/src/test/java/tachyon/util/io/FileUtilsTest.java
+++ b/common/src/test/java/tachyon/util/io/FileUtilsTest.java
@@ -52,6 +52,7 @@ public class FileUtilsTest {
     Assert.assertFalse(tempFile.canExecute());
     // expect a file permission error when we open it for writing
     mException.expect(IOException.class);
+    @SuppressWarnings({"unused", "resource"})
     FileWriter fw = new FileWriter(tempFile);
     Assert.fail("opening a read-only file for writing should have failed");
   }


### PR DESCRIPTION
"resource" is ok to suppress because the constructor is expected to fail
fw needs to be declared so that the @SuppressWarnings can be applied locally