### PR TITLE
[TACHYON-1149] Create the parent folder in underFS for a file if it does not exist

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/file/FileOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/FileOutStream.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 
 import tachyon.Constants;
+import tachyon.TachyonURI;
 import tachyon.annotation.PublicApi;
 import tachyon.client.Cancelable;
 import tachyon.client.ClientContext;
@@ -95,6 +96,10 @@ public class FileOutStream extends OutputStream implements Cancelable {
       mUfsPath = fileInfo.getUfsPath();
       String fileName = PathUtils.temporaryFileName(fileId, mNonce, mUfsPath);
       UnderFileSystem ufs = UnderFileSystem.get(fileName, ClientContext.getConf());
+      String parentPath = (new TachyonURI(mUfsPath)).getParent().getPath();
+      if (!ufs.exists(parentPath) && !ufs.mkdirs(parentPath, true)) {
+        throw new IOException("Failed to create " + parentPath);
+      }
       // TODO(jiri): Implement collection of temporary files left behind by dead clients.
       mUnderStorageOutputStream = ufs.create(fileName, (int) mBlockSize);
     } else {


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1149

This is a hot fix. Will have a unit test in a follow-up PR.