### PR TITLE
[TACHYON-1205]: make equals() implementaion consistent

### DIFF
--- a/common/src/main/java/tachyon/TachyonURI.java
+++ b/common/src/main/java/tachyon/TachyonURI.java
@@ -144,10 +144,14 @@ public final class TachyonURI implements Comparable<TachyonURI> {
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof TachyonURI)) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || !(o instanceof TachyonURI)) {
       return false;
     }
-    return mUri.equals(((TachyonURI) o).mUri);
+    TachyonURI that = (TachyonURI) o;
+    return mUri.equals(that.mUri);
   }
 
   /**

--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -209,15 +209,15 @@ public final class TachyonConf {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
-    if (obj instanceof TachyonConf) {
-      Properties props = ((TachyonConf) obj).getInternalProperties();
-      return mProperties.equals(props);
+    if (o == null || !(o instanceof TachyonConf)) {
+      return false;
     }
-    return false;
+    TachyonConf that = (TachyonConf) o;
+    return mProperties.equals(that.mProperties);
   }
 
   /**

--- a/common/src/main/java/tachyon/security/User.java
+++ b/common/src/main/java/tachyon/security/User.java
@@ -37,11 +37,14 @@ public final class User implements Principal {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    } else {
-      return mName.equals(((User) o).mName);
+    if (this == o) {
+      return true;
     }
+    if (o == null || !(o instanceof User)) {
+      return false;
+    }
+    User that = (User) o;
+    return mName.equals(that.mName);
   }
 
   @Override

--- a/servers/src/main/java/tachyon/SessionInfo.java
+++ b/servers/src/main/java/tachyon/SessionInfo.java
@@ -60,11 +60,11 @@ public class SessionInfo {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (o == null || !(o instanceof SessionInfo)) {
       return false;
     }
-    SessionInfo sessionInfo = (SessionInfo) o;
-    return mSessionId == sessionInfo.mSessionId;
+    SessionInfo that = (SessionInfo) o;
+    return mSessionId == that.mSessionId;
   }
 
   @Override

--- a/servers/src/main/java/tachyon/master/block/journal/BlockContainerIdGeneratorEntry.java
+++ b/servers/src/main/java/tachyon/master/block/journal/BlockContainerIdGeneratorEntry.java
@@ -55,7 +55,10 @@ public class BlockContainerIdGeneratorEntry extends JournalEntry {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || getClass() != o.getClass()) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || !(o instanceof BlockContainerIdGeneratorEntry)) {
       return false;
     }
     BlockContainerIdGeneratorEntry that = (BlockContainerIdGeneratorEntry) o;

--- a/servers/src/main/java/tachyon/master/block/journal/BlockInfoEntry.java
+++ b/servers/src/main/java/tachyon/master/block/journal/BlockInfoEntry.java
@@ -67,7 +67,10 @@ public class BlockInfoEntry extends JournalEntry {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || getClass() != o.getClass()) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || !(o instanceof BlockInfoEntry)) {
       return false;
     }
     BlockInfoEntry that = (BlockInfoEntry) o;

--- a/servers/src/main/java/tachyon/master/file/meta/Inode.java
+++ b/servers/src/main/java/tachyon/master/file/meta/Inode.java
@@ -133,10 +133,14 @@ public abstract class Inode implements JournalEntryRepresentable {
 
   @Override
   public synchronized boolean equals(Object o) {
-    if (!(o instanceof Inode)) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || !(o instanceof Inode)) {
       return false;
     }
-    return mId == ((Inode) o).mId;
+    Inode that = (Inode) o;
+    return mId == that.mId;
   }
 
   /**

--- a/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
@@ -505,17 +505,21 @@ public final class InodeTree implements JournalCheckpointStreamable {
   }
 
   @Override
-  public boolean equals(Object object) {
-    if (object instanceof InodeTree) {
-      InodeTree that = (InodeTree) object;
-      return Objects.equal(mRoot, that.mRoot) && Objects.equal(mIdIndex, that.mIdIndex)
-          && Objects.equal(mInodes, that.mInodes)
-          && Objects.equal(mPinnedInodeFileIds, that.mPinnedInodeFileIds)
-          && Objects.equal(mContainerIdGenerator, that.mContainerIdGenerator)
-          && Objects.equal(mDirectoryIdGenerator, that.mDirectoryIdGenerator)
-          && Objects.equal(mCachedInode, that.mCachedInode);
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
     }
-    return false;
+    if (o == null || !(o instanceof InodeTree)) {
+      return false;
+    }
+    InodeTree that = (InodeTree) o;
+    return Objects.equal(mRoot, that.mRoot)
+        && Objects.equal(mIdIndex, that.mIdIndex)
+        && Objects.equal(mInodes, that.mInodes)
+        && Objects.equal(mPinnedInodeFileIds, that.mPinnedInodeFileIds)
+        && Objects.equal(mContainerIdGenerator, that.mContainerIdGenerator)
+        && Objects.equal(mDirectoryIdGenerator, that.mDirectoryIdGenerator)
+        && Objects.equal(mCachedInode, that.mCachedInode);
   }
 
   private TraversalResult traverseToInode(String[] pathComponents, boolean persist)

--- a/servers/src/main/java/tachyon/master/file/meta/TTLBucket.java
+++ b/servers/src/main/java/tachyon/master/file/meta/TTLBucket.java
@@ -112,20 +112,19 @@ public final class TTLBucket implements Comparable<TTLBucket> {
   /**
    * Compares to a specific object.
    *
-   * @param object the object to compare
+   * @param o the object to compare
    * @return true if object is also {@link TTLBucket} and represents the same TTLIntervalStartTime
    */
   @Override
-  public boolean equals(Object object) {
-    if (this == object) {
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
-
-    if (object == null || getClass() != object.getClass()) {
+    if (o == null || !(o instanceof TTLBucket)) {
       return false;
     }
-
-    return mTTLIntervalStartTimeMs == ((TTLBucket) object).mTTLIntervalStartTimeMs;
+    TTLBucket that = (TTLBucket) o;
+    return mTTLIntervalStartTimeMs == that.mTTLIntervalStartTimeMs;
   }
 
   /**

--- a/servers/src/main/java/tachyon/worker/block/BlockStoreLocation.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockStoreLocation.java
@@ -114,14 +114,19 @@ public final class BlockStoreLocation {
   /**
    * Compares to a specific object.
    *
-   * @param object the object to compare
+   * @param o the object to compare
    * @return true if object is also {@link BlockStoreLocation} and represents the same tier and dir
    */
   @Override
-  public boolean equals(Object object) {
-    return object instanceof BlockStoreLocation
-        && ((BlockStoreLocation) object).tierAlias().equals(tierAlias())
-        && ((BlockStoreLocation) object).dir() == dir();
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || !(o instanceof BlockStoreLocation)) {
+      return false;
+    }
+    BlockStoreLocation that = (BlockStoreLocation) o;
+    return mTierAlias.equals(that.mTierAlias) && mDirIndex == that.mDirIndex;
   }
 
   @Override


### PR DESCRIPTION
https://tachyon.atlassian.net/projects/TACHYON/issues/TACHYON-1205

This commit updated all equals() implementations to have same style with following exceptions:
- thrift classes since they are auto-generated;
- TachyonFile class since it has been deprecated
- Pair.java since it is generics