### PR TITLE
[SMALLFIX] Mock FileSystemContext.INSTANCE instead of mContext

### DIFF
--- a/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/clients/unshaded/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -102,9 +102,9 @@ public class FileInStreamTest {
     }
     mInfo.setBlockIds(blockIds);
 
+    Whitebox.setInternalState(FileSystemContext.class, "INSTANCE", mContext);
     mTestStream = new FileInStream(mInfo, new InStreamOptions.Builder(ClientContext.getConf())
         .setTachyonStorageType(TachyonStorageType.PROMOTE).build());
-    Whitebox.setInternalState(mTestStream, "mContext", mContext);
   }
 
   @After
@@ -283,8 +283,8 @@ public class FileInStreamTest {
   @Test
   public void failToUnderFsTest() throws IOException {
     mInfo.setIsPersisted(true).setUfsPath("testUfsPath");
+    Whitebox.setInternalState(FileSystemContext.class, "INSTANCE", mContext);
     mTestStream = new FileInStream(mInfo, InStreamOptions.defaults());
-    Whitebox.setInternalState(mTestStream, "mContext", mContext);
 
     Mockito.when(mBlockStore.getInStream(1L)).thenThrow(new IOException("test IOException"));
     UnderFileSystem ufs = ClientMockUtils.mockUnderFileSystem(Mockito.eq("testUfsPath"));


### PR DESCRIPTION
When possible it is better to avoid messing with the contents of the
test FileInStream