### PR TITLE
[TACHYON-1278] Extend socket timeout to fix build

### DIFF
--- a/common/src/main/java/tachyon/security/authentication/AuthenticationUtils.java
+++ b/common/src/main/java/tachyon/security/authentication/AuthenticationUtils.java
@@ -103,7 +103,6 @@ public final class AuthenticationUtils {
    * @return An unconnected socket
    */
   public static TSocket createTSocket(InetSocketAddress address, int timeoutMs) {
-    // TODO(gpang): make the timeout configurable.
     return new TSocket(NetworkAddressUtils.getFqdnHost(address), address.getPort(), timeoutMs);
   }
 

--- a/common/src/main/resources/tachyon-default.properties
+++ b/common/src/main/resources/tachyon-default.properties
@@ -55,7 +55,7 @@ tachyon.integration.worker.resource.mem=1024MB
 
 # Security properties
 tachyon.security.authentication.type=NOSASL
-tachyon.security.authentication.socket.timeout.ms=30000
+tachyon.security.authentication.socket.timeout.ms=60000
 
 # Master properties
 tachyon.master.bind.host=0.0.0.0


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1278

Logging revealed that `createRawTable` is taking the server ~32 seconds, but our socket timeout of 30 seconds ruins everything.