### PR TITLE
[SMALLFIX] Explicitly specify jspc version

### DIFF
--- a/servers/pom.xml
+++ b/servers/pom.xml
@@ -134,6 +134,7 @@
       <plugin>
         <groupId>org.apache.sling</groupId>
         <artifactId>maven-jspc-plugin</artifactId>
+        <version>2.0.8</version>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This resolves the warning our builds were giving:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.tachyonproject:tachyon-servers:jar:0.9.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.sling:maven-jspc-plugin is missing. @ line 134, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```