### PR TITLE
[SMALLFIX] Replace make-distribution.sh with mvn to build spark

### DIFF
--- a/deploy/vagrant/provision/roles/spark/files/dist.sh
+++ b/deploy/vagrant/provision/roles/spark/files/dist.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-tar czf /tmp/spark.tar -C /spark/dist .
-rm -rf /spark/*
-tar xzf /tmp/spark.tar -C /spark
-rm -f /tmp/spark.tar

--- a/deploy/vagrant/provision/roles/spark/tasks/compile.yml
+++ b/deploy/vagrant/provision/roles/spark/tasks/compile.yml
@@ -7,15 +7,12 @@
     src=roles/ufs_{{ ufs }}/files/compile_spark.sh
     dest=/tmp/compile_spark.sh
 # need to use `shell`, `script` can not use `async`, then ssh will timeout
-- name: compile spark and make-distribution
+- name: compile spark 
   shell: bash /tmp/compile_spark.sh
   environment:
     HADOOP_VERSION: "{{ hadoop_version }}"
     SPARK_PROFILE: "{{ spark_profile }}"
   async: 18000
   poll: 60
-
-- name: replace /spark with /spark/dist
-  script: dist.sh
 
 # vim :set filetype=ansible.yaml:

--- a/deploy/vagrant/provision/roles/ufs_hadoop1/files/compile_spark.sh
+++ b/deploy/vagrant/provision/roles/ufs_hadoop1/files/compile_spark.sh
@@ -1,2 +1,2 @@
 cd /spark
-./make-distribution.sh -Dhadoop.version=${HADOOP_VERSION} >/spark/make-distribution.log 2>&1
+build/mvn clean install -Dmaven.javadoc.skip=true -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Phadoop-1 -Phive -Phive-thriftserver > compile.log 2>&1

--- a/deploy/vagrant/provision/roles/ufs_hadoop2/files/compile_spark.sh
+++ b/deploy/vagrant/provision/roles/ufs_hadoop2/files/compile_spark.sh
@@ -1,6 +1,2 @@
 cd /spark
-if [[ "$SPARK_PROFILE" == "" ]]; then
-  ./make-distribution.sh -Dhadoop.version=${HADOOP_VERSION} >/spark/make-distribution.log 2>&1
-else
-  ./make-distribution.sh -Phadoop-${SPARK_PROFILE} -Dhadoop.version=${HADOOP_VERSION} >/spark/make-distribution.log 2>&1
-fi
+build/mvn clean install -Dmaven.javadoc.skip=true -DskipTests -Dhadoop.version=${HADOOP_VERSION} -Phadoop-${SPARK_PROFILE} -Pyarn -Phive -Phive-thriftserver > compile.log 2>&1

--- a/deploy/vagrant/provision/roles/ufs_s3/files/compile_spark.sh
+++ b/deploy/vagrant/provision/roles/ufs_s3/files/compile_spark.sh
@@ -1,2 +1,2 @@
 cd /spark
-./make-distribution.sh >/spark/make-distribution.log 2>&1
+build/mvn clean install -Dmaven.javadoc.skip=true -DskipTests -Phive -Phive-thriftserver > compile.log 2>&1


### PR DESCRIPTION
I find that it is more developer friendly to use `mvn` instead of the wrapper script `make-distribution.sh` where some unnecessary logic happens except compilation. Directly use `mvn` will leave spark source code there, so once the cluster is setup, the user can still recompile spark, recompilation is needed in testing process by developers in our community.