### PR TITLE
[SMALLFIX] Remove unneeded sleep

### DIFF
--- a/integration-tests/src/test/java/tachyon/master/file/FileSystemMasterIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/file/FileSystemMasterIntegrationTest.java
@@ -542,10 +542,6 @@ public class FileSystemMasterIntegrationTest {
   public void getCapacityBytesTest() {
     BlockMaster blockMaster =
         mLocalTachyonClusterResource.get().getMaster().getInternalMaster().getBlockMaster();
-    // Sleep to give the workers time to register with the master
-    // TODO(andrew): Remove this when mLocalTachyonClusterResource.start() blocks until workers have
-    // registered with master.
-    CommonUtils.sleepMs(200);
     Assert.assertEquals(1000, blockMaster.getCapacityBytes());
   }
 


### PR DESCRIPTION
This sleep is no longer needed now that test cluster startup blocks on worker registration with master.