### PR TITLE
[TACHYON-1337] Revert un-ignore of broken test

### DIFF
--- a/integration-tests/src/test/java/tachyon/hadoop/TFSRenameIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/TFSRenameIntegrationTest.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import tachyon.Constants;
@@ -212,6 +213,12 @@ public class TFSRenameIntegrationTest {
   }
 
   @Test
+  @Ignore
+  // TODO(jiri): The test logic below does not work in the presence of transparent naming.
+  // The current implementation renames files on UFS if they are marked as persisted. They are
+  // marked as persisted when they are closed. Thus, if the Tachyon path of the file being
+  // written to changes before it is closed, renaming the temporary underlying file to its final
+  // destination fails.
   public void basicRenameTest7() throws Exception {
     // Rename /dirA to /dirB, /dirA/fileA should become /dirB/fileA even if it was not closed
 


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1337

This test was unignored in https://github.com/amplab/tachyon/pull/2106, but breaks on the `hdfs1Test` profile.