### PR TITLE
[SMALLFIX] Prevent flakiness in ServiceSocketBindIntegrationTest

### DIFF
--- a/integration-tests/src/test/java/tachyon/master/ServiceSocketBindIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/ServiceSocketBindIntegrationTest.java
@@ -62,7 +62,7 @@ public class ServiceSocketBindIntegrationTest {
     mMasterTachyonConf = mLocalTachyonCluster.getMasterTachyonConf();
     mWorkerTachyonConf = mLocalTachyonCluster.getWorkerTachyonConf();
     // sleep to wait for services to start.
-    // TODO(andrew) change LocalTachyonCluster.start() to block until all services have started
+    // TODO(TACHYON-1324) change LocalTachyonCluster.start() to block until all services have started
     CommonUtils.sleepMs(200);
   }
 

--- a/integration-tests/src/test/java/tachyon/master/ServiceSocketBindIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/ServiceSocketBindIntegrationTest.java
@@ -31,6 +31,7 @@ import tachyon.LocalTachyonClusterResource;
 import tachyon.client.block.BlockMasterClient;
 import tachyon.client.block.BlockStoreContext;
 import tachyon.conf.TachyonConf;
+import tachyon.util.CommonUtils;
 import tachyon.util.network.NetworkAddressUtils;
 import tachyon.util.network.NetworkAddressUtils.ServiceType;
 import tachyon.worker.WorkerClient;
@@ -60,6 +61,9 @@ public class ServiceSocketBindIntegrationTest {
     mLocalTachyonCluster = mLocalTachyonClusterResource.get();
     mMasterTachyonConf = mLocalTachyonCluster.getMasterTachyonConf();
     mWorkerTachyonConf = mLocalTachyonCluster.getWorkerTachyonConf();
+    // sleep to wait for services to start.
+    // TODO(andrew) change LocalTachyonCluster.start() to block until all services have started
+    CommonUtils.sleepMs(200);
   }
 
   private void connectServices() throws IOException {

--- a/integration-tests/src/test/java/tachyon/master/ServiceSocketBindIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/ServiceSocketBindIntegrationTest.java
@@ -62,7 +62,7 @@ public class ServiceSocketBindIntegrationTest {
     mMasterTachyonConf = mLocalTachyonCluster.getMasterTachyonConf();
     mWorkerTachyonConf = mLocalTachyonCluster.getWorkerTachyonConf();
     // sleep to wait for services to start.
-    // TODO(TACHYON-1324) change LocalTachyonCluster.start() to block until all services have started
+    // TODO(TACHYON-1324) change LocalTachyonCluster.start() to wait until all services have started
     CommonUtils.sleepMs(200);
   }
 


### PR DESCRIPTION
Sometimes the services are too slow to start and Jenkins fails with something like

```
listenEmptyTest(tachyon.master.ServiceSocketBindIntegrationTest)  Time elapsed: 0.561 sec  <<< ERROR!
java.net.ConnectException: Connection refused
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:339)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:579)
	at java.net.Socket.connect(Socket.java:528)
	at sun.net.NetworkClient.doConnect(NetworkClient.java:180)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:432)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:527)
	at sun.net.www.http.HttpClient.<init>(HttpClient.java:211)
	at sun.net.www.http.HttpClient.New(HttpClient.java:308)
	at sun.net.www.http.HttpClient.New(HttpClient.java:326)
	at sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:996)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:932)
	at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:850)
	at tachyon.master.ServiceSocketBindIntegrationTest.connectServices(ServiceSocketBindIntegrationTest.java:94)
	at tachyon.master.ServiceSocketBindIntegrationTest.listenEmptyTest(ServiceSocketBindIntegrationTest.java:108)
```