### PR TITLE
[TACHYON-1167] Significantly speed up integration tests

### DIFF
--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -101,6 +101,7 @@ public final class Constants {
   public static final String IN_TEST_MODE = "tachyon.test.mode";
   public static final String NETWORK_HOST_RESOLUTION_TIMEOUT_MS =
       "tachyon.network.host.resolution.timeout.ms";
+  public static final String THRIFT_STOP_TIMEOUT_SECONDS = "tachyon.thrift.stop.timeout.seconds";
   public static final String UNDERFS_GLUSTERFS_IMPL = "tachyon.underfs.glusterfs.impl";
   public static final String UNDERFS_GLUSTERFS_VOLUMES = "tachyon.underfs.glusterfs.volumes";
   public static final String UNDERFS_GLUSTERFS_MOUNTS = "tachyon.underfs.glusterfs.mounts";

--- a/common/src/main/resources/tachyon-default.properties
+++ b/common/src/main/resources/tachyon-default.properties
@@ -26,6 +26,7 @@ tachyon.max.table.metadata.bytes=5MB
 tachyon.metrics.conf.file=${tachyon.home}/conf/metrics.properties
 tachyon.network.host.resolution.timeout.ms=5000
 tachyon.test.mode=false
+tachyon.thrift.stop.timeout.seconds=60
 tachyon.underfs.address=${tachyon.home}/underFSStorage
 tachyon.underfs.glusterfs.impl=org.apache.hadoop.fs.glusterfs.GlusterFileSystem
 tachyon.underfs.glusterfs.mapred.system.dir=glusterfs:///mapred/system

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
@@ -148,6 +148,7 @@ public final class LocalTachyonCluster {
     testConf.set(Constants.MASTER_TTLCHECKER_INTERVAL_MS, Integer.toString(1000));
     testConf.set(Constants.MASTER_WORKER_THREADS_MIN, "1");
     testConf.set(Constants.MASTER_WORKER_THREADS_MAX, "100");
+    testConf.set(Constants.THRIFT_STOP_TIMEOUT_SECONDS, "0");
 
     // If tests fail to connect they should fail early rather than using the default ridiculously
     // high retries

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -22,6 +22,7 @@ import org.apache.thrift.TMultiplexedProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TServer;
 import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.server.TThreadPoolServer.Args;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TTransportFactory;
 import org.slf4j.Logger;
@@ -351,11 +352,11 @@ public class TachyonMaster {
     }
 
     // create master thrift service with the multiplexed processor.
-    mMasterServiceServer =
-        new TThreadPoolServer(new TThreadPoolServer.Args(mTServerSocket)
-            .maxWorkerThreads(mMaxWorkerThreads).minWorkerThreads(mMinWorkerThreads)
-            .processor(processor).transportFactory(transportFactory)
-            .protocolFactory(new TBinaryProtocol.Factory(true, true)));
+    Args args = new TThreadPoolServer.Args(mTServerSocket).maxWorkerThreads(mMaxWorkerThreads)
+        .minWorkerThreads(mMinWorkerThreads).processor(processor).transportFactory(transportFactory)
+        .protocolFactory(new TBinaryProtocol.Factory(true, true));
+    args.stopTimeoutVal = MasterContext.getConf().getInt(Constants.THRIFT_STOP_TIMEOUT_SECONDS);
+    mMasterServiceServer = new TThreadPoolServer(args);
 
     // start thrift rpc server
     mIsServing = true;

--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Executors;
 
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TThreadPoolServer;
+import org.apache.thrift.server.TThreadPoolServer.Args;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.TTransportFactory;
@@ -330,10 +331,11 @@ public final class BlockWorker {
     } catch (IOException ioe) {
       throw Throwables.propagate(ioe);
     }
-    return new TThreadPoolServer(new TThreadPoolServer.Args(mThriftServerSocket)
-        .minWorkerThreads(minWorkerThreads).maxWorkerThreads(maxWorkerThreads).processor(processor)
-        .transportFactory(tTransportFactory)
-        .protocolFactory(new TBinaryProtocol.Factory(true, true)));
+    Args args = new TThreadPoolServer.Args(mThriftServerSocket).minWorkerThreads(minWorkerThreads)
+        .maxWorkerThreads(maxWorkerThreads).processor(processor).transportFactory(tTransportFactory)
+        .protocolFactory(new TBinaryProtocol.Factory(true, true));
+    args.stopTimeoutVal = WorkerContext.getConf().getInt(Constants.THRIFT_STOP_TIMEOUT_SECONDS);
+    return new TThreadPoolServer(args);
   }
 
   /**


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1167

The default Thrift TThreadPoolServer timeout is 60 seconds. This was causing our
integration tests to wait until all outstanding RPCs were resolved before
completing. As a result, we were spending half of our integration test time
waiting for the Thrift server to stop. This commit fixes this by making the
timeout configurable via TachyonConf, and setting it to 0 for tests.