### PR TITLE
[SMALLFIX] Prevent flakiness in getCapacityBytesTest()

### DIFF
--- a/integration-tests/src/test/java/tachyon/master/file/FileSystemMasterIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/file/FileSystemMasterIntegrationTest.java
@@ -39,11 +39,11 @@ import tachyon.Constants;
 import tachyon.LocalTachyonClusterResource;
 import tachyon.TachyonURI;
 import tachyon.conf.TachyonConf;
+import tachyon.exception.DirectoryNotEmptyException;
 import tachyon.exception.ExceptionMessage;
 import tachyon.exception.FileAlreadyExistsException;
 import tachyon.exception.FileDoesNotExistException;
 import tachyon.exception.InvalidPathException;
-import tachyon.exception.DirectoryNotEmptyException;
 import tachyon.master.MasterContext;
 import tachyon.master.MasterTestUtils;
 import tachyon.master.block.BlockMaster;
@@ -510,6 +510,10 @@ public class FileSystemMasterIntegrationTest {
   public void getCapacityBytesTest() {
     BlockMaster blockMaster =
         mLocalTachyonClusterResource.get().getMaster().getInternalMaster().getBlockMaster();
+    // Sleep to give the workers time to register with the master
+    // TODO(andrew): Remove this when mLocalTachyonClusterResource.start() blocks until workers have
+    // registered with master.
+    CommonUtils.sleepMs(200);
     Assert.assertEquals(1000, blockMaster.getCapacityBytes());
   }
 


### PR DESCRIPTION
Temporary fix for errors like

```
getCapacityBytesTest(tachyon.master.file.FileSystemMasterIntegrationTest)  Time elapsed: 0.001 sec  <<< FAILURE!
java.lang.AssertionError: expected:<1000> but was:<0>
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:645)
	at org.junit.Assert.assertEquals(Assert.java:631)
	at tachyon.master.file.FileSystemMasterIntegrationTest.getCapacityBytesTest(FileSystemMasterIntegrationTest.java:513)
```

Eventually we should improve `LocalTachyonClusterResource` to properly wait for everything to start.