### PR TITLE
[SMALLFIX] Fix syntax error in bin/tachyon.

### DIFF
--- a/bin/tachyon
+++ b/bin/tachyon
@@ -196,8 +196,8 @@ PARAMETER=""
 if [[ ${COMMAND} == "format" ]]; then
   if [[ $# -eq 1 ]]; then
     if [[ $1 == "-s" ]]; then
-      if [[ -e ${TACHYON_UNDERFS_ADDRESS} ]]
-        # if ufs is local filesystem and already exists 
+      if [[ -e ${TACHYON_UNDERFS_ADDRESS} ]]; then
+        # if ufs is local filesystem and already exists
         exit 0
       else
         declare -a schemes=(hdfs s3 s3n glusterfs swift)


### PR DESCRIPTION
Was missing a `; then`