### PR TITLE
[TACHYON-1176] Remove unused variables in TachyonFileSystemIntegrationTest

### DIFF
--- a/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
@@ -50,8 +50,6 @@ public class TachyonFileSystemIntegrationTest {
   private static final int WORKER_CAPACITY_BYTES = 20000;
   private static final int USER_QUOTA_UNIT_BYTES = 1000;
   private static LocalTachyonCluster sLocalTachyonCluster = null;
-  private static String sHost = null;
-  private static int sPort = -1;
   private static TachyonFileSystem sTfs = null;
   private static InStreamOptions sReadCache;
   private static OutStreamOptions sWriteBoth;
@@ -81,8 +79,7 @@ public class TachyonFileSystemIntegrationTest {
         new LocalTachyonCluster(WORKER_CAPACITY_BYTES, USER_QUOTA_UNIT_BYTES, Constants.GB);
     sLocalTachyonCluster.start();
     sTfs = sLocalTachyonCluster.getClient();
-    sHost = sLocalTachyonCluster.getMasterHostname();
-    sPort = sLocalTachyonCluster.getMasterPort();
+
     sWriteBoth =
         new OutStreamOptions.Builder(sLocalTachyonCluster.getMasterTachyonConf())
             .setTachyonStorageType(TachyonStorageType.STORE)


### PR DESCRIPTION
Hi, 
Removing the unused variables from TachyonFileSystemIntegrationTest (that are listed in the JIRA issue).

Removing other unused variables like sReadCache and mWorkerTachyonConf resulted in tests not passing. 