### PR TITLE
[SMALLFIX] Add mention in startup script about where logs are going

### DIFF
--- a/bin/tachyon-start.sh
+++ b/bin/tachyon-start.sh
@@ -101,7 +101,7 @@ start_master() {
     $LAUNCHER $bin/tachyon format
   fi
 
-  echo "Starting master @ $MASTER_ADDRESS"
+  echo "Starting master @ $MASTER_ADDRESS. Logging to $TACHYON_LOGS_DIR"
   (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logs.dir=$TACHYON_LOGS_DIR -Dtachyon.logger.type="MASTER_LOGGER" -Dtachyon.accesslogger.type="MASTER_ACCESS_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_MASTER_JAVA_OPTS tachyon.master.TachyonMaster > $TACHYON_LOGS_DIR/master.out 2>&1) &
 }
 
@@ -116,7 +116,7 @@ start_worker() {
     TACHYON_WORKER_JAVA_OPTS=$TACHYON_JAVA_OPTS
   fi
 
-  echo "Starting worker @ `hostname -f`"
+  echo "Starting worker @ `hostname -f`. Logging to $TACHYON_LOGS_DIR"
   (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logs.dir=$TACHYON_LOGS_DIR -Dtachyon.logger.type="WORKER_LOGGER" -Dtachyon.accesslogger.type="WORKER_ACCESS_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker > $TACHYON_LOGS_DIR/worker.out 2>&1 ) &
 }
 
@@ -127,7 +127,7 @@ restart_worker() {
 
   RUN=`ps -ef | grep "tachyon.worker.TachyonWorker" | grep "java" | wc | cut -d" " -f7`
   if [[ $RUN -eq 0 ]] ; then
-    echo "Restarting worker @ `hostname -f`"
+    echo "Restarting worker @ `hostname -f`. Logging to $TACHYON_LOGS_DIR"
     (nohup $JAVA -cp $CLASSPATH -Dtachyon.home=$TACHYON_HOME -Dtachyon.logs.dir=$TACHYON_LOGS_DIR -Dtachyon.logger.type="WORKER_LOGGER" -Dtachyon.accesslogger.type="WORKER_ACCESS_LOGGER" -Dlog4j.configuration=file:$TACHYON_CONF_DIR/log4j.properties $TACHYON_WORKER_JAVA_OPTS tachyon.worker.TachyonWorker > $TACHYON_LOGS_DIR/worker.out 2>&1) &
   fi
 }


### PR DESCRIPTION
Previously if the master or worker failed to start, it was difficult to figure out why without reading the tachyon-start script.