### PR TITLE
[SMALLFIX] Fixing interval computation in SleepingTimer

### DIFF
--- a/common/src/main/java/tachyon/heartbeat/SleepingTimer.java
+++ b/common/src/main/java/tachyon/heartbeat/SleepingTimer.java
@@ -47,14 +47,13 @@ public final class SleepingTimer implements HeartbeatTimer {
    * @throws InterruptedException if the thread is interrupted while waiting
    */
   public void tick() throws InterruptedException {
-    long currentTickMs = System.currentTimeMillis();
-    long executionTimeMs = currentTickMs - mPreviousTickMs;
-    if (executionTimeMs > mIntervalMs) {
+    long executionTimeMs = System.currentTimeMillis() - mPreviousTickMs;
+    if (mPreviousTickMs != 0 && executionTimeMs > mIntervalMs) {
       LOG.warn(mThreadName + " last execution took " + executionTimeMs
           + " ms. Longer than the interval " + mIntervalMs);
     } else {
       Thread.sleep(mIntervalMs - executionTimeMs);
     }
-    mPreviousTickMs = currentTickMs;
+    mPreviousTickMs = System.currentTimeMillis();
   }
 }

--- a/common/src/main/java/tachyon/heartbeat/SleepingTimer.java
+++ b/common/src/main/java/tachyon/heartbeat/SleepingTimer.java
@@ -47,12 +47,16 @@ public final class SleepingTimer implements HeartbeatTimer {
    * @throws InterruptedException if the thread is interrupted while waiting
    */
   public void tick() throws InterruptedException {
-    long executionTimeMs = System.currentTimeMillis() - mPreviousTickMs;
-    if (mPreviousTickMs != 0 && executionTimeMs > mIntervalMs) {
-      LOG.warn(mThreadName + " last execution took " + executionTimeMs
-          + " ms. Longer than the interval " + mIntervalMs);
+    if (mPreviousTickMs == 0) {
+      Thread.sleep(mIntervalMs);
     } else {
-      Thread.sleep(mIntervalMs - executionTimeMs);
+      long executionTimeMs = System.currentTimeMillis() - mPreviousTickMs;
+      if (executionTimeMs > mIntervalMs) {
+        LOG.warn(mThreadName + " last execution took " + executionTimeMs
+            + " ms. Longer than the interval " + mIntervalMs);
+      } else {
+        Thread.sleep(mIntervalMs - executionTimeMs);
+      }
     }
     mPreviousTickMs = System.currentTimeMillis();
   }


### PR DESCRIPTION
This PR gets rid of the spurious "... last execution took XXX ms. Longer than the interval YYY." log messages.