### PR TITLE
[TACHYON-1325] Cache FileSystems in HdfsUnderFileSystem

### DIFF
--- a/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java
@@ -114,7 +114,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
 
   @Override
   public void close() throws IOException {
-    mFs.close();
+    // Don't close mFs; FileSystems are singletons so closing it here could break other users
   }
 
   @Override


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1325

This significantly speeds up mkdir, bringing the time for `RawTableIntegrationTest.getColumnsTest` from 70 seconds to 20 seconds on my machine. I noticed that we were explicitly disabling caching (https://github.com/amplab/tachyon/blob/f297b579022ccfed8c55107df04b927ac652e35d/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java#L107). Is there a known issue with caching besides the call to `FileSystem.close()` in `HdfsUnderFileSystem.close()` (https://github.com/amplab/tachyon/blob/f297b579022ccfed8c55107df04b927ac652e35d/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java#L118) which I have removed?