### PR TITLE
[SMALLFIX] Added missing bracket in Javadoc in 'ReplayCache'

### DIFF
--- a/common/src/main/java/tachyon/replay/ReplayCache.java
+++ b/common/src/main/java/tachyon/replay/ReplayCache.java
@@ -111,7 +111,7 @@ public final class ReplayCache<V> {
 
   /**
    * Same with {@link ReplayCallable} except that this handler method throws {@link IOException} and
-   * is to be executed in {@link #run(String, ReplayCallableThrowsIOException}.
+   * is to be executed in {@link #run(String, ReplayCallableThrowsIOException)}.
    *
    * @param <V> the return type of {@link #call()}
    */


### PR DESCRIPTION
Added a missing closing bracket in the documentation of the ```ReplayCallableThrowsIOException<V>``` interface.