### PR TITLE
[SMALLFIX] Change deprecated method to private

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/UfsUtils.java
+++ b/clients/unshaded/src/main/java/tachyon/client/UfsUtils.java
@@ -93,11 +93,8 @@ public final class UfsUtils {
    *        mTachyonFS.
    * @param tachyonConf instance of TachyonConf
    * @throws IOException when an event that prevents the operation from completing is encountered
-   * @deprecated As of version 0.8.
-   *             Use {@link #loadUfs(TachyonURI, TachyonURI, String, TachyonConf)} instead.
    */
-  @Deprecated
-  public static void loadUfs(TachyonFileSystem tfs, TachyonURI tachyonPath, TachyonURI
+  private static void loadUfs(TachyonFileSystem tfs, TachyonURI tachyonPath, TachyonURI
       ufsAddrRootPath, PrefixList excludePathPrefix, TachyonConf tachyonConf) throws IOException,
       TachyonException {
     LOG.info("Loading to {} {} {}", tachyonPath, ufsAddrRootPath, excludePathPrefix);


### PR DESCRIPTION
@yupeng9 Nobody outside of `UfsUtils` is using this method any more, does it make sense to change it from deprecated to private?