### PR TITLE
Revert a80cbb2dcaa4d526287e04929d25f1da1bf61ed9

### DIFF
--- a/deploy/vagrant/provision/playbook.yml
+++ b/deploy/vagrant/provision/playbook.yml
@@ -84,10 +84,6 @@
   tasks:
     - include: roles/ufs_{{ ufs }}/tasks/start.yml
 
-    # The Tachyon client needs to be distributed to run mapreduce against Tachyon.
-    - include: roles/ufs_{{ ufs }}/tasks/distribute_tachyon_client.yml
-      when: (ufs == "hadoop1") or (ufs == "hadoop2")
-
 # Start Tachyon on the specified platform(e.x. standalone, mesos)
 - include: start_tachyon_on_{{ tachyon_platform }}.yml
 

--- a/deploy/vagrant/provision/roles/ufs_hadoop1/tasks/distribute_tachyon_client.yml
+++ b/deploy/vagrant/provision/roles/ufs_hadoop1/tasks/distribute_tachyon_client.yml
@@ -1,4 +1,0 @@
-- name: distribute tachyon client
-  shell: /tachyon/bin/tachyon-workers.sh cp /tachyon/clients/client/target/tachyon-client-*-jar-with-dependencies.jar /hadoop/lib/
-
-# vim :set filetype=ansible.yaml:

--- a/deploy/vagrant/provision/roles/ufs_hadoop2/tasks/distribute_tachyon_client.yml
+++ b/deploy/vagrant/provision/roles/ufs_hadoop2/tasks/distribute_tachyon_client.yml
@@ -1,4 +1,0 @@
-- name: distribute tachyon client
-  shell: /tachyon/bin/tachyon-workers.sh cp /tachyon/clients/client/target/tachyon-client-*-jar-with-dependencies.jar /hadoop/share/hadoop/common/lib/
-
-# vim :set filetype=ansible.yaml:


### PR DESCRIPTION
Reverts amplab/tachyon#1914

After this PR, vagrant deploys client jar to `$HADOOP_CLASSPATH` on starting the EC2 instances. However, it also makes `start-yarn.sh` fail to work. Revert this PR for now.