### PR TITLE
[SMALLFIX] Add and fix TTL javadocs

### DIFF
--- a/servers/src/main/java/tachyon/master/file/meta/InodeFile.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeFile.java
@@ -71,6 +71,9 @@ public final class InodeFile extends Inode {
       return this;
     }
 
+    /**
+     * Sets the ttl in milliseconds.
+     */
     public Builder setTTL(long ttl) {
       mTTL = ttl;
       return this;
@@ -160,7 +163,7 @@ public final class InodeFile extends Inode {
   }
 
   /**
-   * @param ttl the TTL to use
+   * @param ttl the TTL to use, in milliseconds
    */
   public void setTTL(long ttl) {
     mTTL = ttl;

--- a/servers/src/main/java/tachyon/master/file/meta/options/CreatePathOptions.java
+++ b/servers/src/main/java/tachyon/master/file/meta/options/CreatePathOptions.java
@@ -91,7 +91,7 @@ public class CreatePathOptions {
     }
 
     /**
-     * @param ttl the TTL (time to live) value to use; it identifies duration (in seconds) the
+     * @param ttl the TTL (time to live) value to use; it identifies duration (in milliseconds) the
      *            created file should be kept around before it is automatically deleted
      * @return the builder
      */

--- a/servers/src/main/java/tachyon/master/file/options/CreateOptions.java
+++ b/servers/src/main/java/tachyon/master/file/options/CreateOptions.java
@@ -80,7 +80,7 @@ public final class CreateOptions {
     }
 
     /**
-     * @param ttl the TTL (time to live) value to use; it identifies duration (in seconds) the
+     * @param ttl the TTL (time to live) value to use; it identifies duration (in milliseconds) the
      *        created file should be kept around before it is automatically deleted
      * @return the builder
      */


### PR DESCRIPTION
We should also change these methods to include the time unit in the name, e.g. setTtlMs.

@calvinjia Do you think it makes sense to deprecate setTTL() and recommend setTtlMs()?