### PR TITLE
[SMALLFIX] Fix javadoc errors

### DIFF
--- a/servers/src/main/java/tachyon/master/file/meta/InodeFile.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeFile.java
@@ -22,9 +22,9 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import tachyon.Constants;
-import tachyon.exception.InvalidFileSizeException;
-import tachyon.exception.FileAlreadyCompletedException;
 import tachyon.exception.BlockInfoException;
+import tachyon.exception.FileAlreadyCompletedException;
+import tachyon.exception.InvalidFileSizeException;
 import tachyon.master.block.BlockId;
 import tachyon.master.file.journal.InodeFileEntry;
 import tachyon.master.journal.JournalEntry;
@@ -156,7 +156,7 @@ public final class InodeFile extends Inode {
   }
 
   /**
-   * @oaram blockSizeBytes the block size to use
+   * @param blockSizeBytes the block size to use
    */
   public void setBlockSize(long blockSizeBytes) {
     Preconditions.checkArgument(blockSizeBytes >= 0, "Block size cannot be negative");

--- a/servers/src/main/java/tachyon/worker/package-info.java
+++ b/servers/src/main/java/tachyon/worker/package-info.java
@@ -13,14 +13,6 @@
  * The thrift service is mostly responsible for metadata operations (with a few operations that
  * effect the worker's cached memory).
  *
- * <h3>Checkpoint</h3>
- *
- * The act of moving temporary data into accessible data on {@link tachyon.underfs.UnderFileSystem}.
- * This is triggered by {@link tachyon.client.WriteType#isThrough()} operations.
- *
- * Implementation can be found at
- * {@link tachyon.worker.block.BlockDataManager#persistFile(long, long, String)}
- *
  * <h3>Cache Block</h3>
  *
  * Move's user generated blocks to the tachyon data directory. This operation expects that the


### PR DESCRIPTION
persistFile is no longer done by the worker, so we can remove the feature
from the worker package javadoc