### PR TITLE
[TACHYON-1145] Fix concurrent modification error in LRUEvictor#mLRUCache.keyset().iterator

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/evictor/LRUEvictor.java
+++ b/servers/src/main/java/tachyon/worker/block/evictor/LRUEvictor.java
@@ -87,7 +87,7 @@ public class LRUEvictor extends EvictorBase {
   public void onRemoveBlockByWorker(long sessionId, long blockId) {
     mLRUCache.remove(blockId);
   }
-  
+
   @Override
   protected void onRemoveBlockFromIterator(long blockId) {
     mLRUCache.remove(blockId);

--- a/servers/src/main/java/tachyon/worker/block/evictor/LRUEvictor.java
+++ b/servers/src/main/java/tachyon/worker/block/evictor/LRUEvictor.java
@@ -15,9 +15,11 @@
 
 package tachyon.worker.block.evictor;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import tachyon.worker.block.BlockMetadataManagerView;
@@ -61,7 +63,8 @@ public class LRUEvictor extends EvictorBase {
 
   @Override
   protected Iterator<Long> getBlockIterator() {
-    return mLRUCache.keySet().iterator();
+    List<Long> blocks = new ArrayList(mLRUCache.keySet());
+    return blocks.iterator();
   }
 
   @Override
@@ -82,6 +85,11 @@ public class LRUEvictor extends EvictorBase {
 
   @Override
   public void onRemoveBlockByWorker(long sessionId, long blockId) {
+    mLRUCache.remove(blockId);
+  }
+  
+  @Override
+  protected void onRemoveBlockFromIterator(long blockId) {
     mLRUCache.remove(blockId);
   }
 }


### PR DESCRIPTION
[TACHYON-1145](https://tachyon.atlassian.net/browse/TACHYON-1145)
When we run hive SQL (aggregation, join and scan) on Tachyon (2G MEM x 9 nodes + 30GHDD x 9 nodes), write data about 20GB on each Tachyon worker, The **EvictorBase.java** often shows "`java.util.ConcurrentModificationException`" error when access the next entry of *mLRUCache.keyset().iterator()*