### PR TITLE
[TACHYON-1193] Move jar location constant to Version to fix build

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/UfsUtils.java
+++ b/clients/unshaded/src/main/java/tachyon/client/UfsUtils.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
+import tachyon.Version;
 import tachyon.collections.Pair;
 import tachyon.collections.PrefixList;
 import tachyon.conf.TachyonConf;
@@ -230,7 +231,7 @@ public final class UfsUtils {
   }
 
   public static void printUsage() {
-    String cmd = "java -cp " + Constants.TACHYON_JAR + " tachyon.client.UfsUtils ";
+    String cmd = "java -cp " + Version.TACHYON_JAR + " tachyon.client.UfsUtils ";
 
     System.out.println("Usage: " + cmd + "<TachyonPath> <UfsPath> "
         + "[<Optional ExcludePathPrefix, separated by ;>]");

--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -333,9 +333,5 @@ public final class Constants {
   public static final String SECURITY_AUTHENTICATION_CUSTOM_PROVIDER =
       "tachyon.security.authentication.custom.provider.class";
 
-  // Relative path to Tachyon target jar
-  public static final String TACHYON_JAR = "target/tachyon-" + Version.VERSION
-      + "-jar-with-dependencies.jar";
-
   private Constants() {} // prevent instantiation
 }

--- a/common/src/main/java/tachyon/Version.java
+++ b/common/src/main/java/tachyon/Version.java
@@ -28,6 +28,10 @@ public final class Version {
     VERSION = tachyonConf.get(Constants.TACHYON_VERSION);
   }
 
+  // Relative path to Tachyon target jar
+  public static final String TACHYON_JAR = "target/tachyon-" + VERSION
+      + "-jar-with-dependencies.jar";
+
   public static void main(String[] args) {
     System.out.println("Tachyon version: " + VERSION);
   }

--- a/examples/src/main/java/tachyon/examples/BasicCheckpoint.java
+++ b/examples/src/main/java/tachyon/examples/BasicCheckpoint.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
+import tachyon.Version;
 import tachyon.client.file.FileInStream;
 import tachyon.client.file.TachyonFile;
 import tachyon.client.file.TachyonFileSystem;
@@ -93,7 +94,7 @@ public class BasicCheckpoint implements Callable<Boolean> {
 
   public static void main(String[] args) throws IOException {
     if (args.length != 3) {
-      System.out.println("java -cp " + Constants.TACHYON_JAR
+      System.out.println("java -cp " + Version.TACHYON_JAR
           + " tachyon.examples.BasicCheckpoint <TachyonMasterAddress> <FileFolder> <Files>");
       System.exit(-1);
     }

--- a/examples/src/main/java/tachyon/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/tachyon/examples/BasicNonByteBufferOperations.java
@@ -22,6 +22,7 @@ import java.util.concurrent.Callable;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
+import tachyon.Version;
 import tachyon.client.ClientContext;
 import tachyon.client.TachyonStorageType;
 import tachyon.client.UnderStorageType;
@@ -150,7 +151,7 @@ public final class BasicNonByteBufferOperations implements Callable<Boolean> {
   }
 
   private static void usage() {
-    System.out.println("java -cp " + Constants.TACHYON_JAR + " "
+    System.out.println("java -cp " + Version.TACHYON_JAR + " "
         + BasicNonByteBufferOperations.class.getName() + " <master address> <file path> "
         + "<tachyon storage type for writes (STORE | NO_STORE)> "
         + "<under storage type for writes (SYNC_PERSIST | NO_PERSIST)> "

--- a/examples/src/main/java/tachyon/examples/BasicOperations.java
+++ b/examples/src/main/java/tachyon/examples/BasicOperations.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
+import tachyon.Version;
 import tachyon.client.ClientContext;
 import tachyon.client.TachyonStorageType;
 import tachyon.client.UnderStorageType;
@@ -104,7 +105,7 @@ public class BasicOperations implements Callable<Boolean> {
 
   public static void main(String[] args) throws IllegalArgumentException {
     if (args.length != 4) {
-      System.out.println("java -cp " + Constants.TACHYON_JAR + " " + BasicOperations.class.getName()
+      System.out.println("java -cp " + Version.TACHYON_JAR + " " + BasicOperations.class.getName()
           + " <under storage type for writes (SYNC_PERSIST|NO_PERSIST)>");
       System.exit(-1);
     }

--- a/examples/src/main/java/tachyon/examples/BasicRawTableOperations.java
+++ b/examples/src/main/java/tachyon/examples/BasicRawTableOperations.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
+import tachyon.Version;
 import tachyon.client.ReadType;
 import tachyon.client.TachyonFS;
 import tachyon.client.TachyonFile;
@@ -132,7 +133,7 @@ public class BasicRawTableOperations implements Callable<Boolean> {
 
   public static void main(String[] args) throws IllegalArgumentException {
     if (args.length != 4) {
-      System.out.println("java -cp " + Constants.TACHYON_JAR + " "
+      System.out.println("java -cp " + Version.TACHYON_JAR + " "
           + BasicRawTableOperations.class.getName() + " <master address> <file path> "
           + "<tachyon storage type for writes (STORE|NO_STORE)> "
           + "<under storage type for writes (SYNC_PERSIST|NO_PERSIST)");

--- a/examples/src/main/java/tachyon/examples/Performance.java
+++ b/examples/src/main/java/tachyon/examples/Performance.java
@@ -34,6 +34,7 @@ import com.google.common.base.Throwables;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
+import tachyon.Version;
 import tachyon.client.ClientContext;
 import tachyon.client.file.FileOutStream;
 import tachyon.client.file.TachyonFile;
@@ -499,7 +500,7 @@ public class Performance {
 
   public static void main(String[] args) throws Exception {
     if (args.length != 9) {
-      System.out.println("java -cp " + Constants.TACHYON_JAR
+      System.out.println("java -cp " + Version.TACHYON_JAR
           + " tachyon.examples.Performance "
           + "<MasterIp> <FileNamePrefix> <WriteBlockSizeInBytes> <BlocksPerFile> "
           + "<DebugMode:true/false> <Threads> <FilesPerThread> <TestCaseNumber> "

--- a/servers/src/main/java/tachyon/Format.java
+++ b/servers/src/main/java/tachyon/Format.java
@@ -30,7 +30,7 @@ import tachyon.util.io.PathUtils;
  */
 public class Format {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-  private static final String USAGE = "java -cp " + Constants.TACHYON_JAR
+  private static final String USAGE = "java -cp " + Version.TACHYON_JAR
       + " tachyon.Format <MASTER/WORKER>";
 
   private static boolean formatFolder(String name, String folder, TachyonConf tachyonConf)

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -56,7 +56,7 @@ public class TachyonMaster {
 
   public static void main(String[] args) {
     if (args.length != 0) {
-      LOG.info("java -cp " + Constants.TACHYON_JAR + " tachyon.Master");
+      LOG.info("java -cp " + Version.TACHYON_JAR + " tachyon.Master");
       System.exit(-1);
     }
 


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1193

`Constants` should be a dependency sink - it should not depend on other classes.

The build was breaking because `Constants` is used by `NetworkAddressUtils` to initialize its logger,
but `Constants` depended statically on `Version` which depended statically on initializing a `TachyonConf`, which used `NetworkAddressUtils` in its construction. This created a circular dependency starting and ending with `NetworkAddressUtils`, as you can see in the stack trace:

```
java.lang.ExceptionInInitializerError: null
	at tachyon.util.network.NetworkAddressUtils.getLocalIpAddress(NetworkAddressUtils.java:356)
	at tachyon.util.network.NetworkAddressUtils.getLocalHostName(NetworkAddressUtils.java:320)
	at tachyon.conf.TachyonConf.<init>(TachyonConf.java:122)
	at tachyon.conf.TachyonConf.<init>(TachyonConf.java:111)
	at tachyon.Version.<clinit>(Version.java:27)
	at tachyon.Constants.<clinit>(Constants.java:337)
	at tachyon.util.network.NetworkAddressUtils.<clinit>(NetworkAddressUtils.java:53)
	at tachyon.network.protocol.RPCMessageIntegrationTest.beforeClass(RPCMessageIntegrationTest.java:107)```