### PR TITLE
[SMALLFIX] make s3 underfs available for proxy-based access

### DIFF
--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -291,6 +291,9 @@ public final class Constants {
 
   public static final String S3_ACCESS_KEY = "fs.s3n.awsAccessKeyId";
   public static final String S3_SECRET_KEY = "fs.s3n.awsSecretAccessKey";
+  public static final String S3_PROXY_HOST = "fs.s3n.proxy-host";
+  public static final String S3_PROXY_PORT = "fs.s3n.proxy-port";
+  public static final String S3_PROTOCOL = "fs.s3n.protocol";
 
   public static final String MASTER_COLUMN_FILE_PREFIX = "COL_";
 

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -20,10 +20,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jets3t.service.Jets3tProperties;
 import org.jets3t.service.S3Service;
 import org.jets3t.service.ServiceException;
 import org.jets3t.service.impl.rest.httpclient.RestS3Service;
@@ -59,6 +62,16 @@ public class S3UnderFileSystem extends UnderFileSystem {
   /** Prefix of the bucket, for example s3n://my-bucket-name/ */
   private final String mBucketPrefix;
 
+  private static final byte[] DIR_HASH;
+
+  static {
+    try {
+      DIR_HASH = MessageDigest.getInstance("MD5").digest(new byte[0]);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
   public S3UnderFileSystem(String bucketName, TachyonConf tachyonConf) throws ServiceException {
     super(tachyonConf);
     Preconditions.checkArgument(tachyonConf.containsKey(Constants.S3_ACCESS_KEY),
@@ -69,7 +82,19 @@ public class S3UnderFileSystem extends UnderFileSystem {
         new AWSCredentials(tachyonConf.get(Constants.S3_ACCESS_KEY), tachyonConf.get(
             Constants.S3_SECRET_KEY));
     mBucketName = bucketName;
-    mClient = new RestS3Service(awsCredentials);
+
+    Jets3tProperties props = new Jets3tProperties();
+    if (tachyonConf.containsKey(Constants.S3_PROXY_HOST)) {
+      props.setProperty("httpclient.proxy-autodetect", "false");
+      props.setProperty("httpclient.proxy-host", tachyonConf.get(Constants.S3_PROXY_HOST));
+      props.setProperty("httpclient.proxy-port", tachyonConf.get(Constants.S3_PROXY_PORT));
+    }
+    if (tachyonConf.containsKey(Constants.S3_PROTOCOL)) {
+      props.setProperty("s3service.https-only", tachyonConf.get(Constants.S3_PROTOCOL)
+          .equalsIgnoreCase("http") ? "false" : "true");
+    }
+    System.err.println(props.getProperties());
+    mClient = new RestS3Service(awsCredentials, null, null, props);
     mBucketPrefix = Constants.HEADER_S3N + mBucketName + PATH_SEPARATOR;
   }
 
@@ -487,6 +512,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
       S3Object obj = new S3Object(keyAsFolder);
       obj.setDataInputStream(new ByteArrayInputStream(new byte[0]));
       obj.setContentLength(0);
+      obj.setMd5Hash(DIR_HASH);
       obj.setContentType(Mimetypes.MIMETYPE_BINARY_OCTET_STREAM);
       mClient.putObject(mBucketName, obj);
       return true;


### PR DESCRIPTION
Additional configurations for the S3UnderFileSystem which enable to use the proxy while access s3.

This modification makes it possible to adopt some other s3-compatible storage as the underfs.

btw, I append MD5 to put request while creating the dir.