### PR TITLE
[TACHYON-1082] Remove unused Tachyon parameters definition from Tachyon.Constants

### DIFF
--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -60,9 +60,6 @@ public final class Constants {
   public static final int DEFAULT_WORKER_DATA_PORT = DEFAULT_WORKER_PORT + 1;
   public static final int DEFAULT_WORKER_WEB_PORT = DEFAULT_WORKER_PORT + 2;
 
-  public static final int DEFAULT_MASTER_MAX_WORKER_THREADS = 2048;
-  public static final int DEFAULT_WORKER_MAX_WORKER_THREADS = 2048;
-
   public static final int DEFAULT_USER_FAILED_SPACE_REQUEST_LIMITS = 3;
 
   public static final int DEFAULT_BLOCK_SIZE_BYTE = 512 * MB;


### PR DESCRIPTION
Just remove constants:
DEFAULT_MASTER_MAX_WORKER_THREADS
DEFAULT_WORKER_MAX_WORKER_THREADS

https://tachyon.atlassian.net/browse/TACHYON-1082