### PR TITLE
[TACHYON-1196] Enable FindBugs to prevent static circular dependencies

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 

--- a/build/findbugs/findbugs-include.xml
+++ b/build/findbugs/findbugs-include.xml
@@ -1,0 +1,6 @@
+<FindBugsFilter>
+  <Match>
+    <!-- IC: Initialization circularity -->
+    <Bug code="IC" />
+  </Match>
+</FindBugsFilter>

--- a/clients/client/pom.xml
+++ b/clients/client/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -18,6 +18,5 @@
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 </project>

--- a/clients/unshaded/pom.xml
+++ b/clients/unshaded/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 
   <dependencies>

--- a/integration/mesos/pom.xml
+++ b/integration/mesos/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -20,6 +20,5 @@
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 </project>

--- a/integration/yarn/pom.xml
+++ b/integration/yarn/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -375,17 +375,33 @@
         </executions>
       </plugin>
 
-      <!-- Find Bugs -->
+      <!-- FindBugs -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.5.2</version>
+        <version>3.0.2</version>
         <configuration>
           <excludeFilterFile>${findbugs.path}findbugs-exclude.xml</excludeFilterFile>
+          <includeFilterFile>${findbugs.path}findbugs-include.xml</includeFilterFile>
+          <!--
+              Enables analysis which takes more memory but finds more bugs.
+              If you run out of memory, changes the value of the effort element
+              to 'Low'.
+            -->
+          <effort>Max</effort>
+          <failOnError>true</failOnError>
+          <threshold>Low</threshold>
           <findbugsXmlOutput>true</findbugsXmlOutput>
           <xmlOutput>true</xmlOutput>
-          <effort>Max</effort>
         </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- Checkstyle -->

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <apache.curator.version>2.1.0-incubating</apache.curator.version>
     <checkstyle.path>build/checkstyle/</checkstyle.path>
     <cxf.version>2.7.0</cxf.version>
-    <findbugs.path>build/findbugs/</findbugs.path>
+    <findbugs.path>build/findbugs</findbugs.path>
     <glusterfs-hadoop.version>2.3.13</glusterfs-hadoop.version>
     <hadoop.version>2.2.0</hadoop.version>
     <java.version>1.6</java.version>
@@ -381,8 +381,8 @@
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>3.0.2</version>
         <configuration>
-          <excludeFilterFile>${findbugs.path}findbugs-exclude.xml</excludeFilterFile>
-          <includeFilterFile>${findbugs.path}findbugs-include.xml</includeFilterFile>
+          <excludeFilterFile>${findbugs.path}/findbugs-exclude.xml</excludeFilterFile>
+          <includeFilterFile>${findbugs.path}/findbugs-include.xml</includeFilterFile>
           <!--
               Enables analysis which takes more memory but finds more bugs.
               If you run out of memory, changes the value of the effort element

--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
         </configuration>
         <executions>
           <execution>
-            <phase>verify</phase>
+            <phase>compile</phase>
             <goals>
               <goal>check</goal>
             </goals>

--- a/servers/pom.xml
+++ b/servers/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 
   <dependencies>

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -13,7 +13,6 @@
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
     <failIfNoTests>false</failIfNoTests>
   </properties>
 

--- a/underfs/glusterfs/pom.xml
+++ b/underfs/glusterfs/pom.xml
@@ -12,7 +12,6 @@
   <properties>
     <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 
   <dependencies>

--- a/underfs/hdfs/pom.xml
+++ b/underfs/hdfs/pom.xml
@@ -12,7 +12,6 @@
   <properties>
     <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 
   <dependencies>

--- a/underfs/local/pom.xml
+++ b/underfs/local/pom.xml
@@ -12,7 +12,6 @@
   <properties>
     <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 
   <dependencies>

--- a/underfs/pom.xml
+++ b/underfs/pom.xml
@@ -21,6 +21,5 @@
   <properties>
     <license.header.path>${project.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 </project>

--- a/underfs/s3/pom.xml
+++ b/underfs/s3/pom.xml
@@ -12,7 +12,6 @@
   <properties>
     <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 
   <dependencies>

--- a/underfs/swift/pom.xml
+++ b/underfs/swift/pom.xml
@@ -12,7 +12,6 @@
   <properties>
     <license.header.path>${project.parent.parent.basedir}/build/license/</license.header.path>
     <checkstyle.path>${project.parent.parent.basedir}/build/checkstyle/</checkstyle.path>
-    <findbugs.path>${project.parent.parent.basedir}/build/findbugs/</findbugs.path>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1196

On my local machine this added around 1.5 minutes to the build, but was able to detect the cyclic dependency issue we had recently (https://tachyon.atlassian.net/browse/TACHYON-1193)