### PR TITLE
[SMALLFIX] Changed thrown exception in Javadoc in 'LocalBlockInStreamIntegrationTest'

### DIFF
--- a/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
@@ -179,7 +179,7 @@ public class LocalBlockInStreamIntegrationTest {
    * exception for seeking a negative position.
    *
    * @throws IOException
-   * @throws TException
+   * @throws TachyonException
    */
   @Test
   public void seekExceptionTest1() throws IOException, TachyonException {
@@ -208,7 +208,7 @@ public class LocalBlockInStreamIntegrationTest {
    * exception for seeking a position that is past buffer limit.
    *
    * @throws IOException
-   * @throws TException
+   * @throws TachyonException
    */
   @Test
   public void seekExceptionTest2() throws IOException, TachyonException {

--- a/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
@@ -236,7 +236,7 @@ public class LocalBlockInStreamIntegrationTest {
    * Test {@link tachyon.client.block.LocalBlockInStream#seek(long)}.
    *
    * @throws IOException
-   * @throws TException
+   * @throws TachyonException
    */
   @Test
   public void seekTest() throws IOException, TachyonException {

--- a/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/LocalBlockInStreamIntegrationTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;


### PR DESCRIPTION
The thrown exception is ```TachyonException```, not ```TException```.