### PR TITLE
[SMALLFIX] Fixed return tag in documentation in 'RoundRobinAllocator'

### DIFF
--- a/servers/src/main/java/tachyon/worker/block/allocator/RoundRobinAllocator.java
+++ b/servers/src/main/java/tachyon/worker/block/allocator/RoundRobinAllocator.java
@@ -102,7 +102,7 @@ public final class RoundRobinAllocator implements Allocator {
    *
    * @param tierView: the tier to find a dir
    * @param blockSize: the requested block size
-   * @return: the index of the dir if nonnegative; -1 if fail to find a dir
+   * @return the index of the dir if nonnegative; -1 if fail to find a dir
    */
   private int getNextAvailDirInTier(StorageTierView tierView, long blockSize) {
     int dirViewIndex = mTierToLastDirMap.get(tierView);


### PR DESCRIPTION
Removed colon after ```@return``` statement in documentation for ```getNextAvailDirInTier```  method.