### PR TITLE
[SMALLFIX] Fix master fault tolerant restart behavior

### DIFF
--- a/common/src/main/java/tachyon/LeaderInquireClient.java
+++ b/common/src/main/java/tachyon/LeaderInquireClient.java
@@ -70,7 +70,9 @@ public final class LeaderInquireClient {
           LOG.info("Master addresses: {}", masters);
           if (masters.size() >= 1) {
             if (masters.size() == 1) {
-              return masters.get(0);
+              String leader = masters.get(0);
+              LOG.info("The leader master: " + leader);
+              return leader;
             }
 
             long maxTime = 0;
@@ -83,6 +85,7 @@ public final class LeaderInquireClient {
                 leader = master;
               }
             }
+            LOG.info("The leader master: " + leader);
             return leader;
           }
         } else {

--- a/common/src/main/java/tachyon/LeaderInquireClient.java
+++ b/common/src/main/java/tachyon/LeaderInquireClient.java
@@ -70,8 +70,7 @@ public final class LeaderInquireClient {
           LOG.info("Master addresses: {}", masters);
           if (masters.size() >= 1) {
             if (masters.size() == 1) {
-              String leader = masters.get(0);
-              return leader;
+              return masters.get(0);
             }
 
             long maxTime = 0;

--- a/common/src/main/java/tachyon/LeaderInquireClient.java
+++ b/common/src/main/java/tachyon/LeaderInquireClient.java
@@ -71,7 +71,6 @@ public final class LeaderInquireClient {
           if (masters.size() >= 1) {
             if (masters.size() == 1) {
               String leader = masters.get(0);
-              LOG.info("The leader master: " + leader);
               return leader;
             }
 

--- a/common/src/main/java/tachyon/LeaderSelectorClient.java
+++ b/common/src/main/java/tachyon/LeaderSelectorClient.java
@@ -62,19 +62,7 @@ public final class LeaderSelectorClient implements Closeable, LeaderSelectorList
 
     // Create a leader selector using the given path for management.
     // All participants in a given leader selection must use the same path.
-    CuratorFramework client =
-        CuratorFrameworkFactory.newClient(mZookeeperAddress, new ExponentialBackoffRetry(
-            Constants.SECOND_MS, 3));
-    client.start();
-
-    // Sometimes, if the master crashes and restarts too quickly, zookeeper thinks the new client is
-    // still an old one. Close the "old" client and recreate a new one.
-    client.close();
-    client = CuratorFrameworkFactory.newClient(mZookeeperAddress,
-        new ExponentialBackoffRetry(Constants.SECOND_MS, 3));
-    client.start();
-
-    mLeaderSelector = new LeaderSelector(client, mElectionPath, this);
+    mLeaderSelector = new LeaderSelector(getNewCuratorClient(), mElectionPath, this);
     mLeaderSelector.setId(name);
 
     // for most cases you will want your instance to requeue when it relinquishes leadership
@@ -175,5 +163,26 @@ public final class LeaderSelectorClient implements Closeable, LeaderSelectorList
       LOG.info("All participants: " + mLeaderSelector.getParticipants());
       client.delete().forPath(mLeaderFolder + mName);
     }
+  }
+
+  /**
+   * Returns a new client for the zookeeper connection. The client is already started before
+   * returning.
+   *
+   * @return a new {@link CuratorFramework} client to use for leader selection
+   */
+  private CuratorFramework getNewCuratorClient() {
+    CuratorFramework client = CuratorFrameworkFactory.newClient(mZookeeperAddress,
+        new ExponentialBackoffRetry(Constants.SECOND_MS, 3));
+    client.start();
+
+    // Sometimes, if the master crashes and restarts too quickly (faster than the zookeeper
+    // timeout), zookeeper thinks the new client is still an old one. In order to ensure a clean
+    // state, explicitly close the "old" client recreate a new one.
+    client.close();
+    client = CuratorFrameworkFactory.newClient(mZookeeperAddress,
+        new ExponentialBackoffRetry(Constants.SECOND_MS, 3));
+    client.start();
+    return client;
   }
 }

--- a/servers/src/main/java/tachyon/master/file/meta/MountTable.java
+++ b/servers/src/main/java/tachyon/master/file/meta/MountTable.java
@@ -130,7 +130,7 @@ public final class MountTable {
    */
   public synchronized TachyonURI resolve(TachyonURI uri) throws InvalidPathException {
     String path = uri.getPath();
-    LOG.info("Resolving " + path);
+    LOG.debug("Resolving " + path);
     String mountPoint = getMountPoint(uri);
     if (mountPoint != null) {
       TachyonURI ufsPath = mMountTable.get(mountPoint);


### PR DESCRIPTION
When a master restarts very quickly and creates a connection to zookeeper, zk still thinks it is the old client, so it thinks the master is the same, instead of a newly started master. This prevents the new master from taking leadership, and therefore, prevents any of the masters to be serving as the leader.