### PR TITLE
[TACHYON-1155] Add toString method for tachyon.client.file.options pa…

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/file/options/CreateOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/CreateOptions.java
@@ -143,6 +143,15 @@ public final class CreateOptions {
   }
 
   /**
+   * @return the name : value pairs for all the fields
+   */
+  @Override
+  public String toString() {
+    return "CreateTOptions{mBlockSizeBytes=" + mBlockSizeBytes + ",mRecursive=" + mRecursive
+        + ",mTTL=" + mTTL + ",mUnderStorageType=" + mUnderStorageType.toString() + "}";
+  }
+
+  /**
    * @return Thrift representation of the options
    */
   public CreateTOptions toThrift() {

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/CreateOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/CreateOptions.java
@@ -147,8 +147,15 @@ public final class CreateOptions {
    */
   @Override
   public String toString() {
-    return "CreateTOptions{mBlockSizeBytes=" + mBlockSizeBytes + ",mRecursive=" + mRecursive
-        + ",mTTL=" + mTTL + ",mUnderStorageType=" + mUnderStorageType.toString() + "}";
+    return "CreateOptions{mBlockSizeBytes=" + mBlockSizeBytes + ", mRecursive=" + mRecursive
+        + ", mTTL=" + mTTL + ", mUnderStorageType=" + mUnderStorageType.toString() + "}";
+  }
+
+  /**
+   * @return the default String representation for testing purposes
+   */
+  public String toStringBase() {
+    return super.toString();
   }
 
   /**

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/CreateOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/CreateOptions.java
@@ -147,15 +147,13 @@ public final class CreateOptions {
    */
   @Override
   public String toString() {
-    return "CreateOptions{mBlockSizeBytes=" + mBlockSizeBytes + ", mRecursive=" + mRecursive
-        + ", mTTL=" + mTTL + ", mUnderStorageType=" + mUnderStorageType.toString() + "}";
-  }
-
-  /**
-   * @return the default String representation for testing purposes
-   */
-  public String toStringBase() {
-    return super.toString();
+    StringBuilder sb = new StringBuilder("CreateOptions(");
+    sb.append(super.toString()).append(", mBlockSizeBytes: ").append(mBlockSizeBytes);
+    sb.append(", mRecursive: ").append(mRecursive);
+    sb.append(", mTTL: ").append(mTTL);
+    sb.append(", mUnderStorageType: ").append(mUnderStorageType.toString());
+    sb.append(")");
+    return sb.toString();
   }
 
   /**

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/CreateOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/CreateOptions.java
@@ -148,10 +148,10 @@ public final class CreateOptions {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("CreateOptions(");
-    sb.append(super.toString()).append(", mBlockSizeBytes: ").append(mBlockSizeBytes);
-    sb.append(", mRecursive: ").append(mRecursive);
-    sb.append(", mTTL: ").append(mTTL);
-    sb.append(", mUnderStorageType: ").append(mUnderStorageType.toString());
+    sb.append(super.toString()).append(", BlockSizeBytes: ").append(mBlockSizeBytes);
+    sb.append(", Recursive: ").append(mRecursive);
+    sb.append(", TTL: ").append(mTTL);
+    sb.append(", UnderStorageType: ").append(mUnderStorageType.toString());
     sb.append(")");
     return sb.toString();
   }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/DeleteOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/DeleteOptions.java
@@ -73,4 +73,12 @@ public final class DeleteOptions {
   public boolean isRecursive() {
     return mRecursive;
   }
+
+  /**
+   * @return the name : value pairs for all the fields
+   */
+  @Override
+  public String toString() {
+    return "DeleteOptions{mRecursive=" + mRecursive + "}";
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/DeleteOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/DeleteOptions.java
@@ -81,4 +81,11 @@ public final class DeleteOptions {
   public String toString() {
     return "DeleteOptions{mRecursive=" + mRecursive + "}";
   }
+
+  /**
+   * @return the default String representation for testing purposes
+   */
+  public String toStringBase() {
+    return super.toString();
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/DeleteOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/DeleteOptions.java
@@ -80,7 +80,7 @@ public final class DeleteOptions {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("DeleteOptions(");
-    sb.append(super.toString()).append(", mRecursive: ").append(mRecursive);
+    sb.append(super.toString()).append(", Recursive: ").append(mRecursive);
     sb.append(")");
     return sb.toString();
   }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/DeleteOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/DeleteOptions.java
@@ -79,13 +79,9 @@ public final class DeleteOptions {
    */
   @Override
   public String toString() {
-    return "DeleteOptions{mRecursive=" + mRecursive + "}";
-  }
-
-  /**
-   * @return the default String representation for testing purposes
-   */
-  public String toStringBase() {
-    return super.toString();
+    StringBuilder sb = new StringBuilder("DeleteOptions(");
+    sb.append(super.toString()).append(", mRecursive: ").append(mRecursive);
+    sb.append(")");
+    return sb.toString();
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/FreeOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/FreeOptions.java
@@ -73,4 +73,12 @@ public final class FreeOptions {
   public boolean isRecursive() {
     return mRecursive;
   }
+
+  /**
+   * @return the name : value pairs for all the fields
+   */
+  @Override
+  public String toString() {
+    return "FreeOptions{mRecursive=" + mRecursive + "}";
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/FreeOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/FreeOptions.java
@@ -81,4 +81,11 @@ public final class FreeOptions {
   public String toString() {
     return "FreeOptions{mRecursive=" + mRecursive + "}";
   }
+
+  /**
+   * @return the default String representation for testing purposes
+   */
+  public String toStringBase() {
+    return super.toString();
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/FreeOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/FreeOptions.java
@@ -80,7 +80,7 @@ public final class FreeOptions {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("FreeOptions(");
-    sb.append(super.toString()).append(", mRecursive: ").append(mRecursive);
+    sb.append(super.toString()).append(", Recursive: ").append(mRecursive);
     sb.append(")");
     return sb.toString();
   }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/FreeOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/FreeOptions.java
@@ -79,13 +79,9 @@ public final class FreeOptions {
    */
   @Override
   public String toString() {
-    return "FreeOptions{mRecursive=" + mRecursive + "}";
-  }
-
-  /**
-   * @return the default String representation for testing purposes
-   */
-  public String toStringBase() {
-    return super.toString();
+    StringBuilder sb = new StringBuilder("FreeOptions(");
+    sb.append(super.toString()).append(", mRecursive: ").append(mRecursive);
+    sb.append(")");
+    return sb.toString();
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/InStreamOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/InStreamOptions.java
@@ -74,4 +74,12 @@ public final class InStreamOptions {
   public TachyonStorageType getTachyonStorageType() {
     return mTachyonStorageType;
   }
+
+  /**
+   * @return the name : value pairs for all the fields
+   */
+  @Override
+  public String toString() {
+    return "InStreamOptions{" + "mTachyonStorageType=" + mTachyonStorageType.toString() + "}";
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/InStreamOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/InStreamOptions.java
@@ -82,4 +82,11 @@ public final class InStreamOptions {
   public String toString() {
     return "InStreamOptions{" + "mTachyonStorageType=" + mTachyonStorageType.toString() + "}";
   }
+
+  /**
+   * @return the default String representation for testing purposes
+   */
+  public String toStringBase() {
+    return super.toString();
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/InStreamOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/InStreamOptions.java
@@ -81,7 +81,7 @@ public final class InStreamOptions {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("InStreamOptions(");
-    sb.append(super.toString()).append(", mTachyonStorageType: ")
+    sb.append(super.toString()).append(", TachyonStorageType: ")
         .append(mTachyonStorageType.toString());
     sb.append(")");
     return sb.toString();

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/InStreamOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/InStreamOptions.java
@@ -80,13 +80,10 @@ public final class InStreamOptions {
    */
   @Override
   public String toString() {
-    return "InStreamOptions{" + "mTachyonStorageType=" + mTachyonStorageType.toString() + "}";
-  }
-
-  /**
-   * @return the default String representation for testing purposes
-   */
-  public String toStringBase() {
-    return super.toString();
+    StringBuilder sb = new StringBuilder("InStreamOptions(");
+    sb.append(super.toString()).append(", mTachyonStorageType: ")
+        .append(mTachyonStorageType.toString());
+    sb.append(")");
+    return sb.toString();
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/LoadMetadataOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/LoadMetadataOptions.java
@@ -81,4 +81,11 @@ public final class LoadMetadataOptions {
   public String toString() {
     return "LoadMetadataOptions{mRecursive=" + mRecursive + "}";
   }
+
+  /**
+   * @return the default String representation for testing purposes
+   */
+  public String toStringBase() {
+    return super.toString();
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/LoadMetadataOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/LoadMetadataOptions.java
@@ -73,4 +73,12 @@ public final class LoadMetadataOptions {
   public boolean isRecursive() {
     return mRecursive;
   }
+
+  /**
+   * @return the name : value pairs for all the fields
+   */
+  @Override
+  public String toString() {
+    return "LoadMetadataOptions{mRecursive=" + mRecursive + "}";
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/LoadMetadataOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/LoadMetadataOptions.java
@@ -80,7 +80,7 @@ public final class LoadMetadataOptions {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("LoadMetadataOptions(");
-    sb.append(super.toString()).append(", mRecursive: ").append(mRecursive);
+    sb.append(super.toString()).append(", Recursive: ").append(mRecursive);
     sb.append(")");
     return sb.toString();
   }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/LoadMetadataOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/LoadMetadataOptions.java
@@ -79,13 +79,9 @@ public final class LoadMetadataOptions {
    */
   @Override
   public String toString() {
-    return "LoadMetadataOptions{mRecursive=" + mRecursive + "}";
-  }
-
-  /**
-   * @return the default String representation for testing purposes
-   */
-  public String toStringBase() {
-    return super.toString();
+    StringBuilder sb = new StringBuilder("LoadMetadataOptions(");
+    sb.append(super.toString()).append(", mRecursive: ").append(mRecursive);
+    sb.append(")");
+    return sb.toString();
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/MkdirOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/MkdirOptions.java
@@ -103,8 +103,15 @@ public final class MkdirOptions {
    */
   @Override
   public String toString() {
-    return "MkdirOptions{mRecursive=" + mRecursive + ",mUnderStorageType="
+    return "MkdirOptions{mRecursive=" + mRecursive + ", mUnderStorageType="
         + mUnderStorageType.toString() + "}";
+  }
+
+  /**
+   * @return the default String representation for testing purposes
+   */
+  public String toStringBase() {
+    return super.toString();
   }
 
   /**

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/MkdirOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/MkdirOptions.java
@@ -99,6 +99,15 @@ public final class MkdirOptions {
   }
 
   /**
+   * @return the name : value pairs for all the fields
+   */
+  @Override
+  public String toString() {
+    return "MkdirOptions{mRecursive=" + mRecursive + ",mUnderStorageType="
+        + mUnderStorageType.toString() + "}";
+  }
+
+  /**
    * @return Thrift representation of the options
    */
   public MkdirTOptions toThrift() {

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/MkdirOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/MkdirOptions.java
@@ -104,8 +104,8 @@ public final class MkdirOptions {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("MkdirOptions(");
-    sb.append(super.toString()).append(", mRecursive: ").append(mRecursive);
-    sb.append(", mUnderStorageType: ").append(mUnderStorageType.toString());
+    sb.append(super.toString()).append(", Recursive: ").append(mRecursive);
+    sb.append(", UnderStorageType: ").append(mUnderStorageType.toString());
     sb.append(")");
     return sb.toString();
   }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/MkdirOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/MkdirOptions.java
@@ -103,15 +103,11 @@ public final class MkdirOptions {
    */
   @Override
   public String toString() {
-    return "MkdirOptions{mRecursive=" + mRecursive + ", mUnderStorageType="
-        + mUnderStorageType.toString() + "}";
-  }
-
-  /**
-   * @return the default String representation for testing purposes
-   */
-  public String toStringBase() {
-    return super.toString();
+    StringBuilder sb = new StringBuilder("MkdirOptions(");
+    sb.append(super.toString()).append(", mRecursive: ").append(mRecursive);
+    sb.append(", mUnderStorageType: ").append(mUnderStorageType.toString());
+    sb.append(")");
+    return sb.toString();
   }
 
   /**

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/OutStreamOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/OutStreamOptions.java
@@ -159,4 +159,14 @@ public final class OutStreamOptions {
   public UnderStorageType getUnderStorageType() {
     return mUnderStorageType;
   }
+
+  /**
+   * @return the name : value pairs for all the fields
+   */
+  @Override
+  public String toString() {
+    return "OutStreamOptions{" + "mBlockSizeBytes=" + mBlockSizeBytes + ",mHostname=" + mHostname
+        + ",mTachyonStorageType=" + mTachyonStorageType.toString() + ",mUnderStorageType="
+        + mUnderStorageType.toString() + ",mTTL=" + mTTL + "}";
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/OutStreamOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/OutStreamOptions.java
@@ -165,8 +165,15 @@ public final class OutStreamOptions {
    */
   @Override
   public String toString() {
-    return "OutStreamOptions{" + "mBlockSizeBytes=" + mBlockSizeBytes + ",mHostname=" + mHostname
-        + ",mTachyonStorageType=" + mTachyonStorageType.toString() + ",mUnderStorageType="
-        + mUnderStorageType.toString() + ",mTTL=" + mTTL + "}";
+    return "OutStreamOptions{" + "mBlockSizeBytes=" + mBlockSizeBytes + ", mHostname=" + mHostname
+        + ", mTachyonStorageType=" + mTachyonStorageType.toString() + ", mUnderStorageType="
+        + mUnderStorageType.toString() + ", mTTL=" + mTTL + "}";
+  }
+
+  /**
+   * @return the default String representation for testing purposes
+   */
+  public String toStringBase() {
+    return super.toString();
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/OutStreamOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/OutStreamOptions.java
@@ -165,15 +165,13 @@ public final class OutStreamOptions {
    */
   @Override
   public String toString() {
-    return "OutStreamOptions{" + "mBlockSizeBytes=" + mBlockSizeBytes + ", mHostname=" + mHostname
-        + ", mTachyonStorageType=" + mTachyonStorageType.toString() + ", mUnderStorageType="
-        + mUnderStorageType.toString() + ", mTTL=" + mTTL + "}";
-  }
-
-  /**
-   * @return the default String representation for testing purposes
-   */
-  public String toStringBase() {
-    return super.toString();
+    StringBuilder sb = new StringBuilder("OutStreamOptions(");
+    sb.append(super.toString()).append(", mBlockSizeBytes: ").append(mBlockSizeBytes);
+    sb.append(", mHostname: ").append(mHostname);
+    sb.append(", mTachyonStorageType: ").append(mTachyonStorageType.toString());
+    sb.append(", mUnderStorageType: ").append(mUnderStorageType.toString());
+    sb.append(", mTTL: ").append(mTTL);
+    sb.append(")");
+    return sb.toString();
   }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/OutStreamOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/OutStreamOptions.java
@@ -166,11 +166,11 @@ public final class OutStreamOptions {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("OutStreamOptions(");
-    sb.append(super.toString()).append(", mBlockSizeBytes: ").append(mBlockSizeBytes);
-    sb.append(", mHostname: ").append(mHostname);
-    sb.append(", mTachyonStorageType: ").append(mTachyonStorageType.toString());
-    sb.append(", mUnderStorageType: ").append(mUnderStorageType.toString());
-    sb.append(", mTTL: ").append(mTTL);
+    sb.append(super.toString()).append(", BlockSizeBytes: ").append(mBlockSizeBytes);
+    sb.append(", Hostname: ").append(mHostname);
+    sb.append(", TachyonStorageType: ").append(mTachyonStorageType.toString());
+    sb.append(", UnderStorageType: ").append(mUnderStorageType.toString());
+    sb.append(", TTL: ").append(mTTL);
     sb.append(")");
     return sb.toString();
   }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/SetStateOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/SetStateOptions.java
@@ -73,4 +73,12 @@ public class SetStateOptions {
   public Boolean getPinned() {
     return mPinned;
   }
+
+  /**
+   * @return the name : value pairs for all the fields
+   */
+  @Override
+  public String toString() {
+    return "SetStateOptions{mPinned=" + mPinned + "}";
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/SetStateOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/SetStateOptions.java
@@ -81,4 +81,11 @@ public class SetStateOptions {
   public String toString() {
     return "SetStateOptions{mPinned=" + mPinned + "}";
   }
+
+  /**
+   * @return the default String representation for testing purposes
+   */
+  public String toStringBase() {
+    return super.toString();
+  }
 }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/SetStateOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/SetStateOptions.java
@@ -80,7 +80,7 @@ public class SetStateOptions {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder("SetStateOptions(");
-    sb.append(super.toString()).append(", mPinned: ").append(mPinned);
+    sb.append(super.toString()).append(", Pinned: ").append(mPinned);
     sb.append(")");
     return sb.toString();
   }

--- a/clients/unshaded/src/main/java/tachyon/client/file/options/SetStateOptions.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/options/SetStateOptions.java
@@ -79,13 +79,9 @@ public class SetStateOptions {
    */
   @Override
   public String toString() {
-    return "SetStateOptions{mPinned=" + mPinned + "}";
-  }
-
-  /**
-   * @return the default String representation for testing purposes
-   */
-  public String toStringBase() {
-    return super.toString();
+    StringBuilder sb = new StringBuilder("SetStateOptions(");
+    sb.append(super.toString()).append(", mPinned: ").append(mPinned);
+    sb.append(")");
+    return sb.toString();
   }
 }

--- a/integration-tests/src/test/java/tachyon/client/BufferedBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/BufferedBlockInStreamIntegrationTest.java
@@ -83,7 +83,7 @@ public class BufferedBlockInStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        String path = uniqPath + "/file_" + k + "_" + op;
+        String path = uniqPath + "/file_" + k + "_" + op.toStringBase();
         TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, path, k, op);
 
         for (int i = 0; i < 2; i ++) {
@@ -113,7 +113,7 @@ public class BufferedBlockInStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        String path = uniqPath + "/file_" + k + "_" + op;
+        String path = uniqPath + "/file_" + k + "_" + op.toStringBase();
         TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, path, k, op);
 
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
@@ -139,7 +139,7 @@ public class BufferedBlockInStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        String path = uniqPath + "/file_" + k + "_" + op;
+        String path = uniqPath + "/file_" + k + "_" + op.toStringBase();
         TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, path, k, op);
 
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
@@ -166,7 +166,7 @@ public class BufferedBlockInStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        String path = uniqPath + "/file_" + k + "_" + op;
+        String path = uniqPath + "/file_" + k + "_" + op.toStringBase();
         TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, path, k, op);
 
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));

--- a/integration-tests/src/test/java/tachyon/client/BufferedBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/BufferedBlockInStreamIntegrationTest.java
@@ -83,7 +83,7 @@ public class BufferedBlockInStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        String path = uniqPath + "/file_" + k + "_" + op.toStringBase();
+        String path = uniqPath + "/file_" + k + "_" + op.hashCode();
         TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, path, k, op);
 
         for (int i = 0; i < 2; i ++) {
@@ -113,7 +113,7 @@ public class BufferedBlockInStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        String path = uniqPath + "/file_" + k + "_" + op.toStringBase();
+        String path = uniqPath + "/file_" + k + "_" + op.hashCode();
         TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, path, k, op);
 
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
@@ -139,7 +139,7 @@ public class BufferedBlockInStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        String path = uniqPath + "/file_" + k + "_" + op.toStringBase();
+        String path = uniqPath + "/file_" + k + "_" + op.hashCode();
         TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, path, k, op);
 
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
@@ -166,7 +166,7 @@ public class BufferedBlockInStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        String path = uniqPath + "/file_" + k + "_" + op.toStringBase();
+        String path = uniqPath + "/file_" + k + "_" + op.hashCode();
         TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, path, k, op);
 
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));

--- a/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
@@ -90,7 +90,8 @@ public class FileInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
 
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         byte[] ret = new byte[k];
@@ -132,7 +133,8 @@ public class FileInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         byte[] ret = new byte[k];
         Assert.assertEquals(k, is.read(ret));
@@ -157,7 +159,8 @@ public class FileInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         byte[] ret = new byte[k / 2];
         Assert.assertEquals(k / 2, is.read(ret, 0, k / 2));
@@ -182,7 +185,8 @@ public class FileInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         try {
           byte[] ret = new byte[k / 2];
@@ -213,7 +217,8 @@ public class FileInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         try {
           is.seek(-1);
@@ -237,7 +242,8 @@ public class FileInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         try {
           is.seek(k + 1);
@@ -260,7 +266,8 @@ public class FileInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         is.seek(k / 3);
         Assert.assertEquals(k / 3, is.read());
@@ -284,7 +291,8 @@ public class FileInStreamIntegrationTest {
     int length = BLOCK_SIZE * 3;
     for (OutStreamOptions op : getOptionSet()) {
       TachyonFile f =
-          TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + op, length, op);
+          TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + op.toStringBase(), length,
+          op);
       FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
       byte[] data = new byte[length];
       is.read(data, 0, length);
@@ -305,7 +313,8 @@ public class FileInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
 
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         Assert.assertEquals(k / 2, is.skip(k / 2));

--- a/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
@@ -91,7 +91,7 @@ public class FileInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
 
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         byte[] ret = new byte[k];
@@ -134,7 +134,7 @@ public class FileInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         byte[] ret = new byte[k];
         Assert.assertEquals(k, is.read(ret));
@@ -160,7 +160,7 @@ public class FileInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         byte[] ret = new byte[k / 2];
         Assert.assertEquals(k / 2, is.read(ret, 0, k / 2));
@@ -186,7 +186,7 @@ public class FileInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         try {
           byte[] ret = new byte[k / 2];
@@ -218,7 +218,7 @@ public class FileInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         try {
           is.seek(-1);
@@ -243,7 +243,7 @@ public class FileInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         try {
           is.seek(k + 1);
@@ -267,7 +267,7 @@ public class FileInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         is.seek(k / 3);
         Assert.assertEquals(k / 3, is.read());
@@ -291,7 +291,7 @@ public class FileInStreamIntegrationTest {
     int length = BLOCK_SIZE * 3;
     for (OutStreamOptions op : getOptionSet()) {
       TachyonFile f =
-          TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + op.toStringBase(), length,
+          TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + op.hashCode(), length,
           op);
       FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
       byte[] data = new byte[length];
@@ -314,7 +314,7 @@ public class FileInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
 
         FileInStream is = sTfs.getInStream(f, TachyonFSTestUtils.toInStreamOptions(op));
         Assert.assertEquals(k / 2, is.skip(k / 2));

--- a/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
@@ -161,7 +161,7 @@ public final class FileOutStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        writeTest1Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op), k, op);
+        writeTest1Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op.toStringBase()), k, op);
       }
     }
   }
@@ -184,7 +184,7 @@ public final class FileOutStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        writeTest2Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op), k, op);
+        writeTest2Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op.toStringBase()), k, op);
       }
     }
   }
@@ -205,7 +205,7 @@ public final class FileOutStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        writeTest3Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op), k, op);
+        writeTest3Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op.toStringBase()), k, op);
       }
     }
   }

--- a/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileOutStreamIntegrationTest.java
@@ -161,7 +161,7 @@ public final class FileOutStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        writeTest1Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op.toStringBase()), k, op);
+        writeTest1Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op.hashCode()), k, op);
       }
     }
   }
@@ -184,7 +184,7 @@ public final class FileOutStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        writeTest2Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op.toStringBase()), k, op);
+        writeTest2Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op.hashCode()), k, op);
       }
     }
   }
