### PR TITLE
[SMALLFIX] Prevent possible flakiness in createFileWithTTLTest

### DIFF
--- a/servers/src/test/java/tachyon/master/file/FileSystemMasterTest.java
+++ b/servers/src/test/java/tachyon/master/file/FileSystemMasterTest.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -28,6 +27,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -138,11 +138,14 @@ public final class FileSystemMasterTest {
 
   @Test
   public void createFileWithTTLTest() throws Exception {
+    final long ttlMs = 1;
     CreateOptions options =
         new CreateOptions.Builder(MasterContext.getConf()).setBlockSizeBytes(Constants.KB)
-            .setRecursive(true).setTTL(1).build();
+            .setRecursive(true).setTTL(ttlMs).build();
     long fileId = mFileSystemMaster.create(NESTED_FILE_URI, options);
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(fileId);
+    // Make sure that the TTL expires before we activate the TTL cleanup thread.
+    Thread.sleep(ttlMs + 1);
     Assert.assertEquals(fileInfo.fileId, fileId);
     // Wait for the TTL check executor to be ready to execute its heartbeat.
     Assert.assertTrue(HeartbeatScheduler.await(HeartbeatContext.MASTER_TTL_CHECK, 1,


### PR DESCRIPTION
Trying to prevent flakes like https://amplab.cs.berkeley.edu/jenkins/job/Tachyon-Pull-Request-Builder/org.tachyonproject$tachyon-servers/6495/testReport/junit/tachyon.master.file/FileSystemMasterTest/createFileWithTTLTest/

If the JVM is having a *really* good day, it could run TTL cleanup before the 1ms TTL in the test has expired, causing the test to fail as in the linked example.