### PR TITLE
[SMALLFIX] Remove tachyon-underfs-s3 exclusion from spark when ufs is s3

### DIFF
--- a/deploy/vagrant/provision/roles/spark/files/remove_s3_exclusion.sh
+++ b/deploy/vagrant/provision/roles/spark/files/remove_s3_exclusion.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+python <<EOF
+import re
+
+PATTERN = r'''<exclusion>
+\s*<groupId>org\.tachyonproject</groupId>
+\s*<artifactId>tachyon-underfs-s3</artifactId>
+\s*</exclusion>'''
+POM = '/spark/core/pom.xml'
+
+new_pom = re.compile(PATTERN).sub('', open(POM).read())
+open(POM, 'w').write(new_pom)
+EOF

--- a/deploy/vagrant/provision/roles/spark/tasks/compile.yml
+++ b/deploy/vagrant/provision/roles/spark/tasks/compile.yml
@@ -3,6 +3,10 @@
 - name: set current tachyon version in spark/core/pom.xml
   script: set_tachyon_version.sh
 
+- name: remove dependency exclusion of tachyon-underfs-s3
+  script: remove_s3_exclusion.sh
+  when: ufs == "s3"
+
 - copy: >
     src=roles/ufs_{{ ufs }}/files/compile_spark.sh
     dest=/tmp/compile_spark.sh


### PR DESCRIPTION
From tachyon 0.8, after removing exclusion of tachyon-underfs-s3 from spark core/pom.xml and recompiling spark against tachyon, spark + tachyon + s3 should work out of box.