### PR TITLE
[SMALLFIX] Remove all unused imports from the Tachyon codebase

### DIFF
--- a/build/checkstyle/tachyon_checks.xml
+++ b/build/checkstyle/tachyon_checks.xml
@@ -68,6 +68,9 @@
       <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
     <module name="AvoidStarImport"/>
+    <module name="UnusedImports">
+        <property name="processJavadoc" value="true"/>
+    </module>
     <module name="OneTopLevelClass"/>
     <module name="NoLineWrap"/>
     <module name="EmptyBlock">

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFS.java
@@ -38,7 +38,6 @@ import tachyon.client.block.BlockStoreContext;
 import tachyon.client.file.FileSystemContext;
 import tachyon.client.file.options.CreateOptions;
 import tachyon.client.file.options.MkdirOptions;
-import tachyon.client.table.RawColumn;
 import tachyon.client.table.RawTable;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.ExceptionMessage;

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFSTestUtils.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFSTestUtils.java
@@ -25,9 +25,8 @@ import tachyon.client.file.TachyonFile;
 import tachyon.client.file.TachyonFileSystem;
 import tachyon.client.file.options.InStreamOptions;
 import tachyon.client.file.options.OutStreamOptions;
-import tachyon.conf.TachyonConf;
-import tachyon.exception.TachyonException;
 import tachyon.exception.ExceptionMessage;
+import tachyon.exception.TachyonException;
 import tachyon.thrift.FileInfo;
 
 public final class TachyonFSTestUtils {

--- a/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
+++ b/clients/unshaded/src/main/java/tachyon/client/TachyonFile.java
@@ -32,7 +32,6 @@ import tachyon.client.file.TachyonFileSystem.TachyonFileSystemFactory;
 import tachyon.client.file.options.InStreamOptions;
 import tachyon.client.file.options.OutStreamOptions;
 import tachyon.conf.TachyonConf;
-import tachyon.exception.ExceptionMessage;
 import tachyon.exception.TachyonException;
 import tachyon.thrift.BlockLocation;
 import tachyon.thrift.FileBlockInfo;

--- a/clients/unshaded/src/main/java/tachyon/client/block/BlockStoreContext.java
+++ b/clients/unshaded/src/main/java/tachyon/client/block/BlockStoreContext.java
@@ -17,8 +17,6 @@ package tachyon.client.block;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -27,7 +25,6 @@ import tachyon.client.BlockMasterClient;
 import tachyon.client.ClientContext;
 import tachyon.thrift.NetAddress;
 import tachyon.thrift.WorkerInfo;
-import tachyon.util.ThreadFactoryUtils;
 import tachyon.util.network.NetworkAddressUtils;
 import tachyon.worker.ClientMetrics;
 import tachyon.worker.WorkerClient;

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystemUtils.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystemUtils.java
@@ -27,7 +27,6 @@ import tachyon.client.ClientContext;
 import tachyon.client.file.options.GetInfoOptions;
 import tachyon.client.file.options.OpenOptions;
 import tachyon.exception.TachyonException;
-import tachyon.exception.TachyonExceptionType;
 import tachyon.util.CommonUtils;
 
 /**

--- a/examples/src/main/java/tachyon/examples/BasicCheckpoint.java
+++ b/examples/src/main/java/tachyon/examples/BasicCheckpoint.java
@@ -30,7 +30,6 @@ import tachyon.client.file.FileInStream;
 import tachyon.client.file.TachyonFile;
 import tachyon.client.file.TachyonFileSystem;
 import tachyon.client.file.TachyonFileSystem.TachyonFileSystemFactory;
-import tachyon.client.file.options.OutStreamOptions;
 import tachyon.exception.TachyonException;
 import tachyon.thrift.FileInfo;
 

--- a/integration-tests/src/test/java/tachyon/master/file/FileSystemMasterIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/file/FileSystemMasterIntegrationTest.java
@@ -24,11 +24,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.apache.zookeeper.Op;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;

--- a/integration-tests/src/test/java/tachyon/master/rawtable/RawTableMasterIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/rawtable/RawTableMasterIntegrationTest.java
@@ -26,11 +26,7 @@ import org.junit.rules.ExpectedException;
 import tachyon.Constants;
 import tachyon.TachyonURI;
 import tachyon.conf.TachyonConf;
-import tachyon.exception.FileAlreadyExistsException;
-import tachyon.exception.FileDoesNotExistException;
-import tachyon.exception.InvalidPathException;
 import tachyon.exception.TableColumnException;
-import tachyon.exception.TableMetadataException;
 import tachyon.master.LocalTachyonCluster;
 import tachyon.master.file.FileSystemMaster;
 

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
@@ -25,7 +25,6 @@ import com.google.common.base.Joiner;
 import tachyon.Constants;
 import tachyon.client.ClientContext;
 import tachyon.client.TachyonFS;
-import tachyon.client.WriteType;
 import tachyon.client.file.TachyonFileSystem;
 import tachyon.conf.TachyonConf;
 import tachyon.thrift.NetAddress;

--- a/servers/src/main/java/tachyon/master/file/meta/InodeFile.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeFile.java
@@ -27,7 +27,6 @@ import tachyon.master.block.BlockId;
 import tachyon.master.file.journal.InodeFileEntry;
 import tachyon.master.journal.JournalEntry;
 import tachyon.thrift.FileInfo;
-import tachyon.util.IdUtils;
 
 /**
  * Tachyon file system's file representation in the file system master.

--- a/servers/src/main/java/tachyon/web/WebInterfaceMemoryServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceMemoryServlet.java
@@ -29,7 +29,6 @@ import com.google.common.base.Preconditions;
 
 import tachyon.TachyonURI;
 import tachyon.exception.FileDoesNotExistException;
-import tachyon.exception.InvalidPathException;
 import tachyon.master.TachyonMaster;
 import tachyon.thrift.FileInfo;
 

--- a/servers/src/main/java/tachyon/web/WebInterfaceWorkersServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceWorkersServlet.java
@@ -26,8 +26,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.google.common.collect.Ordering;
-
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.master.block.BlockMaster;

--- a/servers/src/test/java/tachyon/master/block/BlockMasterTest.java
+++ b/servers/src/test/java/tachyon/master/block/BlockMasterTest.java
@@ -29,7 +29,6 @@ import org.junit.rules.TemporaryFolder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 

--- a/shell/src/main/java/tachyon/shell/TfsShellUtils.java
+++ b/shell/src/main/java/tachyon/shell/TfsShellUtils.java
@@ -28,7 +28,6 @@ import tachyon.TachyonURI;
 import tachyon.client.file.TachyonFile;
 import tachyon.client.file.TachyonFileSystem;
 import tachyon.conf.TachyonConf;
-import tachyon.exception.ExceptionMessage;
 import tachyon.exception.TachyonException;
 import tachyon.thrift.FileInfo;
 import tachyon.util.io.PathUtils;


### PR DESCRIPTION
...except unused imports in autogenerated Thrift files until
the fix to THRIFT-2794 happens in the next version of Thrift.