### PR TITLE
[TACHYON-1333] Fixed UFS mkdir persistence

### DIFF
--- a/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
@@ -1264,8 +1264,19 @@ public final class FileSystemMaster extends MasterBase {
         MkdirOptions options = new MkdirOptions.Builder(MasterContext.getConf())
             .setRecursive(recursive).setPersisted(true).build();
         InodeTree.CreatePathResult result = mkdir(path, options);
-        List<Inode> created = result.getCreated();
-        return created.get(created.size() - 1).getId();
+        List<Inode> inodes = null;
+        if (result.getCreated().size() > 0) {
+          inodes = result.getCreated();
+        } else if (result.getPersisted().size() > 0) {
+          inodes = result.getPersisted();
+        } else if (result.getModified().size() > 0) {
+          inodes = result.getModified();
+        }
+        if (inodes == null) {
+          throw new FileAlreadyExistsException(
+              ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(path));
+        }
+        return inodes.get(inodes.size() - 1).getId();
       }
     } catch (IOException e) {
       LOG.error(ExceptionUtils.getStackTrace(e));

--- a/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
@@ -319,11 +319,11 @@ public final class InodeTree implements JournalCheckpointStreamable {
       Inode lastToPersistInode = toPersistDirectories.get(toPersistDirectories.size() - 1);
       String ufsPath = mMountTable.resolve(getPath(lastToPersistInode)).toString();
       UnderFileSystem ufs = UnderFileSystem.get(ufsPath, MasterContext.getConf());
-      // Persists only the last directory, recursively creating necessary parent directories.
-      if (ufs.mkdirs(ufsPath, true)) {
-        for (Inode inode : toPersistDirectories) {
-          inode.setPersisted(true);
-        }
+      // Persists only the last directory, recursively creating necessary parent directories. Even
+      // if the directory already exists in the ufs, we mark it as persisted.
+      ufs.mkdirs(ufsPath, true);
+      for (Inode inode : toPersistDirectories) {
+        inode.setPersisted(true);
       }
     }
 

--- a/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
@@ -321,9 +321,10 @@ public final class InodeTree implements JournalCheckpointStreamable {
       UnderFileSystem ufs = UnderFileSystem.get(ufsPath, MasterContext.getConf());
       // Persists only the last directory, recursively creating necessary parent directories. Even
       // if the directory already exists in the ufs, we mark it as persisted.
-      ufs.mkdirs(ufsPath, true);
-      for (Inode inode : toPersistDirectories) {
-        inode.setPersisted(true);
+      if (ufs.exists(ufsPath) || ufs.mkdirs(ufsPath, true)) {
+        for (Inode inode : toPersistDirectories) {
+          inode.setPersisted(true);
+        }
       }
     }
 


### PR DESCRIPTION
One case where loadMetadata would fail is when the user calls "ls" on a
directory in the UFS that hasn't been loaded yet, which creates the
inode in the tree, but doesn't mark it as persisted, because the UFS
failed to create the directory (since it already existed). Then when
they call loadMetadata, creating the directory would again try to mark
it as persisted and fail for the same reason, and loadMetadata would
crash because it expected that either a directory was created, or an
exception is thrown.

This modifies InodeTree.createPath to mark a directory as persisted
regardless of whether the ufs directory was actually created or
not (because if it was not, that means it already existed). Now
loadMetadata will throw the proper error message when the directory has
already been loaded into Tachyon.

Added a test in TfsShellTest that reproduces the error.