### PR TITLE
[TACHYON-1143] fix cache remote blocks

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/file/FileInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/FileInStream.java
@@ -222,8 +222,8 @@ public final class FileInStream extends InputStream implements BoundedStream, Se
   private void checkAndAdvanceBlockInStream() throws IOException {
     long currentBlockId = getCurrentBlockId();
     if (mCurrentBlockInStream == null || mCurrentBlockInStream.remaining() == 0) {
-      updateBlockInStream(currentBlockId);
       closeCacheStream();
+      updateBlockInStream(currentBlockId);
       if (mShouldCacheCurrentBlock) {
         try {
           // TODO(calvin): Specify the location to be local.


### PR DESCRIPTION
[TACHYON-1143](https://tachyon.atlassian.net/browse/TACHYON-1143)
When reading files in remote workers with *STORE* `TachyonStorageType`, clients only cache the first block in the files and fail to cache other blocks to local.