### PR TITLE
[SMALLFIX] Move mLocation into RemoteBlockInStream

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/block/BufferedBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/block/BufferedBlockInStream.java
@@ -17,7 +17,6 @@ package tachyon.client.block;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
 import com.google.common.base.Preconditions;
@@ -47,8 +46,6 @@ public abstract class BufferedBlockInStream extends BlockInStream {
   protected final long mBlockId;
   /** The size in bytes of the block. */
   protected final long mBlockSize;
-  /** The address of the worker to read the data from. */
-  protected final InetSocketAddress mLocation;
 
   /** Internal buffer to improve small read performance. */
   protected ByteBuffer mBuffer;
@@ -64,10 +61,9 @@ public abstract class BufferedBlockInStream extends BlockInStream {
    * @param location worker address to read the block from
    */
   // TODO(calvin): Get the block lock here when the remote instream locks at a stream level
-  public BufferedBlockInStream(long blockId, long blockSize, InetSocketAddress location) {
+  public BufferedBlockInStream(long blockId, long blockSize) {
     mBlockId = blockId;
     mBlockSize = blockSize;
-    mLocation = location;
     mBuffer = allocateBuffer();
     mBufferIsValid = false; // No data in buffer
     mClosed = false;

--- a/clients/unshaded/src/main/java/tachyon/client/block/LocalBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/block/LocalBlockInStream.java
@@ -17,7 +17,6 @@ package tachyon.client.block;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
@@ -31,8 +30,8 @@ import tachyon.worker.WorkerClient;
 
 /**
  * This class provides a streaming API to read a block in Tachyon. The data will be directly read
- * from the local machine's storage. The instances of this class should only be used by one
- * thread and are not thread safe.
+ * from the local machine's storage. The instances of this class should only be used by one thread
+ * and are not thread safe.
  */
 public final class LocalBlockInStream extends BufferedBlockInStream {
   /** Helper to manage closables. */
@@ -50,9 +49,8 @@ public final class LocalBlockInStream extends BufferedBlockInStream {
    * @param blockId the block id
    * @throws IOException if I/O error occurs
    */
-  public LocalBlockInStream(long blockId, long blockSize, InetSocketAddress location)
-      throws IOException {
-    super(blockId, blockSize, location);
+  public LocalBlockInStream(long blockId, long blockSize) throws IOException {
+    super(blockId, blockSize);
     mContext = BlockStoreContext.INSTANCE;
 
     mCloser = Closer.create();

--- a/clients/unshaded/src/main/java/tachyon/client/block/RemoteBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/block/RemoteBlockInStream.java
@@ -28,6 +28,9 @@ import tachyon.client.RemoteBlockReader;
  * used by one thread and are not thread safe.
  */
 public final class RemoteBlockInStream extends BufferedBlockInStream {
+  /** The address of the worker to read the data from. */
+  private final InetSocketAddress mLocation;
+
   /**
    * Creates a new remote block input stream.
    *
@@ -37,7 +40,8 @@ public final class RemoteBlockInStream extends BufferedBlockInStream {
    */
   // TODO(calvin): Modify the locking so the stream owns the lock instead of the data server.
   public RemoteBlockInStream(long blockId, long blockSize, InetSocketAddress location) {
-    super(blockId, blockSize, location);
+    super(blockId, blockSize);
+    mLocation = location;
   }
 
   @Override

--- a/clients/unshaded/src/main/java/tachyon/client/block/TachyonBlockStore.java
+++ b/clients/unshaded/src/main/java/tachyon/client/block/TachyonBlockStore.java
@@ -20,8 +20,8 @@ import java.net.InetSocketAddress;
 
 import tachyon.client.BlockMasterClient;
 import tachyon.client.ClientContext;
-import tachyon.exception.TachyonException;
 import tachyon.exception.ExceptionMessage;
+import tachyon.exception.TachyonException;
 import tachyon.thrift.BlockInfo;
 import tachyon.thrift.NetAddress;
 import tachyon.util.network.NetworkAddressUtils;
@@ -96,7 +96,7 @@ public final class TachyonBlockStore {
       if (NetworkAddressUtils.getLocalHostName(ClientContext.getConf()).equals(
           workerAddr.getHostName())) {
         if (mContext.hasLocalWorker()) {
-          return new LocalBlockInStream(blockId, blockInfo.getLength(), workerAddr);
+          return new LocalBlockInStream(blockId, blockInfo.getLength());
         } else {
           throw new IOException(ExceptionMessage.NO_LOCAL_WORKER.getMessage("read"));
         }

--- a/clients/unshaded/src/test/java/tachyon/client/block/TestBufferedBlockInStream.java
+++ b/clients/unshaded/src/test/java/tachyon/client/block/TestBufferedBlockInStream.java
@@ -27,7 +27,7 @@ public class TestBufferedBlockInStream extends BufferedBlockInStream {
   private final byte[] mData;
 
   public TestBufferedBlockInStream(long blockId, int start, long blockSize) {
-    super(blockId, blockSize, null);
+    super(blockId, blockSize);
     mData = BufferUtils.getIncreasingByteArray(start, (int) blockSize);
   }
 


### PR DESCRIPTION
The protected field is never used in the abstract class or any other
subclasses, so we might as well move it to RemoteBlockInStream