### PR TITLE
[SMALLFIX] Changed thrown exception in Javadoc in 'FileInStreamIntegrationTest'

### DIFF
--- a/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
@@ -202,7 +202,7 @@ public class FileInStreamIntegrationTest {
    * position.
    *
    * @throws IOException
-   * @throws TException
+   * @throws TachyonException
    */
   @Test
   public void seekExceptionTest1() throws IOException, TachyonException {


### PR DESCRIPTION
The thrown exception is ```TachyonException```, not ```TException```.