### PR TITLE
[SMALLFIX] Use InetAddress.getLocalHost() instead of hardcoded localhost

### DIFF
--- a/common/src/test/java/tachyon/security/authentication/AuthenticationUtilsTest.java
+++ b/common/src/test/java/tachyon/security/authentication/AuthenticationUtilsTest.java
@@ -15,6 +15,7 @@
 
 package tachyon.security.authentication;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import javax.security.sasl.AuthenticationException;
@@ -58,9 +59,9 @@ public class AuthenticationUtilsTest {
   public void before() throws Exception {
     mTachyonConf = new TachyonConf();
     // Use port 0 to assign each test case an available port (possibly different)
-    mServerTSocket = new TServerSocket(new InetSocketAddress("localhost", 0));
+    mServerTSocket = new TServerSocket(new InetSocketAddress(InetAddress.getLocalHost(), 0));
     int port = NetworkAddressUtils.getThriftPort(mServerTSocket);
-    mServerAddress = new InetSocketAddress("localhost", port);
+    mServerAddress = new InetSocketAddress(InetAddress.getLocalHost(), port);
     mClientTSocket = AuthenticationUtils.createTSocket(mServerAddress,
         mTachyonConf.getInt(Constants.SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS));
   }

--- a/common/src/test/java/tachyon/security/authentication/AuthenticationUtilsTest.java
+++ b/common/src/test/java/tachyon/security/authentication/AuthenticationUtilsTest.java
@@ -15,7 +15,6 @@
 
 package tachyon.security.authentication;
 
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import javax.security.sasl.AuthenticationException;
@@ -59,9 +58,10 @@ public class AuthenticationUtilsTest {
   public void before() throws Exception {
     mTachyonConf = new TachyonConf();
     // Use port 0 to assign each test case an available port (possibly different)
-    mServerTSocket = new TServerSocket(new InetSocketAddress(InetAddress.getLocalHost(), 0));
+    String localhost = NetworkAddressUtils.getLocalHostName(new TachyonConf());
+    mServerTSocket = new TServerSocket(new InetSocketAddress(localhost, 0));
     int port = NetworkAddressUtils.getThriftPort(mServerTSocket);
-    mServerAddress = new InetSocketAddress(InetAddress.getLocalHost(), port);
+    mServerAddress = new InetSocketAddress(localhost, port);
     mClientTSocket = AuthenticationUtils.createTSocket(mServerAddress,
         mTachyonConf.getInt(Constants.SECURITY_AUTHENTICATION_SOCKET_TIMEOUT_MS));
   }


### PR DESCRIPTION
This is better, because 'locahost' might not always be resolved to the correct IP address, as in virtual network.