### PR TITLE
[TACHYON-1378] Fix flaky ttlExpiredCreateFileTest

### DIFF
--- a/integration-tests/src/test/java/tachyon/master/file/FileSystemMasterIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/file/FileSystemMasterIntegrationTest.java
@@ -47,6 +47,7 @@ import tachyon.exception.InvalidPathException;
 import tachyon.master.MasterContext;
 import tachyon.master.MasterTestUtils;
 import tachyon.master.block.BlockMaster;
+import tachyon.master.file.meta.TTLBucket;
 import tachyon.master.file.options.CompleteFileOptions;
 import tachyon.master.file.options.CreateOptions;
 import tachyon.master.file.options.MkdirOptions;
@@ -279,6 +280,7 @@ public class FileSystemMasterIntegrationTest {
     mFsMaster =
         mLocalTachyonClusterResource.get().getMaster().getInternalMaster().getFileSystemMaster();
     mMasterTachyonConf = mLocalTachyonClusterResource.get().getMasterTachyonConf();
+    TTLBucket.setTTlIntervalMs(mMasterTachyonConf.getLong(Constants.MASTER_TTLCHECKER_INTERVAL_MS));
   }
 
   @Test


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1378

The explanation of the problem is in the JIRA ticket, copied here for convenience.

The failing test creates a file with a 1 millisecond time to live(TTL), waits 5000 milliseconds, then asserts that the file does not exist. The TachyonConf is set so that the TTL interval is 1000ms. It should never take more than 2x the TTL interval for an expired file to be cleaned up, so this should be adequate.

When this failure occurs, it is because a TTL interval of MAX_INT ms is used instead of the configured 1000ms. This occurs precisely when the build happens to run TfsShellTest first (integration test ordering is arbitrary). When TfsShellTest runs first, it sets the TachyonConf to use MAX_INT for the TTL interval. When the TTLBucket class loads during TfsShellTest, it reads a snapshot of the TachyonConf's TTL interval into a static field, and uses that interval forever, regardless of updates to the TachyonConf. This makes sense for src/ because changing the interval while the server is running would mess up the bucket partitioning of time-space, causing buckets to overlap. However, this forces tests to manually reset the static field so that they don't run into this issue. https://tachyon.atlassian.net/browse/TACHYON-1382 can help with this by doing this resetting in the @Before method of a superclass shared by all integration tests. In the short term, the fix is to reset the TTL interval at the start of FileSystemMasterIntegrationTest.