### PR TITLE
[TACHYON-1132] Fix resolved path usage

### DIFF
--- a/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
@@ -255,7 +255,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
       currentInodeDirectory.addChild(dir);
       currentInodeDirectory.setLastModificationTimeMs(options.getOperationTimeMs());
       if (options.isPersisted()) {
-        String ufsPath = mMountTable.resolve(getPath(dir)).getPath();
+        String ufsPath = mMountTable.resolve(getPath(dir)).toString();
         UnderFileSystem ufs = UnderFileSystem.get(ufsPath, MasterContext.getConf());
         ufs.mkdirs(ufsPath, false);
       }
@@ -282,7 +282,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
               .setParentId(currentInodeDirectory.getId()).setPersisted(options.isPersisted())
               .build();
       if (options.isPersisted()) {
-        String ufsPath = mMountTable.resolve(getPath(lastInode)).getPath();
+        String ufsPath = mMountTable.resolve(getPath(lastInode)).toString();
         UnderFileSystem ufs = UnderFileSystem.get(ufsPath, MasterContext.getConf());
         ufs.mkdirs(ufsPath, false);
       }
@@ -545,7 +545,7 @@ public final class InodeTree implements JournalCheckpointStreamable {
         if (persist && !next.isPersisted()) {
           next.setPersisted(true);
           persisted.add(next);
-          String ufsPath = mMountTable.resolve(getPath(next)).getPath();
+          String ufsPath = mMountTable.resolve(getPath(next)).toString();
           UnderFileSystem ufs = UnderFileSystem.get(ufsPath, MasterContext.getConf());
           ufs.mkdirs(ufsPath, false);
         }


### PR DESCRIPTION
Using getPath strips the scheme/authority which is required.