### PR TITLE
[TACHYON-1139] Add unit tests for FileInStream

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/file/FileInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/FileInStream.java
@@ -36,8 +36,6 @@ import tachyon.client.file.options.InStreamOptions;
 import tachyon.exception.ExceptionMessage;
 import tachyon.exception.PreconditionMessage;
 import tachyon.master.block.BlockId;
-import tachyon.test.Testable;
-import tachyon.test.Tester;
 import tachyon.thrift.FileInfo;
 import tachyon.util.network.NetworkAddressUtils;
 
@@ -52,8 +50,7 @@ import tachyon.util.network.NetworkAddressUtils;
  * in the local machine, remote machines, or the under storage system.
  */
 @PublicApi
-public final class FileInStream extends InputStream
-    implements BoundedStream, Seekable, Testable<FileInStream> {
+public final class FileInStream extends InputStream implements BoundedStream, Seekable {
   /** Logger for this class */
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
@@ -335,25 +332,5 @@ public final class FileInStream extends InputStream
           new UnderStoreFileInStream(blockStart, mBlockSize, mFileInfo.getUfsPath());
       mShouldCacheCurrentBlock = mTachyonStorageType.isStore();
     }
-  }
-
-  class PrivateAccess {
-    public boolean isClosed() {
-      return mClosed;
-    }
-
-    public boolean shouldCacheCurrentBlock() {
-      return mShouldCacheCurrentBlock;
-    }
-
-    public void setCurrentInstream(BlockInStream inStream) {
-      mCurrentBlockInStream = inStream;
-    }
-  }
-
-  /** Grants access to private members to testers of this class. */
-  @Override
-  public void grantAccess(Tester<FileInStream> tester) {
-    tester.receiveAccess(new PrivateAccess());
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/FileInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/FileInStream.java
@@ -86,14 +86,10 @@ public final class FileInStream extends InputStream
    * @param options the client options
    */
   public FileInStream(FileInfo info, InStreamOptions options) {
-    this(info, options, FileSystemContext.INSTANCE);
-  }
-
-  FileInStream(FileInfo info, InStreamOptions options, FileSystemContext context) {
     mFileInfo = info;
     mBlockSize = info.getBlockSizeBytes();
     mFileLength = info.getLength();
-    mContext = context;
+    mContext = FileSystemContext.INSTANCE;
     mTachyonStorageType = options.getTachyonStorageType();
     mShouldCacheCurrentBlock = mTachyonStorageType.isStore();
     mClosed = false;

--- a/clients/unshaded/src/test/java/tachyon/client/block/BufferedBlockInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/block/BufferedBlockInStreamTest.java
@@ -15,9 +15,6 @@
 
 package tachyon.client.block;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,47 +22,13 @@ import org.junit.Test;
 import tachyon.util.io.BufferUtils;
 
 public class BufferedBlockInStreamTest {
-  private class TestBufferedBlockInStream extends BufferedBlockInStream {
-    private final byte[] mData;
-
-    private int mBytesRead;
-
-    public TestBufferedBlockInStream(long blockId, long blockSize, InetSocketAddress location) {
-      super(blockId, blockSize, location);
-      mData = BufferUtils.getIncreasingByteArray((int) blockSize);
-      mBytesRead = 0;
-    }
-
-    public int getBytesRead() {
-      return mBytesRead;
-    }
-
-    @Override
-    protected void bufferedRead(int len) throws IOException {
-      mBuffer.clear();
-      mBuffer.put(mData, (int) getPosition(), len);
-      mBuffer.flip();
-    }
-
-    @Override
-    protected int directRead(byte[] b, int off, int len) throws IOException {
-      System.arraycopy(mData, (int) getPosition(), b, off, len);
-      return len;
-    }
-
-    @Override
-    protected void incrementBytesReadMetric(int bytes) {
-      mBytesRead += bytes;
-    }
-  }
-
   private static final long BLOCK_LENGTH = 100L;
 
   private TestBufferedBlockInStream mTestStream;
 
   @Before
   public void before() {
-    mTestStream = new TestBufferedBlockInStream(1L, BLOCK_LENGTH, null);
+    mTestStream = new TestBufferedBlockInStream(1L, 0, BLOCK_LENGTH);
   }
 
   @Test

--- a/clients/unshaded/src/test/java/tachyon/client/block/TestBufferedBlockInStream.java
+++ b/clients/unshaded/src/test/java/tachyon/client/block/TestBufferedBlockInStream.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.client.block;
+
+import java.io.IOException;
+
+import tachyon.util.io.BufferUtils;
+
+/**
+ * Test class for mocking BufferedBlockInStream. The stream will read in increasing bytes from
+ * `start` to `start + blockSize`.
+ */
+public class TestBufferedBlockInStream extends BufferedBlockInStream {
+  private final byte[] mData;
+
+  public TestBufferedBlockInStream(long blockId, int start, long blockSize) {
+    super(blockId, blockSize, null);
+    mData = BufferUtils.getIncreasingByteArray(start, (int) blockSize);
+  }
+
+  @Override
+  protected void bufferedRead(int len) throws IOException {
+    mBuffer.clear();
+    mBuffer.put(mData, (int) getPosition(), len);
+    mBuffer.flip();
+  }
+
+  @Override
+  protected int directRead(byte[] b, int off, int len) throws IOException {
+    System.arraycopy(mData, (int) getPosition(), b, off, len);
+    return len;
+  }
+
+  @Override
+  protected void incrementBytesReadMetric(int bytes) {}
+}

--- a/clients/unshaded/src/test/java/tachyon/client/block/TestBufferedBlockOutStream.java
+++ b/clients/unshaded/src/test/java/tachyon/client/block/TestBufferedBlockOutStream.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
  * Test class for mocking BufferedBlockOutStream and exposing internal state.
  */
 public class TestBufferedBlockOutStream extends BufferedBlockOutStream {
-
   // Shouldn't need more than this for unit tests
   private static final int MAX_DATA = 1000;
   private ByteBuffer mDataWritten;

--- a/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.client.file;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.google.common.collect.Lists;
+
+import tachyon.Constants;
+import tachyon.client.ClientContext;
+import tachyon.client.TachyonStorageType;
+import tachyon.client.block.BlockInStream;
+import tachyon.client.block.BufferedBlockInStream;
+import tachyon.client.block.TachyonBlockStore;
+import tachyon.client.block.TestBufferedBlockInStream;
+import tachyon.client.block.TestBufferedBlockOutStream;
+import tachyon.client.file.options.InStreamOptions;
+import tachyon.client.util.ClientMockUtils;
+import tachyon.conf.TachyonConf;
+import tachyon.exception.ExceptionMessage;
+import tachyon.exception.PreconditionMessage;
+import tachyon.test.Tester;
+import tachyon.thrift.FileInfo;
+import tachyon.underfs.UnderFileSystem;
+import tachyon.util.io.BufferUtils;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({FileSystemContext.class, TachyonBlockStore.class, UnderFileSystem.class})
+public class FileInStreamTest implements Tester<FileInStream> {
+
+  private static final long BLOCK_LENGTH = 100L;
+  private static final long FILE_LENGTH = 350L;
+  private static final long NUM_STREAMS = ((FILE_LENGTH - 1) / BLOCK_LENGTH) + 1;
+
+  private TachyonBlockStore mBlockStore;
+  private TachyonConf mConf;
+  private FileSystemContext mContext;
+  private FileInfo mInfo;
+
+  private List<BufferedBlockInStream> mInStreams;
+  private List<TestBufferedBlockOutStream> mCacheStreams;
+
+  private FileInStream.PrivateAccess mPrivateAccess;
+  private FileInStream mTestStream;
+
+  @Override
+  public void receiveAccess(Object access) {
+    mPrivateAccess = (FileInStream.PrivateAccess) access;
+  }
+
+  @Rule
+  public final ExpectedException mThrown = ExpectedException.none();
+
+  @Before
+  public void before() throws IOException {
+    mInfo = new FileInfo().setBlockSizeBytes(BLOCK_LENGTH).setLength(FILE_LENGTH);
+
+    // Set small buffer sizes so that we don't run out of heap space
+    mConf = new TachyonConf();
+    mConf.set(Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES, "4KB");
+    mConf.set(Constants.USER_FILE_BUFFER_BYTES, "4KB");
+    ClientContext.reset(mConf);
+
+    mContext = PowerMockito.mock(FileSystemContext.class);
+    mBlockStore = PowerMockito.mock(TachyonBlockStore.class);
+    Mockito.when(mContext.getTachyonBlockStore()).thenReturn(mBlockStore);
+
+    // Set up BufferedBlockInStreams and caching streams
+    mInStreams = Lists.newArrayList();
+    mCacheStreams = Lists.newArrayList();
+    List<Long> blockIds = Lists.newArrayList();
+    for (int i = 0; i < NUM_STREAMS; i ++) {
+      blockIds.add((long) i);
+      mInStreams.add(new TestBufferedBlockInStream(i, (int) (i * BLOCK_LENGTH), BLOCK_LENGTH));
+      mCacheStreams.add(new TestBufferedBlockOutStream(i, BLOCK_LENGTH));
+      Mockito.when(mBlockStore.getInStream(i)).thenReturn(mInStreams.get(i));
+      Mockito
+          .when(
+              mBlockStore.getOutStream(Mockito.eq((long) i), Mockito.eq(-1L), Mockito.anyString()))
+          .thenReturn(mCacheStreams.get(i));
+    }
+    mInfo.setBlockIds(blockIds);
+
+    mTestStream = new FileInStream(mInfo, new InStreamOptions.Builder(mConf)
+        .setTachyonStorageType(TachyonStorageType.PROMOTE).build(), mContext);
+    mTestStream.grantAccess(FileInStreamTest.this);
+  }
+
+  @Test
+  public void singleByteReadTest() throws Exception {
+    // Verify byte by byte read is equal to increasing byte array
+    for (int i = 0; i < FILE_LENGTH; i ++) {
+      Assert.assertEquals((byte) i, (byte) mTestStream.read());
+    }
+    verifyCacheStreams(FILE_LENGTH);
+    mTestStream.close();
+    Assert.assertTrue(mPrivateAccess.isClosed());
+  }
+
+  @Test
+  public void readFileTest() throws Exception {
+    testReadBuffer((int) FILE_LENGTH);
+  }
+
+  @Test
+  public void readHalfFileTest() throws Exception {
+    testReadBuffer((int) (FILE_LENGTH / 2));
+  }
+
+  @Test
+  public void readPartialBlockTest() throws Exception {
+    testReadBuffer((int) (BLOCK_LENGTH / 2));
+  }
+
+  @Test
+  public void readBlockTest() throws Exception {
+    testReadBuffer((int) BLOCK_LENGTH);
+  }
+
+  @Test
+  public void readOffsetTest() throws IOException {
+    int offset = (int) (BLOCK_LENGTH / 3);
+    int len = (int) BLOCK_LENGTH;
+    byte[] buffer = new byte[offset + len];
+    Arrays.fill(buffer, (byte) 0);
+    byte[] expectedBuffer = new byte[offset + len];
+    Arrays.fill(expectedBuffer, (byte) 0);
+    System.arraycopy(BufferUtils.getIncreasingByteArray(len), 0, expectedBuffer, offset, len);
+    mTestStream.read(buffer, offset, len);
+    Assert.assertArrayEquals(expectedBuffer, buffer);
+  }
+
+  @Test
+  public void readManyChunks() throws IOException {
+    int chunksize = 10;
+    Assert.assertEquals(0, FILE_LENGTH % chunksize);
+    byte[] buffer = new byte[chunksize];
+    int offset = 0;
+    for (int i = 0; i < FILE_LENGTH / chunksize; i ++) {
+      mTestStream.read(buffer, 0, chunksize);
+      Assert.assertArrayEquals(BufferUtils.getIncreasingByteArray(offset, chunksize), buffer);
+      offset += chunksize;
+    }
+    verifyCacheStreams(FILE_LENGTH);
+  }
+
+  @Test
+  public void testRemaining() throws IOException {
+    Assert.assertEquals(FILE_LENGTH, mTestStream.remaining());
+    mTestStream.read();
+    Assert.assertEquals(FILE_LENGTH - 1, mTestStream.remaining());
+    mTestStream.read(new byte[150]);
+    Assert.assertEquals(FILE_LENGTH - 151, mTestStream.remaining());
+  }
+
+  @Test
+  public void testSeek() throws IOException {
+    int seekAmount = (int) (BLOCK_LENGTH / 2);
+    int readAmount = (int) (BLOCK_LENGTH * 2);
+    byte[] buffer = new byte[readAmount];
+    mTestStream.seek(seekAmount);
+    mTestStream.read(buffer);
+    Assert.assertArrayEquals(BufferUtils.getIncreasingByteArray(seekAmount, readAmount), buffer);
+    // First block should not be cached since we skipped over it, but the second should be
+    Assert.assertTrue(mCacheStreams.get(0).isCanceled());
+    Assert.assertArrayEquals(
+        BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH),
+        mCacheStreams.get(1).getDataWritten());
+
+    mTestStream.seek(seekAmount + readAmount);
+    mTestStream.seek((long) (BLOCK_LENGTH * 3.1));
+    Assert.assertEquals((byte) (BLOCK_LENGTH * 3.1), mTestStream.read());
+  }
+
+  @Test
+  public void testSkip() throws IOException {
+    int skipAmount = (int) (BLOCK_LENGTH / 2);
+    int readAmount = (int) (BLOCK_LENGTH * 2);
+    byte[] buffer = new byte[readAmount];
+    mTestStream.skip(skipAmount);
+    mTestStream.read(buffer);
+    Assert.assertArrayEquals(BufferUtils.getIncreasingByteArray(skipAmount, readAmount), buffer);
+    // First block should not be cached since we skipped over it, but the second should be
+    Assert.assertTrue(mCacheStreams.get(0).isCanceled());
+    Assert.assertArrayEquals(
+        BufferUtils.getIncreasingByteArray((int) BLOCK_LENGTH, (int) BLOCK_LENGTH),
+        mCacheStreams.get(1).getDataWritten());
+
+    Assert.assertEquals(0, mTestStream.skip(0));
+    Assert.assertEquals(BLOCK_LENGTH / 2, mTestStream.skip(BLOCK_LENGTH / 2));
+    Assert.assertEquals((byte) (BLOCK_LENGTH * 3), mTestStream.read());
+  }
+
+  @Test
+  public void testPromote() throws IOException {
+    Mockito.verify(mBlockStore, Mockito.times(0)).promote(0);
+    mTestStream.read();
+    Mockito.verify(mBlockStore, Mockito.times(1)).promote(0);
+    mTestStream.read();
+    Mockito.verify(mBlockStore, Mockito.times(1)).promote(0);
+    Mockito.verify(mBlockStore, Mockito.times(0)).promote(1);
+    mTestStream.read(new byte[(int) BLOCK_LENGTH]);
+    Mockito.verify(mBlockStore, Mockito.times(1)).promote(1);
+  }
+
+  @Test
+  public void failGetInStreamTest() throws IOException {
+    Mockito.when(mBlockStore.getInStream(1L)).thenThrow(new IOException("test IOException"));
+
+    mThrown.expect(IOException.class);
+    mThrown.expectMessage("test IOException");
+    mTestStream.seek(BLOCK_LENGTH);
+  }
+
+  @Test
+  public void failToUnderFsTest() throws IOException {
+    mInfo.setIsPersisted(true).setUfsPath("testUfsPath");
+    mTestStream = new FileInStream(mInfo, InStreamOptions.defaults(), mContext);
+
+    Mockito.when(mBlockStore.getInStream(1L)).thenThrow(new IOException("test IOException"));
+    UnderFileSystem ufs = ClientMockUtils.mockUnderFileSystem(Mockito.eq("testUfsPath"));
+    InputStream stream = Mockito.mock(InputStream.class);
+    Mockito.when(ufs.open("testUfsPath")).thenReturn(stream);
+    Mockito.when(stream.skip(BLOCK_LENGTH)).thenReturn(BLOCK_LENGTH);
+    Mockito.when(stream.skip(BLOCK_LENGTH / 2)).thenReturn(BLOCK_LENGTH / 2);
+
+    mTestStream.seek(BLOCK_LENGTH + (BLOCK_LENGTH / 2));
+    Mockito.verify(stream, Mockito.times(1)).skip(100);
+    Mockito.verify(stream, Mockito.times(1)).skip(50);
+    Assert.assertTrue(mPrivateAccess.shouldCacheCurrentBlock());
+  }
+
+  @Test
+  public void readOutOfBoundsTest() throws IOException {
+    mTestStream.read(new byte[(int) FILE_LENGTH]);
+    Assert.assertEquals(-1, mTestStream.read());
+    Assert.assertEquals(-1, mTestStream.read(new byte[10]));
+  }
+
+  @Test
+  public void readBadBufferTest() throws IOException {
+    mThrown.expect(IllegalArgumentException.class);
+    mThrown.expectMessage(String.format(PreconditionMessage.ERR_BUFFER_STATE, 10, 5, 6));
+    mTestStream.read(new byte[10], 5, 6);
+  }
+
+  @Test
+  public void seekNegativeTest() throws IOException {
+    mThrown.expect(IllegalArgumentException.class);
+    mThrown.expectMessage(String.format(PreconditionMessage.ERR_SEEK_NEGATIVE, -1));
+    mTestStream.seek(-1);
+  }
+
+  @Test
+  public void seekPastEndTest() throws IOException {
+    mThrown.expect(IllegalArgumentException.class);
+    mThrown.expectMessage(
+        String.format(PreconditionMessage.ERR_SEEK_PAST_END_OF_FILE, FILE_LENGTH + 1));
+    mTestStream.seek(FILE_LENGTH + 1);
+  }
+
+  @Test
+  public void skipNegativeTest() throws IOException {
+    Assert.assertEquals(0, mTestStream.skip(-10));
+  }
+
+  @Test
+  public void skipInstreamExceptionTest() throws IOException {
+    long skipSize = BLOCK_LENGTH / 2;
+    BlockInStream blockInStream = Mockito.mock(BlockInStream.class);
+    mPrivateAccess.setCurrentInstream(blockInStream);
+    Mockito.when(blockInStream.skip(skipSize)).thenReturn(0L);
+    Mockito.when(blockInStream.remaining()).thenReturn(BLOCK_LENGTH);
+
+    mThrown.expect(IOException.class);
+    mThrown.expectMessage(ExceptionMessage.INSTREAM_CANNOT_SKIP.getMessage(skipSize));
+    mTestStream.skip(skipSize);
+  }
+
+  private void testReadBuffer(int dataRead) throws Exception {
+    byte[] buffer = new byte[dataRead];
+    Arrays.fill(buffer, (byte) 0);
+    byte[] expectedBuffer = new byte[dataRead];
+    Arrays.fill(expectedBuffer, (byte) 0);
+    mTestStream.read(buffer);
+    Assert.assertArrayEquals(BufferUtils.getIncreasingByteArray(dataRead), buffer);
+
+    verifyCacheStreams(dataRead);
+  }
+
+  /**
+   * Verify that data was properly written to the cache streams
+   */
+  private void verifyCacheStreams(long dataRead) {
+    for (int streamIndex = 0; streamIndex < NUM_STREAMS; streamIndex ++) {
+      TestBufferedBlockOutStream stream = mCacheStreams.get(streamIndex);
+      byte[] data = stream.getDataWritten();
+      if (streamIndex * BLOCK_LENGTH > dataRead) {
+        Assert.assertEquals(0, data.length);
+      } else {
+        long dataStart = streamIndex * BLOCK_LENGTH;
+        for (int i = 0; i < BLOCK_LENGTH && dataStart + i < dataRead; i ++) {
+          Assert.assertEquals((byte) (dataStart + i), data[i]);
+        }
+      }
+    }
+  }
+}

--- a/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -107,6 +108,11 @@ public class FileInStreamTest implements Tester<FileInStream> {
         .setTachyonStorageType(TachyonStorageType.PROMOTE).build());
     Whitebox.setInternalState(mTestStream, "mContext", mContext);
     mTestStream.grantAccess(FileInStreamTest.this);
+  }
+
+  @After
+  public void after() {
+	  ClientContext.reset();
   }
 
   @Test
@@ -313,7 +319,7 @@ public class FileInStreamTest implements Tester<FileInStream> {
   }
 
   /**
-   * Verify that data was properly written to the cache streams
+   * Verifies that data was properly written to the cache streams.
    */
   private void verifyCacheStreams(long dataRead) {
     for (int streamIndex = 0; streamIndex < NUM_STREAMS; streamIndex ++) {

--- a/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -60,7 +60,6 @@ public class FileInStreamTest implements Tester<FileInStream> {
   private static final long NUM_STREAMS = ((FILE_LENGTH - 1) / BLOCK_LENGTH) + 1;
 
   private TachyonBlockStore mBlockStore;
-  private TachyonConf mConf;
   private FileSystemContext mContext;
   private FileInfo mInfo;
 
@@ -83,7 +82,7 @@ public class FileInStreamTest implements Tester<FileInStream> {
     mInfo = new FileInfo().setBlockSizeBytes(BLOCK_LENGTH).setLength(FILE_LENGTH);
 
     // Set small buffer sizes so that we don't run out of heap space
-    mConf = new TachyonConf();
+    TachyonConf mConf = new TachyonConf();
     mConf.set(Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES, "4KB");
     mConf.set(Constants.USER_FILE_BUFFER_BYTES, "4KB");
     ClientContext.reset(mConf);
@@ -108,7 +107,7 @@ public class FileInStreamTest implements Tester<FileInStream> {
     }
     mInfo.setBlockIds(blockIds);
 
-    mTestStream = new FileInStream(mInfo, new InStreamOptions.Builder(mConf)
+    mTestStream = new FileInStream(mInfo, new InStreamOptions.Builder(ClientContext.getConf())
         .setTachyonStorageType(TachyonStorageType.PROMOTE).build(), mContext);
     mTestStream.grantAccess(FileInStreamTest.this);
   }

--- a/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.Lists;
 
@@ -103,7 +104,8 @@ public class FileInStreamTest implements Tester<FileInStream> {
     mInfo.setBlockIds(blockIds);
 
     mTestStream = new FileInStream(mInfo, new InStreamOptions.Builder(ClientContext.getConf())
-        .setTachyonStorageType(TachyonStorageType.PROMOTE).build(), mContext);
+        .setTachyonStorageType(TachyonStorageType.PROMOTE).build());
+    Whitebox.setInternalState(mTestStream, "mContext", mContext);
     mTestStream.grantAccess(FileInStreamTest.this);
   }
 
@@ -236,7 +238,8 @@ public class FileInStreamTest implements Tester<FileInStream> {
   @Test
   public void failToUnderFsTest() throws IOException {
     mInfo.setIsPersisted(true).setUfsPath("testUfsPath");
-    mTestStream = new FileInStream(mInfo, InStreamOptions.defaults(), mContext);
+    mTestStream = new FileInStream(mInfo, InStreamOptions.defaults());
+    Whitebox.setInternalState(mTestStream, "mContext", mContext);
 
     Mockito.when(mBlockStore.getInStream(1L)).thenThrow(new IOException("test IOException"));
     UnderFileSystem ufs = ClientMockUtils.mockUnderFileSystem(Mockito.eq("testUfsPath"));

--- a/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -112,9 +112,11 @@ public class FileInStreamTest {
     ClientContext.reset();
   }
 
+  /**
+   * Tests that reading through the file one byte at a time will yield the correct data.
+   */
   @Test
   public void singleByteReadTest() throws Exception {
-    // Verify byte by byte read is equal to increasing byte array
     for (int i = 0; i < FILE_LENGTH; i ++) {
       Assert.assertEquals(i & 0xff, mTestStream.read());
     }
@@ -176,6 +178,9 @@ public class FileInStreamTest {
     verifyCacheStreams(FILE_LENGTH);
   }
 
+  /**
+   * Tests that FileInStream.remaining() is correctly updated during reads, skips, and seeks.
+   */
   @Test
   public void testRemaining() throws IOException {
     Assert.assertEquals(FILE_LENGTH, mTestStream.remaining());
@@ -259,6 +264,10 @@ public class FileInStreamTest {
     Mockito.verify(mBlockStore, Mockito.times(1)).promote(1);
   }
 
+  /**
+   * Tests that {@link IOException}s thrown by the {@link TachyonBlockStore} are properly
+   * propagated.
+   */
   @Test
   public void failGetInStreamTest() throws IOException {
     Mockito.when(mBlockStore.getInStream(1L)).thenThrow(new IOException("test IOException"));
@@ -290,6 +299,9 @@ public class FileInStreamTest {
     Mockito.verify(stream, Mockito.times(1)).skip(50);
   }
 
+  /**
+   * Tests that seeking into the middle of a block will invalidate caching for that block.
+   */
   @Test
   public void dontCacheMidBlockSeekTest() throws IOException {
     mTestStream.seek(BLOCK_LENGTH + (BLOCK_LENGTH / 2));
@@ -298,6 +310,9 @@ public class FileInStreamTest {
         .assertFalse((Boolean) Whitebox.getInternalState(mTestStream, "mShouldCacheCurrentBlock"));
   }
 
+  /**
+   * Tests that reading out of bounds properly returns -1.
+   */
   @Test
   public void readOutOfBoundsTest() throws IOException {
     mTestStream.read(new byte[(int) FILE_LENGTH]);
@@ -305,6 +320,9 @@ public class FileInStreamTest {
     Assert.assertEquals(-1, mTestStream.read(new byte[10]));
   }
 
+  /**
+   * Tests that specifying an invalid offset/length for a buffer read throws the right exception.
+   */
   @Test
   public void readBadBufferTest() throws IOException {
     mThrown.expect(IllegalArgumentException.class);
@@ -312,6 +330,9 @@ public class FileInStreamTest {
     mTestStream.read(new byte[10], 5, 6);
   }
 
+  /**
+   * Tests that seeking to a negative position will throw the right exception.
+   */
   @Test
   public void seekNegativeTest() throws IOException {
     mThrown.expect(IllegalArgumentException.class);
@@ -319,6 +340,9 @@ public class FileInStreamTest {
     mTestStream.seek(-1);
   }
 
+  /**
+   * Tests that seeking past the end of the stream will throw the right exception.
+   */
   @Test
   public void seekPastEndTest() throws IOException {
     mThrown.expect(IllegalArgumentException.class);
@@ -327,6 +351,9 @@ public class FileInStreamTest {
     mTestStream.seek(FILE_LENGTH + 1);
   }
 
+  /**
+   * Tests that skipping a negative amount correctly reports that 0 bytes were skipped.
+   */
   @Test
   public void skipNegativeTest() throws IOException {
     Assert.assertEquals(0, mTestStream.skip(-10));

--- a/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -249,7 +249,8 @@ public class FileInStreamTest {
     mTestStream.seek(BLOCK_LENGTH + (BLOCK_LENGTH / 2));
     Mockito.verify(stream, Mockito.times(1)).skip(100);
     Mockito.verify(stream, Mockito.times(1)).skip(50);
-    Assert.assertFalse((Boolean) Whitebox.getInternalState(mTestStream, "mShouldCacheCurrentBlock"));
+    Assert
+        .assertFalse((Boolean) Whitebox.getInternalState(mTestStream, "mShouldCacheCurrentBlock"));
   }
 
   @Test

--- a/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -111,7 +111,7 @@ public class FileInStreamTest {
   public void singleByteReadTest() throws Exception {
     // Verify byte by byte read is equal to increasing byte array
     for (int i = 0; i < FILE_LENGTH; i ++) {
-      Assert.assertEquals((byte) i, (byte) mTestStream.read());
+      Assert.assertEquals(i & 0xff, mTestStream.read());
     }
     verifyCacheStreams(FILE_LENGTH);
     mTestStream.close();

--- a/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -33,7 +33,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.google.common.collect.Lists;
 
-import tachyon.Constants;
 import tachyon.client.ClientContext;
 import tachyon.client.TachyonStorageType;
 import tachyon.client.block.BlockInStream;
@@ -43,7 +42,7 @@ import tachyon.client.block.TestBufferedBlockInStream;
 import tachyon.client.block.TestBufferedBlockOutStream;
 import tachyon.client.file.options.InStreamOptions;
 import tachyon.client.util.ClientMockUtils;
-import tachyon.conf.TachyonConf;
+import tachyon.client.util.ClientTestUtils;
 import tachyon.exception.ExceptionMessage;
 import tachyon.exception.PreconditionMessage;
 import tachyon.test.Tester;
@@ -81,11 +80,7 @@ public class FileInStreamTest implements Tester<FileInStream> {
   public void before() throws IOException {
     mInfo = new FileInfo().setBlockSizeBytes(BLOCK_LENGTH).setLength(FILE_LENGTH);
 
-    // Set small buffer sizes so that we don't run out of heap space
-    TachyonConf mConf = new TachyonConf();
-    mConf.set(Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES, "4KB");
-    mConf.set(Constants.USER_FILE_BUFFER_BYTES, "4KB");
-    ClientContext.reset(mConf);
+    ClientTestUtils.setSmallBufferSizes();
 
     mContext = PowerMockito.mock(FileSystemContext.class);
     mBlockStore = PowerMockito.mock(TachyonBlockStore.class);

--- a/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -112,7 +112,7 @@ public class FileInStreamTest implements Tester<FileInStream> {
 
   @After
   public void after() {
-	  ClientContext.reset();
+    ClientContext.reset();
   }
 
   @Test

--- a/clients/unshaded/src/test/java/tachyon/client/util/ClientMockUtils.java
+++ b/clients/unshaded/src/test/java/tachyon/client/util/ClientMockUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.client.util;
+
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+
+import tachyon.conf.TachyonConf;
+import tachyon.underfs.UnderFileSystem;
+
+public final class ClientMockUtils {
+  /**
+   * Convenience method for mocking the {@link UnderFileSystem} for any ufsPath.
+   */
+  public static UnderFileSystem mockUnderFileSystem() {
+    return mockUnderFileSystem(Mockito.anyString());
+  }
+
+  /**
+   * When {@link UnderFileSystem.get(filename, tachyonConf)} is called to get an
+   * {@link UnderFileSystem}, it will instead return the mock returned by this method, as long as
+   * `filename` matches `ufsPathMatcher`
+   *
+   * Because this method needs to mock a static method from {@link UnderFileSystem}, calling tests
+   * should make sure to annotate their classes with `@PrepareForTesting(UnderFileSystem.class)`.
+   *
+   * @param ufsPathMatcher a {@link Mockito} String Matcher
+   * @return the {@link UnderFileSystem} mock
+   */
+  public static UnderFileSystem mockUnderFileSystem(String ufsPathMatcher) {
+    UnderFileSystem ufs = PowerMockito.mock(UnderFileSystem.class);
+    PowerMockito.mockStatic(UnderFileSystem.class);
+    PowerMockito.when(UnderFileSystem.get(ufsPathMatcher, Mockito.any(TachyonConf.class)))
+        .thenReturn(ufs);
+    return ufs;
+  }
+
+  private ClientMockUtils() {} // Utils class should not be instantiated
+}

--- a/clients/unshaded/src/test/java/tachyon/client/util/ClientTestUtils.java
+++ b/clients/unshaded/src/test/java/tachyon/client/util/ClientTestUtils.java
@@ -21,7 +21,7 @@ import tachyon.conf.TachyonConf;
 
 public final class ClientTestUtils {
   public static void setSmallBufferSizes() {
-    // Set small buffer sizes so that we don't run out of heap space
+    // Sets small buffer sizes so that we don't run out of heap space
     TachyonConf mConf = new TachyonConf();
     mConf.set(Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES, "4KB");
     mConf.set(Constants.USER_FILE_BUFFER_BYTES, "4KB");

--- a/clients/unshaded/src/test/java/tachyon/client/util/ClientTestUtils.java
+++ b/clients/unshaded/src/test/java/tachyon/client/util/ClientTestUtils.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.client.util;
+
+import tachyon.Constants;
+import tachyon.client.ClientContext;
+import tachyon.conf.TachyonConf;
+
+public final class ClientTestUtils {
+  public static void setSmallBufferSizes() {
+    // Set small buffer sizes so that we don't run out of heap space
+    TachyonConf mConf = new TachyonConf();
+    mConf.set(Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES, "4KB");
+    mConf.set(Constants.USER_FILE_BUFFER_BYTES, "4KB");
+    ClientContext.reset(mConf);
+  }
+}


### PR DESCRIPTION
ClientMockUtils are currently only used by FileInStreamTest, but they will soon be used by FileOutStreamTest after this commit merges.