### PR TITLE
[SMALLFIX] Avoid or suppress vararg generic warnings

### DIFF
--- a/common/src/main/java/tachyon/collections/IndexedSet.java
+++ b/common/src/main/java/tachyon/collections/IndexedSet.java
@@ -16,6 +16,7 @@
 package tachyon.collections;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -195,7 +196,7 @@ public class IndexedSet<T> implements Iterable<T> {
               throw new IllegalStateException("Indexed Set is in an illegal state");
             }
           } else {
-            fieldValueToSet.put(fieldValue, Sets.newHashSet(objToAdd));
+            fieldValueToSet.put(fieldValue, Sets.newHashSet(Collections.singleton(objToAdd)));
           }
         }
       }

--- a/common/src/test/java/tachyon/collections/IndexedSetTest.java
+++ b/common/src/test/java/tachyon/collections/IndexedSetTest.java
@@ -60,7 +60,10 @@ public class IndexedSetTest {
         return o.longValue();
       }
     };
-    mSet = new IndexedSet<Pair>(mIntIndex, mLongIndex);
+    // This warning cannot be avoided when passing generics into varargs
+    @SuppressWarnings("unchecked")
+    IndexedSet<Pair> set = new IndexedSet<Pair>(mIntIndex, mLongIndex);
+    mSet = set;
     for (int i = 0; i < 3; i ++) {
       for (long l = 0; l < 3; l ++) {
         mSet.add(new Pair(i, l));

--- a/servers/src/main/java/tachyon/master/block/BlockMaster.java
+++ b/servers/src/main/java/tachyon/master/block/BlockMaster.java
@@ -121,6 +121,8 @@ public final class BlockMaster extends MasterBase
    * Keeps track of workers which are no longer in communication with the master. Access must be
    * synchronized on mWorkers.
    */
+  // This warning cannot be avoided when passing generics into varargs
+  @SuppressWarnings("unchecked")
   private final IndexedSet<MasterWorkerInfo> mLostWorkers =
       new IndexedSet<MasterWorkerInfo>(mIdIndex, mAddressIndex);
   /** The service that detects lost worker nodes, and tries to restart the failed workers. */

--- a/servers/src/main/java/tachyon/master/rawtable/meta/RawTables.java
+++ b/servers/src/main/java/tachyon/master/rawtable/meta/RawTables.java
@@ -36,6 +36,8 @@ public class RawTables implements JournalCheckpointStreamable {
     }
   };
   /** A set of TableInfo indexed by table id */
+  // This warning cannot be avoided when passing generics into varargs
+  @SuppressWarnings("unchecked")
   private final IndexedSet<RawTable> mTables = new IndexedSet<RawTable>(mIdIndex);
 
   /**


### PR DESCRIPTION
Generics can't be safely passed into varargs because varargs creates an array of the generic type, and Java doesn't support generic arrays.

http://www.angelikalanger.com/GenericsFAQ/FAQSections/ProgrammingIdioms.html#FAQ300