### PR TITLE
[TACHYON-1329] Mitigate thread contention at resource getting

### DIFF
--- a/common/src/main/java/tachyon/resource/ResourcePool.java
+++ b/common/src/main/java/tachyon/resource/ResourcePool.java
@@ -15,10 +15,10 @@
 
 package tachyon.resource;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-
-import com.google.common.base.Preconditions;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Class representing a pool of resources to be temporarily used and returned. Inheriting classes
@@ -29,10 +29,11 @@ import com.google.common.base.Preconditions;
  * @param <T> the type of resource this pool manages
  */
 public abstract class ResourcePool<T> {
-  protected final Object mCapacityLock;
+  private final ReentrantLock mTakeLock;
+  private final Condition mNotEmpty;
   protected final int mMaxCapacity;
-  protected final BlockingQueue<T> mResources;
-  protected int mCurrentCapacity;
+  protected final ConcurrentLinkedQueue<T> mResources;
+  protected final AtomicInteger mCurrentCapacity;
 
   /**
    * Creates a {@link ResourcePool} instance with the specified capacity.
@@ -40,7 +41,7 @@ public abstract class ResourcePool<T> {
    * @param maxCapacity the maximum of resources in this pool
    */
   public ResourcePool(int maxCapacity) {
-    this(maxCapacity, new LinkedBlockingQueue<T>(maxCapacity));
+    this(maxCapacity, new ConcurrentLinkedQueue<T>());
   }
 
   /**
@@ -49,11 +50,11 @@ public abstract class ResourcePool<T> {
    * @param maxCapacity bhe maximum of resources in this pool
    * @param resources blocking queue to use
    */
-  protected ResourcePool(int maxCapacity, BlockingQueue<T> resources) {
-    Preconditions.checkArgument(maxCapacity > 0, "Capacity must be non-negative");
-    mCapacityLock = new Object();
+  protected ResourcePool(int maxCapacity, ConcurrentLinkedQueue<T> resources) {
+    mTakeLock = new ReentrantLock();
+    mNotEmpty = mTakeLock.newCondition();
     mMaxCapacity = maxCapacity;
-    mCurrentCapacity = 0;
+    mCurrentCapacity = new AtomicInteger();
     mResources = resources;
   }
 
@@ -66,19 +67,33 @@ public abstract class ResourcePool<T> {
    */
   public T acquire() {
     // If the resource pool is empty but capacity is not yet full, create a new resource.
-    synchronized (mCapacityLock) {
-      if (mResources.isEmpty() && mCurrentCapacity < mMaxCapacity) {
-        T newResource = createNewResource();
-        mCurrentCapacity ++;
-        return newResource;
-      }
+    T resource = mResources.poll();
+    if (resource != null) {
+      return resource;
     }
+
+    if (mCurrentCapacity.getAndIncrement() < mMaxCapacity) {
+      return createNewResource();
+    }
+
+    mCurrentCapacity.decrementAndGet();
 
     // Otherwise, try to take a resource from the pool, blocking if none are available.
     try {
-      return mResources.take();
+      mTakeLock.lockInterruptibly();
+      try {
+        while (true) {
+          resource = mResources.poll();
+          if (resource != null) {
+            mNotEmpty.signal();
+            return resource;
+          }
+          mNotEmpty.await();
+        }
+      } finally {
+        mTakeLock.unlock();
+      }
     } catch (InterruptedException ie) {
-      // TODO(calvin): Investigate the best way to handle this.
       throw new RuntimeException(ie);
     }
   }
@@ -97,6 +112,12 @@ public abstract class ResourcePool<T> {
    */
   public void release(T resource) {
     mResources.add(resource);
+    mTakeLock.lock();
+    try {
+      mNotEmpty.signal();
+    } finally {
+      mTakeLock.unlock();
+    }
   }
 
   /**

--- a/common/src/main/java/tachyon/resource/ResourcePool.java
+++ b/common/src/main/java/tachyon/resource/ResourcePool.java
@@ -66,13 +66,14 @@ public abstract class ResourcePool<T> {
    * @return a resource taken from the pool
    */
   public T acquire() {
-    // If the resource pool is empty but capacity is not yet full, create a new resource.
+    // Try to take a resource without blocking
     T resource = mResources.poll();
     if (resource != null) {
       return resource;
     }
 
     if (mCurrentCapacity.getAndIncrement() < mMaxCapacity) {
+      // If the resource pool is empty but capacity is not yet full, create a new resource.
       return createNewResource();
     }
 
@@ -85,7 +86,6 @@ public abstract class ResourcePool<T> {
         while (true) {
           resource = mResources.poll();
           if (resource != null) {
-            mNotEmpty.signal();
             return resource;
           }
           mNotEmpty.await();

--- a/common/src/test/java/tachyon/resource/ResourcePoolTest.java
+++ b/common/src/test/java/tachyon/resource/ResourcePoolTest.java
@@ -15,8 +15,7 @@
 
 package tachyon.resource;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -38,7 +37,7 @@ public class ResourcePoolTest {
       super(maxCapacity);
     }
 
-    public TestResourcePool(int maxCapacity, BlockingQueue<Integer> resources) {
+    public TestResourcePool(int maxCapacity, ConcurrentLinkedQueue<Integer> resources) {
       super(maxCapacity, resources);
     }
 
@@ -68,10 +67,10 @@ public class ResourcePoolTest {
     mThrown.expect(RuntimeException.class);
     final int POOL_SIZE = 2;
     @SuppressWarnings("unchecked")
-    LinkedBlockingQueue<Integer> queue = Mockito.mock(LinkedBlockingQueue.class);
+    ConcurrentLinkedQueue<Integer> queue = Mockito.mock(ConcurrentLinkedQueue.class);
     TestResourcePool testPool = new TestResourcePool(POOL_SIZE, queue);
     Mockito.when(queue.isEmpty()).thenReturn(true);
-    Mockito.when(queue.take()).thenThrow(new InterruptedException());
+    Mockito.when(queue.poll()).thenThrow(new InterruptedException());
     for (int i = 0; i < POOL_SIZE + 1; i ++) {
       testPool.acquire();
     }


### PR DESCRIPTION
Even with the following configuration, I sometimes got starvation at resource getting.

```
tachyonConf.set(Constants.USER_FILE_MASTER_CLIENT_THREADS, Integer.toString(50000));
tachyonConf.set(Constants.USER_BLOCK_MASTER_CLIENT_THREADS, Integer.toString(50000));
```

By first checking available resource without synchronization, we could mitigate thread contention somewhat.