### PR TITLE
[SMALLFIX] Fixed link in documentation in 'GreedyAllocator'

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/allocator/GreedyAllocator.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/GreedyAllocator.java
@@ -41,8 +41,10 @@ public final class GreedyAllocator implements Allocator {
   }
 
   /**
-   * Should only be accessed by {@link allocateBlockWithView} inside class. Allocates a block from
-   * the given block store location. The location can be a specific location, or
+   * Should only be accessed by
+   * {@link #allocateBlockWithView(long, long, BlockStoreLocation, BlockMetadataManagerView)}
+   * inside class. Allocates a block from the given block store location. The location can be a
+   * specific location, or
    * {@link BlockStoreLocation#anyTier()} or {@link BlockStoreLocation#anyDirInTier(String)}.
    *
    * @param sessionId the ID of session to apply for the block allocation


### PR DESCRIPTION
Fixed problems in JavaDoc references in ```GreedyAllocator```.