### PR TITLE
[SMALLFIX] Fix format of configuration page in docs for easier read 

### DIFF
--- a/docs/Command-Line-Interface.md
+++ b/docs/Command-Line-Interface.md
@@ -22,7 +22,7 @@ Or, if no header is provided, the default hostname and port (set in the env file
 
 # List of Operations
 
-<table class="table">
+<table class="table table-striped">
   <tr><th>Operation</th><th>Syntax</th><th>Description</th></tr>
   <tr>
     <td>cat</td>

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -72,7 +72,7 @@ The common configuration contains constants shared by different components.
   in the `conf` directory.</td>
 </tr>
 <tr>
-  <td>tachyon.network.host.resolution.timeout.ms</td>
+  <td><div>tachyon.network.host.resolution.</div><div>timeout.ms</div></td>
   <td>5000</td>
   <td>During startup of the Master and Worker processes Tachyon needs to ensure that they are
     listening on externally resolvable and reachable host names.  To do this, Tachyon will
@@ -92,11 +92,11 @@ The common configuration contains constants shared by different components.
 </tr>
 <tr>
   <td>tachyon.underfs.glusterfs.impl</td>
-  <td>org.apache.hadoop.fs.glusterfs.GlusterFileSystem</td>
+  <td><div>org.apache.hadoop.fs.glusterfs.</div><div>GlusterFileSystem</div></td>
   <td>Glusterfs hook with hadoop.</td>
 </tr>
 <tr>
-  <td>tachyon.underfs.glusterfs.mapred.system.dir</td>
+  <td><div>tachyon.underfs.glusterfs.mapred.</div><div>system.dir</div></td>
   <td>glusterfs:///mapred/system</td>
   <td>Optionally, specify subdirectory under GlusterFS for intermediary MapReduce data.</td>
 </tr>
@@ -107,7 +107,7 @@ The common configuration contains constants shared by different components.
 </tr>
 <tr>
   <td>tachyon.underfs.hdfs.impl</td>
-  <td>org.apache.hadoop.hdfs.DistributedFileSystem</td>
+  <td><div>org.apache.hadoop.hdfs.</div></div>DistributedFileSystem</div></td>
   <td>The implementation class of the HDFS as the under storage system.</td>
 </tr>
 <tr>
@@ -194,7 +194,7 @@ the port number.
 </tr>
 <tr>
   <td>tachyon.master.journal.formatter.class</td>
-  <td>tachyon.master.journal.JsonJournalFormatter</td>
+  <td><div>tachyon.master.journal.</div><div>JsonJournalFormatter</div></td>
   <td>The class to serialize the journal in a specified format.</td>
 </tr>
 <tr>
@@ -203,7 +203,7 @@ the port number.
   <td>If a log file is bigger than this value, it will rotate to next file</td>
 </tr>
 <tr>
-  <td>tachyon.master.journal.tailer.shutdown.quiet.wait.time.ms</td>
+  <td><div>tachyon.master.journal.tailer.</div><div>shutdown.quiet.wait.time.ms</div></td>
   <td>5000</td>
   <td>Before the standby master shuts down its tailer thread, there should be no update to the
     leader master's journal in this specified time period (in milliseconds).</td>
@@ -223,7 +223,7 @@ the port number.
 </tr>
 <tr>
   <td>tachyon.master.lineage.checkpoint.class</td>
-  <td>tachyon.master.lineage.checkpoint.CheckpointLatestScheduler</td>
+  <td><div>tachyon.master.lineage.checkpoint.</div><div>CheckpointLatestScheduler</div></td>
   <td>
   The class name of the checkpoint strategy for lineage output files. The default strategy is to
   checkpoint the latest completed lineage, i.e. the lineage whose output files are completed.
@@ -303,7 +303,7 @@ the port number.
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td>tachyon.worker.allocator.class</td>
-  <td>tachyon.worker.block.allocator.MaxFreeAllocator</td>
+  <td><div>tachyon.worker.block.allocator.</div><div>MaxFreeAllocator</div></td>
   <td>The strategy that a worker uses to allocate space among storage directories in certain storage
   layer. Valid options include: `tachyon.worker.block.allocator.MaxFreeAllocator`,
   `tachyon.worker.block.allocator.GreedyAllocator`,
@@ -351,13 +351,13 @@ the port number.
   <td>The port Tachyon's worker's data server runs on.</td>
 </tr>
 <tr> <td>tachyon.worker.data.server.class</td>
-  <td>tachyon.worker.netty.NettyDataServer</td>
+  <td><div>tachyon.worker.netty.</div><div>NettyDataServer</div></td>
   <td>Selects the networking stack to run the worker with. Valid options are:
   `tachyon.worker.netty.NettyDataServer`, `tachyon.worker.nio.NIODataServer`.</td>
 </tr>
 <tr>
   <td>tachyon.worker.evictor.class</td>
-  <td>tachyon.worker.block.evictor.LRUEvictor</td>
+  <td><div>tachyon.worker.block.</div><div>evictor.LRUEvictor</div></td>
   <td>The strategy that a worker uses to evict block files when a storage layer runs out of space. Valid
   options include `tachyon.worker.block.evictor.LRFUEvictor`,
   `tachyon.worker.block.evictor.GreedyEvictor`, `tachyon.worker.block.evictor.LRUEvictor`.</td>
@@ -525,14 +525,14 @@ The user configuration specifies values regarding file system access.
 </tr>
 <tr>
   <td>tachyon.user.block.remote.reader.class</td>
-  <td>tachyon.client.netty.NettyRemoteBlockReader</td>
+  <td><div>tachyon.client.netty.</div><div>NettyRemoteBlockReader</div></td>
   <td>Selects networking stack to run the client with. Valid options are
     `tachyon.client.netty.NettyRemoteBlockReader` (read remote data using netty) and
     [DEPRECATED] `tachyon.client.tcp.TCPRemoteBlockReader`</td>
 </tr>
 <tr>
   <td>tachyon.user.block.remote.writer.class</td>
-  <td>tachyon.client.netty.NettyRemoteBlockWriter</td>
+  <td><div>tachyon.client.netty.</div><div>NettyRemoteBlockWriter</div></td>
   <td>Selects networking stack to run the client with for block writes.</td>
 </tr>
 <tr>

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -38,7 +38,7 @@ All Tachyon configuration properties fall into one of the four categories:
 
 The common configuration contains constants shared by different components.
 
-<table class="table">
+<table class="table table-striped">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td>tachyon.debug</td>
@@ -163,7 +163,7 @@ The common configuration contains constants shared by different components.
 The master configuration specifies information regarding the master node, such as the address and
 the port number.
 
-<table class="table">
+<table class="table table-striped">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td>tachyon.master.bind.host</td>
@@ -299,7 +299,7 @@ the port number.
 The worker configuration specifies information regarding the worker nodes, such as the address and
 the port number.
 
-<table class="table">
+<table class="table table-striped">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td>tachyon.worker.allocator.class</td>
@@ -506,7 +506,7 @@ the port number.
 
 The user configuration specifies values regarding file system access.
 
-<table class="table">
+<table class="table table-striped">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td>tachyon.user.block.master.client.threads</td>
@@ -623,7 +623,7 @@ The user configuration specifies values regarding file system access.
 When running Tachyon with cluster managers like Mesos and YARN, Tachyon has additional
 configuration options.
 
-<table class="table">
+<table class="table table-striped">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td>tachyon.integration.master.resource.cpu</td>

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -72,7 +72,7 @@ The common configuration contains constants shared by different components.
   in the `conf` directory.</td>
 </tr>
 <tr>
-  <td><div>tachyon.network.host.resolution.</div><div>timeout.ms</div></td>
+  <td>tachyon.network.host.resolution.&#8203;timeout.ms</td>
   <td>5000</td>
   <td>During startup of the Master and Worker processes Tachyon needs to ensure that they are
     listening on externally resolvable and reachable host names.  To do this, Tachyon will
@@ -92,11 +92,11 @@ The common configuration contains constants shared by different components.
 </tr>
 <tr>
   <td>tachyon.underfs.glusterfs.impl</td>
-  <td><div>org.apache.hadoop.fs.glusterfs.</div><div>GlusterFileSystem</div></td>
+  <td>org.apache.hadoop.fs.glusterfs.&#8203;GlusterFileSystem</td>
   <td>Glusterfs hook with hadoop.</td>
 </tr>
 <tr>
-  <td><div>tachyon.underfs.glusterfs.mapred.</div><div>system.dir</div></td>
+  <td>tachyon.underfs.glusterfs.mapred.&#8203;system.dir</td>
   <td>glusterfs:///mapred/system</td>
   <td>Optionally, specify subdirectory under GlusterFS for intermediary MapReduce data.</td>
 </tr>
@@ -107,7 +107,7 @@ The common configuration contains constants shared by different components.
 </tr>
 <tr>
   <td>tachyon.underfs.hdfs.impl</td>
-  <td><div>org.apache.hadoop.hdfs.</div></div>DistributedFileSystem</div></td>
+  <td>org.apache.hadoop.hdfs.&#8203;DistributedFileSystem</td>
   <td>The implementation class of the HDFS as the under storage system.</td>
 </tr>
 <tr>
@@ -194,7 +194,7 @@ the port number.
 </tr>
 <tr>
   <td>tachyon.master.journal.formatter.class</td>
-  <td><div>tachyon.master.journal.</div><div>JsonJournalFormatter</div></td>
+  <td>tachyon.master.journal.&#8203;JsonJournalFormatter</td>
   <td>The class to serialize the journal in a specified format.</td>
 </tr>
 <tr>
@@ -203,7 +203,7 @@ the port number.
   <td>If a log file is bigger than this value, it will rotate to next file</td>
 </tr>
 <tr>
-  <td><div>tachyon.master.journal.tailer.</div><div>shutdown.quiet.wait.time.ms</div></td>
+  <td>tachyon.master.journal.tailer.&#8203;shutdown.quiet.wait.time.ms</td>
   <td>5000</td>
   <td>Before the standby master shuts down its tailer thread, there should be no update to the
     leader master's journal in this specified time period (in milliseconds).</td>
@@ -223,7 +223,7 @@ the port number.
 </tr>
 <tr>
   <td>tachyon.master.lineage.checkpoint.class</td>
-  <td><div>tachyon.master.lineage.checkpoint.</div><div>CheckpointLatestScheduler</div></td>
+  <td>tachyon.master.lineage.checkpoint.&#8203;CheckpointLatestScheduler</td>
   <td>
   The class name of the checkpoint strategy for lineage output files. The default strategy is to
   checkpoint the latest completed lineage, i.e. the lineage whose output files are completed.
@@ -303,7 +303,7 @@ the port number.
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
   <td>tachyon.worker.allocator.class</td>
-  <td><div>tachyon.worker.block.allocator.</div><div>MaxFreeAllocator</div></td>
+  <td>tachyon.worker.block.allocator.&#8203;MaxFreeAllocator</td>
   <td>The strategy that a worker uses to allocate space among storage directories in certain storage
   layer. Valid options include: `tachyon.worker.block.allocator.MaxFreeAllocator`,
   `tachyon.worker.block.allocator.GreedyAllocator`,
@@ -351,13 +351,13 @@ the port number.
   <td>The port Tachyon's worker's data server runs on.</td>
 </tr>
 <tr> <td>tachyon.worker.data.server.class</td>
-  <td><div>tachyon.worker.netty.</div><div>NettyDataServer</div></td>
+  <td>tachyon.worker.netty.&#8203;NettyDataServer</td>
   <td>Selects the networking stack to run the worker with. Valid options are:
   `tachyon.worker.netty.NettyDataServer`, `tachyon.worker.nio.NIODataServer`.</td>
 </tr>
 <tr>
   <td>tachyon.worker.evictor.class</td>
-  <td><div>tachyon.worker.block.</div><div>evictor.LRUEvictor</div></td>
+  <td>tachyon.worker.block.&#8203;evictor.LRUEvictor</td>
   <td>The strategy that a worker uses to evict block files when a storage layer runs out of space. Valid
   options include `tachyon.worker.block.evictor.LRFUEvictor`,
   `tachyon.worker.block.evictor.GreedyEvictor`, `tachyon.worker.block.evictor.LRUEvictor`.</td>
@@ -525,14 +525,14 @@ The user configuration specifies values regarding file system access.
 </tr>
 <tr>
   <td>tachyon.user.block.remote.reader.class</td>
-  <td><div>tachyon.client.netty.</div><div>NettyRemoteBlockReader</div></td>
+  <td>tachyon.client.netty.&#8203;NettyRemoteBlockReader</td>
   <td>Selects networking stack to run the client with. Valid options are
     `tachyon.client.netty.NettyRemoteBlockReader` (read remote data using netty) and
     [DEPRECATED] `tachyon.client.tcp.TCPRemoteBlockReader`</td>
 </tr>
 <tr>
   <td>tachyon.user.block.remote.writer.class</td>
-  <td><div>tachyon.client.netty.</div><div>NettyRemoteBlockWriter</div></td>
+  <td>tachyon.client.netty.&#8203;NettyRemoteBlockWriter</td>
   <td>Selects networking stack to run the client with for block writes.</td>
 </tr>
 <tr>

--- a/docs/File-System-API.md
+++ b/docs/File-System-API.md
@@ -70,7 +70,7 @@ interaction with the Tachyon's native storage and under storage through the `Tac
 Below is a table of commonly used `TachyonStorageType` and `UnderStorageType` combinations as well
 as the deprecated `WriteType, ReadType` equivalents.
 
-<table class="table">
+<table class="table table-striped">
 <tr><th>TachyonStorageType</th><th>UnderStorageType</th><th>Previously</th>
 <th>Read Behavior</th><th>Write Behavior</th>
 </tr>

--- a/docs/Lineage-API.md
+++ b/docs/Lineage-API.md
@@ -100,7 +100,7 @@ tl.deleteLineage(1, options);
 
 These are the configuration parameters related to Tachyon's lineage feature.
 
-<table class="table-striped">
+<table class="table table-striped">
 <tr><th>Parameter</th><th>Default Value</th><th>Description</th></tr>
 <tr>
   <td>tachyon.master.lineage.checkpoint.interval.ms</td>

--- a/docs/Running-Spark-on-Tachyon.md
+++ b/docs/Running-Spark-on-Tachyon.md
@@ -16,7 +16,7 @@ data to those systems.
 If the versions of Spark and Tachyon form one of the the following pairs, they will work together
 out-of-the-box.
 
-<table class="table">
+<table class="table table-striped">
 <tr><th>Spark Version</th><th>Tachyon Version</th></tr>
 <tr>
   <td> 1.0.x and Below </td>

--- a/docs/Tiered-Storage-on-Tachyon.md
+++ b/docs/Tiered-Storage-on-Tachyon.md
@@ -193,18 +193,18 @@ by using multiple paths for `tachyon.worker.tieredstore.level{x}.dirs.path`.
 Additionally, the specific evictor and allocator strategies can be configured. Those configuration
 parameters are:
 
-    tachyon.worker.allocate.strategy.class=tachyon.worker.block.allocator.MaxFreeAllocator
-    tachyon.worker.evict.strategy.class=tachyon.worker.block.evictor.LRUEvictor
+    tachyon.worker.allocator.class=tachyon.worker.block.allocator.MaxFreeAllocator
+    tachyon.worker.evictor.class=tachyon.worker.block.evictor.LRUEvictor
 
 Space reserver can be configured to be enabled or disabled through:
 
-    tachyon.worker.space.reserver.enable=false
+    tachyon.worker.tieredstore.reserver.enabled=false
 
 # Configuration Parameters For Tiered Storage
 
 These are the configuration parameters for tiered storage.
 
-<table class="table-striped">
+<table class="table table-striped">
 <tr><th>Parameter</th><th>Default Value</th><th>Description</th></tr>
 <tr>
   <td>tachyon.worker.tieredstore.level.max</td>
@@ -215,7 +215,9 @@ These are the configuration parameters for tiered storage.
 </tr>
 <tr>
   <td>tachyon.worker.tieredstore.level{x}.alias</td>
-  <td>MEM (for tachyon.worker.tieredstore.level0.alias)</td>
+  <td>MEM
+  <div>(for tachyon.worker.tieredstore.</div>
+  <div>level0.alias)</div></td>
   <td>
   The alias of each storage tier, where x represents storage tier number (top tier is 0). Currently,
   there are 3 aliases, MEM, SSD, and HDD.
@@ -223,7 +225,9 @@ These are the configuration parameters for tiered storage.
 </tr>
 <tr>
   <td>tachyon.worker.tieredstore.level{x}.dirs.path</td>
-  <td>/mnt/ramdisk (for tachyon.worker.tieredstore.level0.dirs.path)</td>
+  <td>/mnt/ramdisk
+  <div>(for tachyon.worker.tieredstore.</div>
+  <div>level0.dirs.path)</div></td>
   <td>
   The paths of storage directories in storage tier x, delimited by comma. x represents the storage
   tier number (top tier is 0). It is suggested to have one storage directory per hardware device for
@@ -232,7 +236,9 @@ These are the configuration parameters for tiered storage.
 </tr>
 <tr>
   <td>tachyon.worker.tieredstore.level{x}.dirs.quota</td>
-  <td>128MB (for tachyon.worker.tieredstore.level0.dirs.quota)</td>
+  <td>128MB
+  <div>(for tachyon.worker.tieredstore.</div>
+  <div>level0.dirs.quota)</div></td>
   <td>
   The quotas for all storage directories in storage tier x, delimited by comma. x represents the
   storage tier number (starting from 0). For a particular storage tier, if the list of quotas is
@@ -249,29 +255,30 @@ These are the configuration parameters for tiered storage.
   </td>
 </tr>
 <tr>
-  <td>tachyon.worker.space.reserver.enable</td>
+  <td>tachyon.worker.tieredstore.reserver.enabled</td>
   <td>false</td>
   <td>
   Flag for enabling the space reserver service.
   </td>
 </tr>
 <tr>
-  <td>tachyon.worker.space.reserver.interval.ms</td>
+  <td>tachyon.worker.tieredstore.reserver.interval.ms</td>
   <td>1000</td>
   <td>
   Interval for the space reserver to check if enough space is reserved in all tiers.
   </td>
 </tr>
 <tr>
-  <td>tachyon.worker.allocate.strategy.class</td>
-  <td>tachyon.worker.block.allocator.MaxFreeAllocator</td>
+  <td>tachyon.worker.allocator.class</td>
+  <td><div>tachyon.worker.block.allocator.</div><div>MaxFreeAllocator</div></td>
   <td>
   The class name of the allocation strategy to use for new blocks in Tachyon.
   </td>
 </tr>
 <tr>
-  <td>tachyon.worker.evict.strategy.class</td>
-  <td>tachyon.worker.block.evictor.LRUEvictor</td>
+  <td>tachyon.worker.evictor.class</td>
+  <td><div>tachyon.worker.block.evictor.</div>
+  <div>LRUEvictor</div></td>
   <td>
   The class name of the block eviction strategy to use when a storage layer runs out of space.
   </td>

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -316,3 +316,7 @@ h1, h2, h3, h4 {
         display: block;
     }
 }
+table {
+    table-layout: fixed;
+    word-wrap:break-word;
+}

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -316,7 +316,3 @@ h1, h2, h3, h4 {
         display: block;
     }
 }
-table {
-    table-layout: fixed;
-    word-wrap:break-word;
-}


### PR DESCRIPTION
In Configuration page:
- Some columns are too thin to read due to previous columns too wide---making them wrappable by using `&#8203;` as line-break indicator.
- Add stripes into tables so they are easy to read.