### PR TITLE
Rename Master and Worker RPC port Constants for consistency

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/ClientContext.java
+++ b/clients/unshaded/src/main/java/tachyon/client/ClientContext.java
@@ -65,7 +65,7 @@ public final class ClientContext {
     sTachyonConf = conf;
 
     String masterHostname = Preconditions.checkNotNull(sTachyonConf.get(Constants.MASTER_HOSTNAME));
-    int masterPort = sTachyonConf.getInt(Constants.MASTER_PORT);
+    int masterPort = sTachyonConf.getInt(Constants.MASTER_RPC_PORT);
 
     sMasterAddress = new InetSocketAddress(masterHostname, masterPort);
     sClientMetrics = new ClientMetrics();

--- a/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -366,7 +366,7 @@ abstract class AbstractTFS extends FileSystem {
       mTachyonConf.merge(siteConf);
     }
     mTachyonConf.set(Constants.MASTER_HOSTNAME, uri.getHost());
-    mTachyonConf.set(Constants.MASTER_PORT, Integer.toString(uri.getPort()));
+    mTachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
     mTachyonConf.set(Constants.ZOOKEEPER_ENABLED, Boolean.toString(isZookeeperMode()));
     ClientContext.reset(mTachyonConf);
 

--- a/clients/unshaded/src/test/java/tachyon/hadoop/TFSTest.java
+++ b/clients/unshaded/src/test/java/tachyon/hadoop/TFSTest.java
@@ -95,7 +95,7 @@ public class TFSTest {
     final URI uri = URI.create(Constants.HEADER_FT + "localhost:19998/tmp/path.txt");
 
     mTachyonConf.set(Constants.MASTER_HOSTNAME, uri.getHost());
-    mTachyonConf.set(Constants.MASTER_PORT, Integer.toString(uri.getPort()));
+    mTachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
     mTachyonConf.set(Constants.ZOOKEEPER_ENABLED, "true");
     ClientContext.reset(mTachyonConf);
     mockMasterClient();
@@ -119,7 +119,7 @@ public class TFSTest {
     final URI uri = URI.create(Constants.HEADER + "localhost:19998/tmp/path.txt");
 
     mTachyonConf.set(Constants.MASTER_HOSTNAME, uri.getHost());
-    mTachyonConf.set(Constants.MASTER_PORT, Integer.toString(uri.getPort()));
+    mTachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
     mTachyonConf.set(Constants.ZOOKEEPER_ENABLED, "false");
     ClientContext.reset(mTachyonConf);
     mockMasterClient();

--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -171,7 +171,7 @@ public final class Constants {
 
   public static final String MASTER_HOSTNAME = "tachyon.master.hostname";
   public static final String MASTER_BIND_HOST = "tachyon.master.bind.host";
-  public static final String MASTER_PORT = "tachyon.master.port";
+  public static final String MASTER_RPC_PORT = "tachyon.master.port";
   public static final String MASTER_ADDRESS = "tachyon.master.address";
   public static final String MASTER_WEB_HOSTNAME = "tachyon.master.web.hostname";
   public static final String MASTER_WEB_BIND_HOST = "tachyon.master.web.bind.host";
@@ -202,7 +202,7 @@ public final class Constants {
   public static final String WORKER_MEMORY_SIZE = "tachyon.worker.memory.size";
   public static final String WORKER_HOSTNAME = "tachyon.worker.hostname";
   public static final String WORKER_BIND_HOST = "tachyon.worker.bind.host";
-  public static final String WORKER_PORT = "tachyon.worker.port";
+  public static final String WORKER_RPC_PORT = "tachyon.worker.port";
   public static final String WORKER_DATA_HOSTNAME = "tachyon.worker.data.hostname";
   public static final String WORKER_DATA_BIND_HOST = "tachyon.worker.data.bind.host";
   public static final String WORKER_DATA_PORT = "tachyon.worker.data.port";

--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -167,7 +167,7 @@ public final class TachyonConf {
 
     // Update tachyon.master_address based on if Zookeeper is used or not.
     String masterHostname = mProperties.getProperty(Constants.MASTER_HOSTNAME);
-    String masterPort = mProperties.getProperty(Constants.MASTER_PORT);
+    String masterPort = mProperties.getProperty(Constants.MASTER_RPC_PORT);
     boolean useZk = Boolean.parseBoolean(mProperties.getProperty(Constants.ZOOKEEPER_ENABLED));
     String masterAddress =
         (useZk ? Constants.HEADER_FT : Constants.HEADER) + masterHostname + ":" + masterPort;

--- a/common/src/main/java/tachyon/util/network/NetworkAddressUtils.java
+++ b/common/src/main/java/tachyon/util/network/NetworkAddressUtils.java
@@ -68,7 +68,7 @@ public final class NetworkAddressUtils {
      * Master RPC service (Thrift)
      */
     MASTER_RPC("Tachyon Master RPC service", Constants.MASTER_HOSTNAME, Constants.MASTER_BIND_HOST,
-        Constants.MASTER_PORT, Constants.DEFAULT_MASTER_PORT),
+        Constants.MASTER_RPC_PORT, Constants.DEFAULT_MASTER_PORT),
 
     /**
      * Master web service (Jetty)
@@ -81,7 +81,7 @@ public final class NetworkAddressUtils {
      * Worker RPC service (Thrift)
      */
     WORKER_RPC("Tachyon Worker RPC service", Constants.WORKER_HOSTNAME, Constants.WORKER_BIND_HOST,
-        Constants.WORKER_PORT, Constants.DEFAULT_WORKER_PORT),
+        Constants.WORKER_RPC_PORT, Constants.DEFAULT_WORKER_PORT),
 
     /**
      * Worker data service (Netty)

--- a/common/src/test/java/tachyon/conf/TachyonConfTest.java
+++ b/common/src/test/java/tachyon/conf/TachyonConfTest.java
@@ -27,7 +27,7 @@ public class TachyonConfTest {
   @AfterClass
   public static void afterClass() {
     System.clearProperty(Constants.MASTER_HOSTNAME);
-    System.clearProperty(Constants.MASTER_PORT);
+    System.clearProperty(Constants.MASTER_RPC_PORT);
     System.clearProperty(Constants.ZOOKEEPER_ENABLED);
   }
 
@@ -45,7 +45,7 @@ public class TachyonConfTest {
 
     // initialize the system properties
     System.setProperty(Constants.MASTER_HOSTNAME, "master");
-    System.setProperty(Constants.MASTER_PORT, "20001");
+    System.setProperty(Constants.MASTER_RPC_PORT, "20001");
     System.setProperty(Constants.ZOOKEEPER_ENABLED, "true");
 
     // initialize
@@ -131,7 +131,7 @@ public class TachyonConfTest {
     Assert.assertNotNull(value);
     Assert.assertEquals(NetworkAddressUtils.WILDCARD_ADDRESS, value);
 
-    int intValue = sDefaultTachyonConf.getInt(Constants.MASTER_PORT);
+    int intValue = sDefaultTachyonConf.getInt(Constants.MASTER_RPC_PORT);
     Assert.assertEquals(19998, intValue);
 
     value = sDefaultTachyonConf.get(Constants.MASTER_WEB_BIND_HOST);
@@ -164,7 +164,7 @@ public class TachyonConfTest {
     Assert.assertNotNull(value);
     Assert.assertEquals(NetworkAddressUtils.WILDCARD_ADDRESS, value);
 
-    int intValue = sDefaultTachyonConf.getInt(Constants.WORKER_PORT);
+    int intValue = sDefaultTachyonConf.getInt(Constants.WORKER_RPC_PORT);
     Assert.assertEquals(29998, intValue);
 
     value = sDefaultTachyonConf.get(Constants.WORKER_DATA_BIND_HOST);

--- a/common/src/test/java/tachyon/util/network/GetMasterWorkerAddressTest.java
+++ b/common/src/test/java/tachyon/util/network/GetMasterWorkerAddressTest.java
@@ -29,7 +29,7 @@ public class GetMasterWorkerAddressTest {
   public void getMasterAddressTest() {
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.MASTER_HOSTNAME, "RemoteMaster1");
-    conf.set(Constants.MASTER_PORT, "10000");
+    conf.set(Constants.MASTER_RPC_PORT, "10000");
     String defaultHostname = NetworkAddressUtils.getLocalHostName(conf);
     int defaultPort = Constants.DEFAULT_MASTER_PORT;
 
@@ -39,7 +39,7 @@ public class GetMasterWorkerAddressTest {
     Assert.assertEquals(new InetSocketAddress("RemoteMaster1", 10000), masterAddress);
 
     conf = new TachyonConf();
-    conf.set(Constants.MASTER_PORT, "20000");
+    conf.set(Constants.MASTER_RPC_PORT, "20000");
     // port only
     masterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
     Assert.assertEquals(new InetSocketAddress(defaultHostname, 20000), masterAddress);
@@ -59,7 +59,7 @@ public class GetMasterWorkerAddressTest {
   @Test
   public void getWorkerAddressTest() {
     TachyonConf conf = new TachyonConf();
-    conf.set(Constants.WORKER_PORT, "10001");
+    conf.set(Constants.WORKER_RPC_PORT, "10001");
 
     String defaultHostname = NetworkAddressUtils.getLocalHostName(conf);
     int defaultPort = Constants.DEFAULT_WORKER_PORT;

--- a/common/src/test/java/tachyon/util/network/NetworkAddressUtilsTest.java
+++ b/common/src/test/java/tachyon/util/network/NetworkAddressUtilsTest.java
@@ -149,7 +149,7 @@ public class NetworkAddressUtilsTest {
         workerAddress);
 
     // connect host and wildcard bind host with port
-    conf.set(Constants.WORKER_PORT, "20000");
+    conf.set(Constants.WORKER_RPC_PORT, "20000");
     workerAddress = NetworkAddressUtils.getBindAddress(service, conf);
     Assert.assertEquals(new InetSocketAddress(NetworkAddressUtils.WILDCARD_ADDRESS, 20000),
         workerAddress);

--- a/examples/src/main/java/tachyon/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/tachyon/examples/BasicNonByteBufferOperations.java
@@ -70,7 +70,7 @@ public final class BasicNonByteBufferOperations implements Callable<Boolean> {
   public Boolean call() throws Exception {
     TachyonConf tachyonConf = ClientContext.getConf();
     tachyonConf.set(Constants.MASTER_HOSTNAME, mMasterLocation.getHost());
-    tachyonConf.set(Constants.MASTER_PORT, Integer.toString(mMasterLocation.getPort()));
+    tachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(mMasterLocation.getPort()));
     ClientContext.reset(tachyonConf);
     TachyonFileSystem tachyonClient = TachyonFileSystem.TachyonFileSystemFactory.get();
     write(tachyonClient);

--- a/examples/src/main/java/tachyon/examples/BasicOperations.java
+++ b/examples/src/main/java/tachyon/examples/BasicOperations.java
@@ -62,7 +62,7 @@ public class BasicOperations implements Callable<Boolean> {
   public Boolean call() throws Exception {
     TachyonConf tachyonConf = ClientContext.getConf();
     tachyonConf.set(Constants.MASTER_HOSTNAME, mMasterLocation.getHost());
-    tachyonConf.set(Constants.MASTER_PORT, Integer.toString(mMasterLocation.getPort()));
+    tachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(mMasterLocation.getPort()));
     ClientContext.reset(tachyonConf);
     TachyonFileSystem tFS = TachyonFileSystem.TachyonFileSystemFactory.get();
     writeFile(tFS);

--- a/examples/src/main/java/tachyon/examples/Performance.java
+++ b/examples/src/main/java/tachyon/examples/Performance.java
@@ -536,7 +536,7 @@ public class Performance {
     CommonUtils.warmUpLoop();
 
     tachyonConf.set(Constants.MASTER_HOSTNAME, sMasterAddress.getHost());
-    tachyonConf.set(Constants.MASTER_PORT, Integer.toString(sMasterAddress.getPort()));
+    tachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(sMasterAddress.getPort()));
     ClientContext.reset(tachyonConf);
 
     if (testCase == 1) {

--- a/minicluster/src/main/java/tachyon/master/AbstractLocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/AbstractLocalTachyonCluster.java
@@ -117,7 +117,7 @@ public abstract class AbstractLocalTachyonCluster {
     LOG.info(actionMessage + ELLIPSIS);
     // The port should be set properly after the server has started
     while (!NetworkAddressUtils.isServing(getMaster().getRPCBindHost(),
-        getMaster().getRPCLocalPort()) || mMasterConf.getInt(Constants.MASTER_PORT) == 0) {
+        getMaster().getRPCLocalPort()) || mMasterConf.getInt(Constants.MASTER_RPC_PORT) == 0) {
       waitAndCheckTimeout(startTime, actionMessage);
     }
   }
@@ -153,7 +153,7 @@ public abstract class AbstractLocalTachyonCluster {
     LOG.info(actionMessage + ELLIPSIS);
     // The port should be set properly after the server has started
     while (!NetworkAddressUtils.isServing(mWorker.getRPCBindHost(), mWorker.getRPCLocalPort())
-        || mWorkerConf.getInt(Constants.WORKER_PORT) == 0) {
+        || mWorkerConf.getInt(Constants.WORKER_RPC_PORT) == 0) {
       waitAndCheckTimeout(startTime, actionMessage);
     }
   }
@@ -249,7 +249,7 @@ public abstract class AbstractLocalTachyonCluster {
     testConf.set(Constants.USER_BLOCK_SIZE_BYTES_DEFAULT, Integer.toString(mUserBlockSize));
     testConf.set(Constants.USER_BLOCK_REMOTE_READ_BUFFER_SIZE_BYTES, Integer.toString(64));
     testConf.set(Constants.MASTER_HOSTNAME, mHostname);
-    testConf.set(Constants.MASTER_PORT, Integer.toString(0));
+    testConf.set(Constants.MASTER_RPC_PORT, Integer.toString(0));
     testConf.set(Constants.MASTER_WEB_PORT, Integer.toString(0));
     testConf.set(Constants.MASTER_TTLCHECKER_INTERVAL_MS, Integer.toString(1000));
     testConf.set(Constants.MASTER_WORKER_THREADS_MIN, "1");
@@ -276,7 +276,7 @@ public abstract class AbstractLocalTachyonCluster {
     // TODO(binfan): eliminate this setting after updating integration tests
     testConf.set(Constants.USER_FILE_WRITE_TYPE_DEFAULT, "CACHE_THROUGH");
 
-    testConf.set(Constants.WORKER_PORT, Integer.toString(0));
+    testConf.set(Constants.WORKER_RPC_PORT, Integer.toString(0));
     testConf.set(Constants.WORKER_DATA_PORT, Integer.toString(0));
     testConf.set(Constants.WORKER_WEB_PORT, Integer.toString(0));
     testConf.set(Constants.WORKER_DATA_FOLDER, "/datastore");

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
@@ -143,7 +143,7 @@ public final class LocalTachyonCluster extends AbstractLocalTachyonCluster {
     mMaster.start();
 
     // Update the test conf with actual RPC port.
-    testConf.set(Constants.MASTER_PORT, String.valueOf(getMasterPort()));
+    testConf.set(Constants.MASTER_RPC_PORT, String.valueOf(getMasterPort()));
 
     // If we are using the LocalMiniDFSCluster, we need to update the UNDERFS_ADDRESS to point to
     // the cluster's current address. This must happen here because the cluster isn't initialized

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonClusterMultiMaster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonClusterMultiMaster.java
@@ -200,7 +200,7 @@ public class LocalTachyonClusterMultiMaster extends AbstractLocalTachyonCluster 
           master.getAddress());
       mMasters.add(master);
       // Each master should generate a new port for binding
-      mMasterConf.set(Constants.MASTER_PORT, "0");
+      mMasterConf.set(Constants.MASTER_RPC_PORT, "0");
     }
 
     // Create the UFS directory after LocalTachyonMaster construction, because LocalTachyonMaster
@@ -221,7 +221,7 @@ public class LocalTachyonClusterMultiMaster extends AbstractLocalTachyonCluster 
       }
     }
     // Use first master port
-    mMasterConf.set(Constants.MASTER_PORT, String.valueOf(getMaster().getRPCLocalPort()));
+    mMasterConf.set(Constants.MASTER_RPC_PORT, String.valueOf(getMaster().getRPCLocalPort()));
   }
 
   @Override

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
@@ -99,7 +99,7 @@ public final class LocalTachyonMaster {
     mTachyonMaster = TachyonMaster.Factory.createMaster();
 
     // Reset the master port
-    tachyonConf.set(Constants.MASTER_PORT, Integer.toString(getRPCLocalPort()));
+    tachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(getRPCLocalPort()));
 
     Runnable runMaster = new Runnable() {
       @Override

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -151,7 +151,7 @@ public class TachyonMaster {
           new TServerSocket(NetworkAddressUtils.getBindAddress(ServiceType.MASTER_RPC, conf));
       mPort = NetworkAddressUtils.getThriftPort(mTServerSocket);
       // reset master port
-      conf.set(Constants.MASTER_PORT, Integer.toString(mPort));
+      conf.set(Constants.MASTER_RPC_PORT, Integer.toString(mPort));
       mMasterAddress = NetworkAddressUtils.getConnectAddress(ServiceType.MASTER_RPC, conf);
 
       // Check the journal directory

--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -196,7 +196,7 @@ public final class BlockWorker extends WorkerBase {
     mThriftServerSocket = createThriftServerSocket();
     mPort = NetworkAddressUtils.getThriftPort(mThriftServerSocket);
     // reset worker RPC port
-    mTachyonConf.set(Constants.WORKER_PORT, Integer.toString(mPort));
+    mTachyonConf.set(Constants.WORKER_RPC_PORT, Integer.toString(mPort));
     mThriftServer = createThriftServer();
     mWorkerNetAddress =
         new NetAddress(NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC, mTachyonConf),

--- a/shell/src/main/java/tachyon/shell/TfsShellUtils.java
+++ b/shell/src/main/java/tachyon/shell/TfsShellUtils.java
@@ -78,7 +78,7 @@ public class TfsShellUtils {
       }
     } else {
       String hostname = NetworkAddressUtils.getConnectHost(ServiceType.MASTER_RPC, tachyonConf);
-      int port =  tachyonConf.getInt(Constants.MASTER_PORT);
+      int port =  tachyonConf.getInt(Constants.MASTER_RPC_PORT);
       if (tachyonConf.getBoolean(Constants.ZOOKEEPER_ENABLED)) {
         return PathUtils.concatPath(Constants.HEADER_FT + hostname + ":" + port, path);
       }


### PR DESCRIPTION
We call the master web port `MASTER_WEB_PORT` and the worker web and data ports `WORKER_WEB_PORT` and `WORKER_DATA_PORT`.