### PR TITLE
[SMALLFIX] Fix generics in Inode.Builder and subclasses

### DIFF
--- a/servers/src/main/java/tachyon/master/file/meta/Inode.java
+++ b/servers/src/main/java/tachyon/master/file/meta/Inode.java
@@ -22,7 +22,7 @@ import tachyon.thrift.FileInfo;
  * <code>Inode</code> is an abstract class, with information shared by all types of Inodes.
  */
 public abstract class Inode implements JournalEntryRepresentable {
-  public abstract static class Builder<T> {
+  public abstract static class Builder<T extends Builder<T>> {
     private long mCreationTimeMs;
     protected boolean mDirectory;
     protected long mId;
@@ -40,27 +40,27 @@ public abstract class Inode implements JournalEntryRepresentable {
 
     public T setCreationTimeMs(long creationTimeMs) {
       mCreationTimeMs = creationTimeMs;
-      return (T) this;
+      return getThis();
     }
 
     public T setId(long id) {
       mId = id;
-      return (T) this;
+      return getThis();
     }
 
     public T setName(String name) {
       mName = name;
-      return (T) this;
+      return getThis();
     }
 
     public T setParentId(long parentId) {
       mParentId = parentId;
-      return (T) this;
+      return getThis();
     }
 
     public T setPersisted(boolean persisted) {
       mPersisted = persisted;
-      return (T) this;
+      return getThis();
     }
 
     /**
@@ -69,6 +69,11 @@ public abstract class Inode implements JournalEntryRepresentable {
      * @return a {@link Inode} instance
      */
     public abstract Inode build();
+
+    /**
+     * Returns `this` so that the abstract class can use the fluent builder pattern.
+     */
+    protected abstract T getThis();
   }
 
   private final long mCreationTimeMs;
@@ -96,7 +101,7 @@ public abstract class Inode implements JournalEntryRepresentable {
    */
   private boolean mDeleted = false;
 
-  protected Inode(Builder builder) {
+  protected Inode(Builder<?> builder) {
     mCreationTimeMs = builder.mCreationTimeMs;
     mDirectory = builder.mDirectory;
     mLastModificationTimeMs = builder.mCreationTimeMs;

--- a/servers/src/main/java/tachyon/master/file/meta/InodeDirectory.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeDirectory.java
@@ -42,8 +42,14 @@ public final class InodeDirectory extends Inode {
      *
      * @return a {@link InodeDirectory} instance
      */
+    @Override
     public InodeDirectory build() {
       return new InodeDirectory(this);
+    }
+
+    @Override
+    protected Builder getThis() {
+      return this;
     }
   }
 

--- a/servers/src/main/java/tachyon/master/file/meta/InodeFile.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeFile.java
@@ -27,7 +27,6 @@ import tachyon.master.block.BlockId;
 import tachyon.master.file.journal.InodeFileEntry;
 import tachyon.master.journal.JournalEntry;
 import tachyon.thrift.FileInfo;
-import tachyon.util.IdUtils;
 
 /**
  * Tachyon file system's file representation in the file system master.
@@ -71,8 +70,14 @@ public final class InodeFile extends Inode {
      *
      * @return a {@link InodeFile} instance
      */
+    @Override
     public InodeFile build() {
       return new InodeFile(this);
+    }
+
+    @Override
+    protected InodeFile.Builder getThis() {
+      return this;
     }
   }
 


### PR DESCRIPTION
Previously all of the (T) casts were considered unsafe by Java, and Builder was a raw type.

Credit for proper abstract fluent builder generics goes to http://stackoverflow.com/questions/5818504/can-i-have-an-abstract-builder-class-in-java-with-method-chaining-without-doing