### PR TITLE
[SMALLFIX] Changed thrown exception in Javadoc in 'FileInStreamIntegrationTest'

### DIFF
--- a/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
@@ -252,7 +252,7 @@ public class FileInStreamIntegrationTest {
    * Test <code>void seek(long pos)</code>.
    *
    * @throws IOException
-   * @throws TException
+   * @throws TachyonException
    */
   @Test
   public void seekTest() throws IOException, TachyonException {

--- a/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileInStreamIntegrationTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;


### PR DESCRIPTION
The thrown exception is ```TachyonException```, not ```TException```.