### PR TITLE
[TACHYON-1343] Build break for MasterClientAuthenticationIntegrationTest

### DIFF
--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -131,6 +131,7 @@ public enum ExceptionMessage {
 
   // security
   PERMISSION_IS_NULL("Permission cannot be null when constructing PermissionStatus"),
+  AUTHORIZED_CLIENT_USER_IS_NULL("The client user is not authorized so as to be null in server"),
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;
 

--- a/common/src/main/java/tachyon/security/authentication/PlainSaslServer.java
+++ b/common/src/main/java/tachyon/security/authentication/PlainSaslServer.java
@@ -115,9 +115,6 @@ public final class PlainSaslServer implements SaslServer {
         throw new SaslException("AuthorizeCallback authorized failure");
       }
       mAuthorizationId = authCallback.getAuthorizedID();
-
-      // After verification succeeds, a user with this authz id will be set to a Threadlocal.
-      AuthorizedClientUser.set(mAuthorizationId);
     } catch (Exception e) {
       throw new SaslException("Plain authentication failed: " + e.getMessage(), e);
     }
@@ -206,6 +203,9 @@ public final class PlainSaslServer implements SaslServer {
 
       if (ac != null) {
         ac.setAuthorized(true);
+
+        // After verification succeeds, a user with this authz id will be set to a Threadlocal.
+        AuthorizedClientUser.set(ac.getAuthorizedID());
       }
     }
   }

--- a/common/src/main/java/tachyon/security/authorization/PermissionStatus.java
+++ b/common/src/main/java/tachyon/security/authorization/PermissionStatus.java
@@ -21,6 +21,7 @@ import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.ExceptionMessage;
 import tachyon.security.LoginUser;
+import tachyon.security.User;
 import tachyon.security.authentication.AuthType;
 import tachyon.security.authentication.PlainSaslServer;
 
@@ -117,7 +118,11 @@ public final class PermissionStatus {
     }
     if (remote) {
       // get the username through the authentication mechanism
-      return new PermissionStatus(PlainSaslServer.AuthorizedClientUser.get().getName(),
+      User user = PlainSaslServer.AuthorizedClientUser.get();
+      if (user == null) {
+        throw new IOException(ExceptionMessage.AUTHORIZED_CLIENT_USER_IS_NULL.getMessage());
+      }
+      return new PermissionStatus(user.getName(),
           "", // TODO(dong) group permission binding into Inode
           FileSystemPermission.getDefault().applyUMask(conf));
     }


### PR DESCRIPTION
JIRA: https://tachyon.atlassian.net/browse/TACHYON-1343

Fix the issue and refine exception message.

In hdfs2Test profile, `PLAIN` mechanism is set as `org.apache.hadoop.security.SaslPlainServer`. `tachyon.security.authentication.PlainSaslServer` does not take effect. So the threadlocal user is not set by method `evaluateResponse()`. We move the setting user into callback handler, which can be executed no matter what the underlying `SaslServer` is.

@jsimsa , @apc999 
