### PR TITLE
[SMALLFIX] Fix broken build of developer profile 

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -12,11 +12,6 @@
   <name>Tachyon Integration</name>
   <description>Parent POM for different integrations with Tachyon</description>
 
-  <modules>
-    <module>mesos</module>
-    <module>yarn</module>
-  </modules>
-
   <properties>
     <!-- These need to be defined here as well as in the parent pom so that mvn can run
          properly from sub-project directories -->

--- a/integration/yarn/pom.xml
+++ b/integration/yarn/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-client</artifactId>
-      <version>${yarn.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/integration/yarn/pom.xml
+++ b/integration/yarn/pom.xml
@@ -44,6 +44,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-client</artifactId>
+      <version>${yarn.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/integration/yarn/pom.xml
+++ b/integration/yarn/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-client</artifactId>
-      <version>${yarn.version}</version>
+      <version>${hadoop.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
     <slf4j.version>1.7.2</slf4j.version>
     <test.output.redirect>true</test.output.redirect>
     <hadoop-openstack.version>2.6.0</hadoop-openstack.version>
+    <yarn.version>2.6.0</yarn.version>
   </properties>
 
   <modules>
@@ -225,6 +226,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-yarn-client</artifactId>
+        <version>${yarn.version}</version>
       </dependency>
 
       <!-- Test Dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
     <module>shell</module>
     <module>examples</module>
     <module>integration-tests</module>
+    <module>integration</module>
     <module>assembly</module>
     <module>minicluster</module>
   </modules>
@@ -586,7 +587,8 @@
     <profile>
       <id>developer</id>
       <modules>
-        <module>integration</module>
+        <module>integration/yarn</module>
+        <module>integration/mesos</module>
       </modules>
       <properties>
         <hadoop.version>2.6.0</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -228,11 +228,6 @@
         <artifactId>slf4j-log4j12</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.hadoop</groupId>
-        <artifactId>hadoop-yarn-client</artifactId>
-        <version>${yarn.version}</version>
-      </dependency>
 
       <!-- Test Dependencies -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,6 @@
     <slf4j.version>1.7.2</slf4j.version>
     <test.output.redirect>true</test.output.redirect>
     <hadoop-openstack.version>2.6.0</hadoop-openstack.version>
-    <yarn.version>2.6.0</yarn.version>
   </properties>
 
   <modules>
@@ -567,15 +566,12 @@
       </modules>
     </profile>
 
+    <!-- Requires hadoop.version to be 2.4.0 or later -->
     <profile>
       <id>yarn</id>
       <modules>
         <module>integration/yarn</module>
       </modules>
-      <properties>
-        <!-- Requires hadoop.version to be 2.4.0 or later -->
-        <yarn.version>${hadoop.version}</yarn.version>
-      </properties>
     </profile>
 
     <!-- profile that Tachyon developers should use -->
@@ -587,7 +583,6 @@
       </modules>
       <properties>
         <hadoop.version>2.6.0</hadoop.version>
-        <yarn.version>${hadoop.version}</yarn.version>
       </properties>
     </profile>
 


### PR DESCRIPTION
When compiling with developer profile, assembly/ failed due to undefined `${yarn.version}` in `integration/yarn/pom.xml`. Moving this definition into the dependency management session of parent pom.