### PR TITLE
[SMALLFIX] Remove unwrap

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/file/AbstractTachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/AbstractTachyonFileSystem.java
@@ -37,7 +37,6 @@ import tachyon.client.file.options.OpenOptions;
 import tachyon.client.file.options.RenameOptions;
 import tachyon.client.file.options.SetStateOptions;
 import tachyon.client.file.options.UnmountOptions;
-import tachyon.exception.BlockInfoException;
 import tachyon.exception.ExceptionMessage;
 import tachyon.exception.FileAlreadyExistsException;
 import tachyon.exception.FileDoesNotExistException;
@@ -72,8 +71,6 @@ public abstract class AbstractTachyonFileSystem implements TachyonFileSystemCore
     try {
       final long fileId = masterClient.create(path.getPath(), options);
       return new TachyonFile(fileId);
-    } catch (BlockInfoException e) {
-      throw new FileAlreadyExistsException(e.getMessage(), e);
     } finally {
       mContext.releaseMasterClient(masterClient);
     }

--- a/clients/unshaded/src/main/java/tachyon/client/file/AbstractTachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/AbstractTachyonFileSystem.java
@@ -73,7 +73,7 @@ public abstract class AbstractTachyonFileSystem implements TachyonFileSystemCore
       final long fileId = masterClient.create(path.getPath(), options);
       return new TachyonFile(fileId);
     } catch (BlockInfoException e) {
-        throw new FileAlreadyExistsException(e.getMessage(), e);
+      throw new FileAlreadyExistsException(e.getMessage(), e);
     } finally {
       mContext.releaseMasterClient(masterClient);
     }

--- a/clients/unshaded/src/main/java/tachyon/client/lineage/AbstractLineageClient.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/AbstractLineageClient.java
@@ -65,9 +65,6 @@ public abstract class AbstractLineageClient implements LineageClient {
           stripURIList(outputFiles), (CommandLineJob) job);
       LOG.info("Created lineage " + lineageId);
       return lineageId;
-    } catch (TachyonException e) {
-      TachyonException.unwrap(e, FileDoesNotExistException.class);
-      throw e;
     } finally {
       mContext.releaseMasterClient(masterClient);
     }
@@ -81,10 +78,6 @@ public abstract class AbstractLineageClient implements LineageClient {
       boolean result = masterClient.deleteLineage(lineageId, options.isCascade());
       LOG.info(result ? "Succeeded to " : "Failed to " + "delete lineage " + lineageId);
       return result;
-    } catch (TachyonException e) {
-      TachyonException.unwrap(e, LineageDoesNotExistException.class);
-      TachyonException.unwrap(e, LineageDeletionException.class);
-      throw e;
     } finally {
       mContext.releaseMasterClient(masterClient);
     }

--- a/clients/unshaded/src/main/java/tachyon/client/lineage/TachyonLineageFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/TachyonLineageFileSystem.java
@@ -64,9 +64,6 @@ public class TachyonLineageFileSystem extends TachyonFileSystem {
           masterClient.reinitializeFile(path.getPath(), options.getBlockSizeBytes(),
               options.getTTL());
       return fileId;
-    } catch (TachyonException e) {
-      TachyonException.unwrap(e, LineageDoesNotExistException.class);
-      throw e;
     } finally {
       mContext.releaseMasterClient(masterClient);
     }
@@ -97,9 +94,6 @@ public class TachyonLineageFileSystem extends TachyonFileSystem {
     LineageMasterClient masterClient = mContext.acquireMasterClient();
     try {
       masterClient.reportLostFile(path.getPath());
-    } catch (TachyonException e) {
-      TachyonException.unwrap(e, FileDoesNotExistException.class);
-      throw e;
     } finally {
       mContext.releaseMasterClient(masterClient);
     }

--- a/clients/unshaded/src/main/java/tachyon/client/lineage/TachyonLineageFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/TachyonLineageFileSystem.java
@@ -60,9 +60,8 @@ public class TachyonLineageFileSystem extends TachyonFileSystem {
       throws LineageDoesNotExistException, IOException, TachyonException {
     LineageMasterClient masterClient = mContext.acquireMasterClient();
     try {
-      long fileId =
-          masterClient.reinitializeFile(path.getPath(), options.getBlockSizeBytes(),
-              options.getTTL());
+      long fileId = masterClient.reinitializeFile(path.getPath(), options.getBlockSizeBytes(),
+          options.getTTL());
       return fileId;
     } finally {
       mContext.releaseMasterClient(masterClient);
@@ -89,8 +88,8 @@ public class TachyonLineageFileSystem extends TachyonFileSystem {
     return new LineageFileOutStream(fileId, options);
   }
 
-  public void reportLostFile(TachyonURI path) throws IOException, FileDoesNotExistException,
-      TachyonException {
+  public void reportLostFile(TachyonURI path)
+      throws IOException, FileDoesNotExistException, TachyonException {
     LineageMasterClient masterClient = mContext.acquireMasterClient();
     try {
       masterClient.reportLostFile(path.getPath());

--- a/common/src/main/java/tachyon/exception/TachyonException.java
+++ b/common/src/main/java/tachyon/exception/TachyonException.java
@@ -85,19 +85,4 @@ public abstract class TachyonException extends Exception {
         + "constructor: " + reflectError.getMessage();
     throw new IllegalStateException(errorMessage);
   }
-
-  /**
-   * Checks if the given exception is an instance of the given derived class and if so, downcasts
-   * the exception and throws it.
-   *
-   * @param e the {@link TachyonException}
-   * @param throwClass the type of exception to throw e is of the right type
-   * @throws T if e is of type T
-   */
-  public static <T extends TachyonException> void unwrap(TachyonException e, Class<T> throwClass)
-      throws T {
-    if (throwClass.isInstance(e)) {
-      throw throwClass.cast(e);
-    }
-  }
 }


### PR DESCRIPTION
Followup to https://github.com/amplab/tachyon/pull/1787, which changed exception handling so that `TachyonException`s are never wrapped. After https://github.com/amplab/tachyon/pull/1787, any `unwrap(e, type)` followed by `throw e` does nothing at all and is a waste of cycles.