### PR TITLE
[SMALLFIX] Remove duplicated javadoc param in lineage.

### DIFF
--- a/servers/src/main/java/tachyon/master/lineage/meta/Lineage.java
+++ b/servers/src/main/java/tachyon/master/lineage/meta/Lineage.java
@@ -57,7 +57,6 @@ public final class Lineage implements JournalEntryRepresentable {
    *
    * @param id the lineage id
    * @param inputFiles the input files
-   * @param inputFiles the input files
    * @param outputFiles the output files
    * @param job the job
    * @param creationTimeMs the creation time


### PR DESCRIPTION
We only need to document it once.