### PR TITLE
[SMALLFIX] Removed unnecessary return statement in Javadoc in 'TieredBlockStoreTestUtils'

### DIFF
--- a/servers/src/test/java/tachyon/worker/block/TieredBlockStoreTestUtils.java
+++ b/servers/src/test/java/tachyon/worker/block/TieredBlockStoreTestUtils.java
@@ -113,7 +113,6 @@ public class TieredBlockStoreTestUtils {
    *        into `baseDir/tierPath`.
    * @param tierCapacity Capacity of this tier
    * @param workerDataFolder When specified it sets up the tachyon.worker.data.folder property
-   * @return The created TachyonConf
    * @throws Exception When error happens during creating temporary folder
    */
   public static void setupTachyonConfWithSingleTier(String baseDir, int tierOrdinal,


### PR DESCRIPTION
```setupTachyonConfWithSingleTier``` is a void method and does not need a ```@return``` statement in the documentation.