### PR TITLE
[SMALLFIX] Simplify flaky JsonJournalFormatterTest

### DIFF
--- a/servers/src/test/java/tachyon/master/journal/JsonJournalFormatterTest.java
+++ b/servers/src/test/java/tachyon/master/journal/JsonJournalFormatterTest.java
@@ -15,8 +15,8 @@
 
 package tachyon.master.journal;
 
-import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Map;
 
 import org.junit.Before;
@@ -41,8 +41,8 @@ public class JsonJournalFormatterTest extends JournalFormatterTestBase {
   @Override
   @Before
   public void before() throws Exception {
-    String entriesFile = JsonJournalFormatterTest.class.getResource(JSON_SAMPLE_PATH).getFile();
-    mRootNode = new ObjectMapper().readTree(new File(entriesFile));
+    URL entriesURL = JsonJournalFormatterTest.class.getResource(JSON_SAMPLE_PATH);
+    mRootNode = new ObjectMapper().readTree(entriesURL);
     super.before();
   }
 


### PR DESCRIPTION
The test was sometimes failing to find `"/home/jenkins/workspace/Tachyon-Pull-Request-Builder%403/servers/target/test-classes/tachyon/master/journal/JsonJournalEntries.json"`. I suspect that something is going wrong with our handling of a filename with `%` in it, so we will give Jackson the `URL` directly and see if the test continues to flake.