### PR TITLE
[SMALLFIX] Improve error when incomplete tachyon uri is specified

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.util.Progressable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import tachyon.Constants;
@@ -341,6 +342,8 @@ abstract class AbstractTFS extends FileSystem {
    */
   @Override
   public void initialize(URI uri, Configuration conf) throws IOException {
+    Preconditions.checkNotNull(uri.getHost(), "URI hostname must not be null");
+    Preconditions.checkNotNull(uri.getPort(), "URI post must not be null");
     super.initialize(uri, conf);
     LOG.info("initialize(" + uri + ", " + conf + "). Connecting to Tachyon: " + uri.toString());
     Utils.addS3Credentials(conf);


### PR DESCRIPTION
Previously if a user created the client with a url like tachyon:///path/to/data or
tachyon://localhost/path/to/data, missing either hostname or port, they would get
a NullPointerException or complaint about port -1 being invalid.