@@ -205,7 +205,7 @@ public final class FileOutStreamIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
-        writeTest3Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op.toStringBase()), k, op);
+        writeTest3Util(new TachyonURI(uniqPath + "/file_" + k + "_" + op.hashCode()), k, op);
       }
     }
   }

--- a/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
@@ -93,7 +93,8 @@ public class LocalBlockInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
         byte[] ret = new byte[k];
@@ -137,7 +138,8 @@ public class LocalBlockInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
         byte[] ret = new byte[k];
@@ -165,7 +167,8 @@ public class LocalBlockInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
         byte[] ret = new byte[k / 2];
@@ -199,7 +202,8 @@ public class LocalBlockInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
 
@@ -228,7 +232,8 @@ public class LocalBlockInStreamIntegrationTest {
     for (int k = MIN_LEN; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
         try {
@@ -252,7 +257,8 @@ public class LocalBlockInStreamIntegrationTest {
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
 
@@ -276,7 +282,8 @@ public class LocalBlockInStreamIntegrationTest {
     for (int k = MIN_LEN + DELTA; k <= MAX_LEN; k += DELTA) {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
-            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_" + op, k, op);
+            TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
+            + op.toStringBase(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
         Assert.assertEquals(k / 2, is.skip(k / 2));

--- a/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
@@ -94,7 +94,7 @@ public class LocalBlockInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
         byte[] ret = new byte[k];
@@ -139,7 +139,7 @@ public class LocalBlockInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
         byte[] ret = new byte[k];
@@ -168,7 +168,7 @@ public class LocalBlockInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
         byte[] ret = new byte[k / 2];
@@ -203,7 +203,7 @@ public class LocalBlockInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
 
@@ -233,7 +233,7 @@ public class LocalBlockInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
         try {
@@ -258,7 +258,7 @@ public class LocalBlockInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
 
@@ -283,7 +283,7 @@ public class LocalBlockInStreamIntegrationTest {
       for (OutStreamOptions op : getOptionSet()) {
         TachyonFile f =
             TachyonFSTestUtils.createByteFile(sTfs, uniqPath + "/file_" + k + "_"
-            + op.toStringBase(), k, op);
+            + op.hashCode(), k, op);
 
         FileInStream is = sTfs.getInStream(f, sReadNoCache);
         Assert.assertEquals(k / 2, is.skip(k / 2));


### PR DESCRIPTION
…ckage

https://tachyon.atlassian.net/browse/TACHYON-1155

Some tests (like `FileOutStreamIntegrationTest` use `options.toString()` as temporary file names which is why no space is used in the override `toString()` impl.