### PR TITLE
[SMALLFIX] Use timeout for thrift RPCs

### DIFF
--- a/common/src/main/java/tachyon/security/authentication/AuthenticationUtils.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationUtils.java
@@ -102,7 +102,9 @@ public final class AuthenticationUtils {
    * @return An unconnected socket
    */
   public static TSocket createTSocket(InetSocketAddress address) {
-    return new TSocket(NetworkAddressUtils.getFqdnHost(address), address.getPort());
+    // TODO: make the timeout configurable.
+    return new TSocket(NetworkAddressUtils.getFqdnHost(address), address.getPort(),
+        30 * Constants.SECOND_MS);
   }
 
   private AuthenticationUtils() {} // prevent instantiation

--- a/common/src/main/java/tachyon/security/authentication/AuthenticationUtils.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationUtils.java
@@ -102,7 +102,7 @@ public final class AuthenticationUtils {
    * @return An unconnected socket
    */
   public static TSocket createTSocket(InetSocketAddress address) {
-    // TODO: make the timeout configurable.
+    // TODO(gpang): make the timeout configurable.
     return new TSocket(NetworkAddressUtils.getFqdnHost(address), address.getPort(),
         30 * Constants.SECOND_MS);
   }


### PR DESCRIPTION
Sometimes, when a master failover happens, a client might try to send RPCs to the old master, but the RPC hangs forever, since the old master is standby now. Clients shouldn't wait forever to get a response from an RPC, so it can try to reconnect to the real leader master.