### PR TITLE
[SMALLFIX] Remove tachyon-underfs-glusterfs from client uber jar

### DIFF
--- a/clients/client/pom.xml
+++ b/clients/client/pom.xml
@@ -96,17 +96,22 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon-underfs-glusterfs</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.tachyonproject</groupId>
-          <artifactId>tachyon-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
+    <!-- module tachyon-underfs-glusterfs depends on
+         hadoop library of 2.3.0, which may have problem when using with
+         hadoop 2.4 and later. Please check instructions in
+         http://tachyon-project.org/documentation/Configuring-Tachyon-with-GlusterFS.html
+         for how to use glusterfs with Tachyon. -->
+    <!-- <dependency> -->
+    <!--   <groupId>org.tachyonproject</groupId> -->
+    <!--   <artifactId>tachyon-underfs-glusterfs</artifactId> -->
+    <!--   <version>${project.version}</version> -->
+    <!--   <exclusions> -->
+    <!--     <exclusion> -->
+    <!--       <groupId>org.tachyonproject</groupId> -->
+    <!--       <artifactId>tachyon-common</artifactId> -->
+    <!--     </exclusion> -->
+    <!--   </exclusions> -->
+    <!-- </dependency> -->
     <dependency>
       <groupId>org.tachyonproject</groupId>
       <artifactId>tachyon-underfs-s3</artifactId>


### PR DESCRIPTION
The reason of this PR is because `tachyon-underfs-glusterfs` depends on some library in hadoop 2.3.0. 
```
[INFO] +- org.tachyonproject:tachyon-underfs-glusterfs:jar:0.9.0-SNAPSHOT:compile
[INFO] |  \- org.gluster:glusterfs-hadoop:jar:2.3.13:compile
[INFO] |     \- org.apache.hadoop:hadoop-yarn-server-nodemanager:jar:2.3.0:compile
```
Once this client jar is in `$HADOOP_PATH` (which is not really required for Tachyon to work but may happen by mistakes), people may see the following error to stop YARN namenode to start if hadoop version > 2.4.0
```
************************************************************/
2015-11-09 10:46:48,382 INFO org.apache.hadoop.yarn.server.nodemanager.NodeManager: registered UNIX signal handlers for [TERM, HUP, INT]
2015-11-09 10:46:48,586 FATAL org.apache.hadoop.yarn.YarnUncaughtExceptionHandler: Thread Thread[main,5,main] threw an Error.  Shutting down now...
java.lang.NoSuchMethodError: org.apache.hadoop.http.HttpConfig.setPolicy(Lorg/apache/hadoop/http/HttpConfig$Policy;)V
        at org.apache.hadoop.yarn.server.nodemanager.NodeManager.setHttpPolicy(NodeManager.java:405)
        at org.apache.hadoop.yarn.server.nodemanager.NodeManager.main(NodeManager.java:400)
2015-11-09 10:46:48,588 INFO org.apache.hadoop.util.ExitUtil: Exiting with status -1
2015-11-09 10:46:48,589 INFO org.apache.hadoop.yarn.server.nodemanager.NodeManager: SHUTDOWN_MSG:
/************************************************************
SHUTDOWN_MSG: Shutting down NodeManager at Bins-MacBook-Pro.local/192.168.1.12
************************************************************/
```

To run Tachyon on Gluster FS, please follow http://tachyon-project.org/documentation/Configuring-Tachyon-with-GlusterFS.html.