### PR TITLE
[SMALLFIX] Remove links to inaccessible files

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/block/TachyonBlockStore.java
+++ b/clients/unshaded/src/main/java/tachyon/client/block/TachyonBlockStore.java
@@ -30,8 +30,7 @@ import tachyon.worker.WorkerClient;
 /**
  * Tachyon Block Store client. This is an internal client for all block level operations in Tachyon.
  * An instance of this class can be obtained via {@link TachyonBlockStore#get}. The methods in this
- * class are completely opaque to user input (such as {@link ClientOptions}). This class is thread
- * safe.
+ * class are completely opaque to user input. This class is thread safe.
  */
 public final class TachyonBlockStore implements Closeable {
 

--- a/common/src/main/java/tachyon/resource/ResourcePool.java
+++ b/common/src/main/java/tachyon/resource/ResourcePool.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
  * Class representing a pool of resources to be temporarily used and returned. Inheriting classes
  * must implement the close method as well as initialize the resources in the constructor. The
  * implemented methods are thread-safe and inheriting classes should also written in a thread-safe
- * manner. See {@link tachyon.client.file.FileSystemMasterClientPool} as an example.
+ * manner. See {@code FileSystemMasterClientPool} as an example.
  *
  * @param <T> the type of resource this pool manages
  */


### PR DESCRIPTION
ClientOptions is completely gone, and FileSystemMasterClientPool is in a separate project from ResourcePool, so it can't be linked by javadoc.