### PR TITLE
[Tachyon-1333] Improved mount path checking

### DIFF
--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -29,6 +29,7 @@ public enum ExceptionMessage {
   NOT_SUPPORTED("This method is not supported"),
   PATH_DOES_NOT_EXIST("Path {0} does not exist"),
   PATH_MUST_BE_FILE("Path {0} must be a file"),
+  PATH_MUST_BE_DIRECTORY("Path {0} must be a directory"),
 
   // general block
   BLOCK_NOT_LOCALLY_AVAILABLE("Block {0} is not available on local machine"),
@@ -139,6 +140,12 @@ public enum ExceptionMessage {
   YARN_NOT_ENOUGH_HOSTS(
       "Not enough usable hosts in the cluster to launch {0} workers. Only {1} hosts available"),
 
+  // mounting
+  MOUNT_POINT_ALREADY_EXISTS("Mount point {0} already exists"),
+  MOUNT_POINT_PREFIX_OF_ANOTHER("Mount point {0} is a prefix of {1}"),
+  UFS_PATH_DOES_NOT_EXIST("Ufs path {0} does not exist"),
+  MOUNT_PATH_SHADOWS_DEFAULT_UFS(
+      "Mount path {0} shadows an existing path in the default underlying filesystem"),
   // SEMICOLON! minimize merge conflicts by putting it on its own line
   ;
 

--- a/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
@@ -179,6 +179,8 @@ public class TachyonFileSystemIntegrationTest {
    * Creates another directory on the local filesystem, alongside the existing Ufs, to be used as a
    * second Ufs
    * @return the path of the alternate Ufs directory
+   * @throws InvalidPathException if the UNDERFS_ADDRESS is not properly formed
+   * @throws IOException if a UnderFS I/O error occurs
    */
   private String createAlternateUfs() throws InvalidPathException, IOException {
     String parentDir =
@@ -193,7 +195,7 @@ public class TachyonFileSystemIntegrationTest {
   /**
    * Deletes the alternate under file system directory
    * @param alternateUfsRoot the root of the alternate Ufs
-   * @throws IOException
+   * @throws IOException if an UnderFS I/O error occurs
    */
   private void destroyAlternateUfs(String alternateUfsRoot) throws IOException {
     UnderFileSystemUtils.deleteDir(alternateUfsRoot, mLocalTachyonClusterResource.getTestConf());

--- a/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
@@ -18,8 +18,7 @@ package tachyon.client;
 import java.io.IOException;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -39,6 +38,7 @@ import tachyon.exception.InvalidPathException;
 import tachyon.exception.TachyonException;
 import tachyon.exception.TachyonExceptionType;
 import tachyon.thrift.FileInfo;
+import tachyon.util.UnderFileSystemUtils;
 import tachyon.util.io.PathUtils;
 
 /**
@@ -47,27 +47,26 @@ import tachyon.util.io.PathUtils;
 public class TachyonFileSystemIntegrationTest {
   private static final int WORKER_CAPACITY_BYTES = 20000;
   private static final int USER_QUOTA_UNIT_BYTES = 1000;
-  @ClassRule
-  public static LocalTachyonClusterResource sLocalTachyonClusterResource =
+  @Rule
+  public LocalTachyonClusterResource mLocalTachyonClusterResource =
       new LocalTachyonClusterResource(WORKER_CAPACITY_BYTES, USER_QUOTA_UNIT_BYTES, Constants.GB,
           Constants.USER_FILE_BUFFER_BYTES, Integer.toString(USER_QUOTA_UNIT_BYTES));
-  private static TachyonFileSystem sTfs = null;
-  private static OutStreamOptions sWriteBoth;
+  private TachyonFileSystem mTfs = null;
+  private OutStreamOptions mWriteBoth;
 
   @Rule
   public ExpectedException mThrown = ExpectedException.none();
 
-  @BeforeClass
-  public static void beforeClass() throws Exception {
-    sTfs = sLocalTachyonClusterResource.get().getClient();
-
-    TachyonConf conf = sLocalTachyonClusterResource.get().getMasterTachyonConf();
-    sWriteBoth = StreamOptionUtils.getOutStreamOptionsWriteBoth(conf);
+  @Before
+  public void before() throws Exception {
+    mTfs = mLocalTachyonClusterResource.get().getClient();
+    TachyonConf conf = mLocalTachyonClusterResource.get().getMasterTachyonConf();
+    mWriteBoth = StreamOptionUtils.getOutStreamOptionsWriteBoth(conf);
   }
 
   @Test
   public void getRootTest() throws IOException, TachyonException {
-    Assert.assertEquals(0, sTfs.getInfo(sTfs.open(new TachyonURI("/"))).getFileId());
+    Assert.assertEquals(0, mTfs.getInfo(mTfs.open(new TachyonURI("/"))).getFileId());
   }
 
   @Test
@@ -75,18 +74,18 @@ public class TachyonFileSystemIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     for (int k = 1; k < 5; k ++) {
       TachyonURI uri = new TachyonURI(uniqPath + k);
-      sTfs.getOutStream(uri, sWriteBoth).close();
-      Assert.assertNotNull(sTfs.getInfo(sTfs.open(uri)));
+      mTfs.getOutStream(uri, mWriteBoth).close();
+      Assert.assertNotNull(mTfs.getInfo(mTfs.open(uri)));
     }
   }
 
   @Test
   public void createFileWithFileAlreadyExistsExceptionTest() throws IOException, TachyonException {
     TachyonURI uri = new TachyonURI(PathUtils.uniqPath());
-    sTfs.getOutStream(uri, sWriteBoth).close();
-    Assert.assertNotNull(sTfs.getInfo(sTfs.open(uri)));
+    mTfs.getOutStream(uri, mWriteBoth).close();
+    Assert.assertNotNull(mTfs.getInfo(mTfs.open(uri)));
     try {
-      sTfs.getOutStream(uri, sWriteBoth);
+      mTfs.getOutStream(uri, mWriteBoth);
     } catch (TachyonException e) {
       Assert.assertEquals(e.getType(), TachyonExceptionType.FILE_ALREADY_EXISTS);
     }
@@ -96,7 +95,7 @@ public class TachyonFileSystemIntegrationTest {
   public void createFileWithInvalidPathExceptionTest() throws IOException, TachyonException {
     mThrown.expect(InvalidPathException.class);
     mThrown.expectMessage("Path root/testFile1 is invalid.");
-    sTfs.getOutStream(new TachyonURI("root/testFile1"), sWriteBoth);
+    mTfs.getOutStream(new TachyonURI("root/testFile1"), mWriteBoth);
   }
 
   @Test
@@ -105,18 +104,18 @@ public class TachyonFileSystemIntegrationTest {
 
     for (int k = 0; k < 5; k ++) {
       TachyonURI fileURI = new TachyonURI(uniqPath + k);
-      TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, fileURI.getPath(), k, sWriteBoth);
-      Assert.assertTrue(sTfs.getInfo(f).getInMemoryPercentage() == 100);
-      Assert.assertNotNull(sTfs.getInfo(f));
+      TachyonFile f = TachyonFSTestUtils.createByteFile(mTfs, fileURI.getPath(), k, mWriteBoth);
+      Assert.assertTrue(mTfs.getInfo(f).getInMemoryPercentage() == 100);
+      Assert.assertNotNull(mTfs.getInfo(f));
     }
 
     for (int k = 0; k < 5; k ++) {
       TachyonURI fileURI = new TachyonURI(uniqPath + k);
-      TachyonFile f = sTfs.open(fileURI);
-      sTfs.delete(f);
-      Assert.assertNull(sTfs.openIfExists(fileURI));
+      TachyonFile f = mTfs.open(fileURI);
+      mTfs.delete(f);
+      Assert.assertNull(mTfs.openIfExists(fileURI));
       mThrown.expect(FileDoesNotExistException.class);
-      sTfs.getInfo(f);
+      mTfs.getInfo(f);
     }
   }
 
@@ -125,9 +124,9 @@ public class TachyonFileSystemIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     int writeBytes = USER_QUOTA_UNIT_BYTES * 2;
     TachyonURI uri = new TachyonURI(uniqPath);
-    TachyonFile f = TachyonFSTestUtils.createByteFile(sTfs, uri.getPath(), writeBytes, sWriteBoth);
-    Assert.assertTrue(sTfs.getInfo(f).getInMemoryPercentage() == 100);
-    FileInfo fileInfo = sTfs.getInfo(f);
+    TachyonFile f = TachyonFSTestUtils.createByteFile(mTfs, uri.getPath(), writeBytes, mWriteBoth);
+    Assert.assertTrue(mTfs.getInfo(f).getInMemoryPercentage() == 100);
+    FileInfo fileInfo = mTfs.getInfo(f);
     Assert.assertNotNull(fileInfo);
     Assert.assertTrue(fileInfo.getPath().equals(uniqPath));
   }
@@ -137,9 +136,9 @@ public class TachyonFileSystemIntegrationTest {
     String uniqPath = PathUtils.uniqPath();
     MkdirOptions options = new MkdirOptions.Builder(new TachyonConf()).setRecursive(true).build();
     for (int k = 0; k < 10; k ++) {
-      Assert.assertTrue(sTfs.mkdir(new TachyonURI(uniqPath + k), options));
+      Assert.assertTrue(mTfs.mkdir(new TachyonURI(uniqPath + k), options));
       try {
-        Assert.assertFalse(sTfs.mkdir(new TachyonURI(uniqPath + k), options));
+        Assert.assertFalse(mTfs.mkdir(new TachyonURI(uniqPath + k), options));
         Assert.assertTrue("mkdir should throw FileAlreadyExistsException", false);
       } catch (FileAlreadyExistsException faee) {
         Assert.assertEquals(faee.getMessage(),
@@ -152,15 +151,15 @@ public class TachyonFileSystemIntegrationTest {
   public void renameFileTest1() throws IOException, TachyonException {
     String uniqPath = PathUtils.uniqPath();
     TachyonURI path1 = new TachyonURI(uniqPath + 1);
-    sTfs.getOutStream(path1, sWriteBoth).close();
+    mTfs.getOutStream(path1, mWriteBoth).close();
     for (int k = 1; k < 10; k ++) {
       TachyonURI fileA = new TachyonURI(uniqPath + k);
       TachyonURI fileB = new TachyonURI(uniqPath + (k + 1));
-      TachyonFile existingFile = sTfs.open(fileA);
+      TachyonFile existingFile = mTfs.open(fileA);
       long oldFileId = existingFile.getFileId();
       Assert.assertNotNull(existingFile);
-      Assert.assertTrue(sTfs.rename(existingFile, fileB));
-      TachyonFile renamedFile = sTfs.open(fileB);
+      Assert.assertTrue(mTfs.rename(existingFile, fileB));
+      TachyonFile renamedFile = mTfs.open(fileB);
       Assert.assertNotNull(renamedFile);
       Assert.assertEquals(oldFileId, renamedFile.getFileId());
     }
@@ -169,10 +168,118 @@ public class TachyonFileSystemIntegrationTest {
   @Test
   public void renameFileTest2() throws IOException, TachyonException {
     TachyonURI uniqUri = new TachyonURI(PathUtils.uniqPath());
-    sTfs.getOutStream(uniqUri, sWriteBoth).close();
-    TachyonFile f = sTfs.open(uniqUri);
+    mTfs.getOutStream(uniqUri, mWriteBoth).close();
+    TachyonFile f = mTfs.open(uniqUri);
     long oldFileId = f.getFileId();
-    Assert.assertTrue(sTfs.rename(f, uniqUri));
-    Assert.assertEquals(oldFileId, sTfs.open(uniqUri).getFileId());
+    Assert.assertTrue(mTfs.rename(f, uniqUri));
+    Assert.assertEquals(oldFileId, mTfs.open(uniqUri).getFileId());
+  }
+
+  /**
+   * Creates another directory on the local filesystem, alongside the existing Ufs, to be used as a
+   * second Ufs
+   * @return the path of the alternate Ufs directory
+   */
+  private String createAlternateUfs() throws InvalidPathException, IOException {
+    String parentDir =
+        PathUtils.getParent(mLocalTachyonClusterResource.getTestConf().get(
+            Constants.UNDERFS_ADDRESS));
+    String alternateUfsRoot = PathUtils.concatPath(parentDir, "alternateUnderFSStorage");
+    UnderFileSystemUtils.mkdirIfNotExists(alternateUfsRoot,
+        mLocalTachyonClusterResource.getTestConf());
+    return alternateUfsRoot;
+  }
+
+  /**
+   * Deletes the alternate under file system directory
+   * @param alternateUfsRoot the root of the alternate Ufs
+   * @throws IOException
+   */
+  private void destroyAlternateUfs(String alternateUfsRoot) throws IOException {
+    UnderFileSystemUtils.deleteDir(alternateUfsRoot, mLocalTachyonClusterResource.getTestConf());
+  }
+
+  @Test
+  public void mountAlternateUfsTest() throws IOException, TachyonException {
+    String alternateUfsRoot = createAlternateUfs();
+    try {
+      String filePath = PathUtils.concatPath(alternateUfsRoot, "file1");
+      UnderFileSystemUtils.touch(filePath, mLocalTachyonClusterResource.getTestConf());
+      Assert.assertTrue(mTfs.mount(new TachyonURI("/dir1"), new TachyonURI(alternateUfsRoot)));
+      mTfs.loadMetadata(new TachyonURI("/dir1/file1"));
+      Assert.assertEquals("file1", mTfs.listStatus(mTfs.open(new TachyonURI("/dir1"))).get(0)
+          .getName());
+    } finally {
+      destroyAlternateUfs(alternateUfsRoot);
+    }
+  }
+
+  @Test
+  public void mountAlternateUfsSubdirsTest() throws Exception {
+    String alternateUfsRoot = createAlternateUfs();
+    try {
+      TachyonConf testConf = mLocalTachyonClusterResource.getTestConf();
+      String dirPath1 = PathUtils.concatPath(alternateUfsRoot, "dir1");
+      String dirPath2 = PathUtils.concatPath(alternateUfsRoot, "dir2");
+      UnderFileSystemUtils.mkdirIfNotExists(dirPath1, testConf);
+      UnderFileSystemUtils.mkdirIfNotExists(dirPath2, testConf);
+      String filePath1 = PathUtils.concatPath(dirPath1, "file1");
+      String filePath2 = PathUtils.concatPath(dirPath2, "file2");
+      UnderFileSystemUtils.touch(filePath1, testConf);
+      UnderFileSystemUtils.touch(filePath2, testConf);
+
+      Assert.assertTrue(mTfs.mount(new TachyonURI("/dirx"), new TachyonURI(dirPath1)));
+      Assert.assertTrue(mTfs.mount(new TachyonURI("/diry"), new TachyonURI(dirPath2)));
+      mTfs.loadMetadata(new TachyonURI("/dirx/file1"));
+      mTfs.loadMetadata(new TachyonURI("/diry/file2"));
+      Assert.assertEquals("file1", mTfs.listStatus(mTfs.open(new TachyonURI("/dirx"))).get(0)
+          .getName());
+      Assert.assertEquals("file2", mTfs.listStatus(mTfs.open(new TachyonURI("/diry"))).get(0)
+          .getName());
+    } finally {
+      destroyAlternateUfs(alternateUfsRoot);
+    }
+  }
+
+  @Test
+  public void mountPrefixUfsTest() throws Exception {
+    TachyonConf testConf = mLocalTachyonClusterResource.getTestConf();
+    // Primary UFS cannot be re-mounted
+    String ufsRoot = testConf.get(Constants.UNDERFS_ADDRESS);
+    String ufsSubdir = PathUtils.concatPath(ufsRoot, "dir1");
+    UnderFileSystemUtils.mkdirIfNotExists(ufsSubdir, testConf);
+    Assert.assertFalse(mTfs.mount(new TachyonURI("/dir"), new TachyonURI(ufsSubdir)));
+
+    String alternateUfsRoot = createAlternateUfs();
+    try {
+      String midDirPath = PathUtils.concatPath(alternateUfsRoot, "mid");
+      String innerDirPath = PathUtils.concatPath(midDirPath, "inner");
+      UnderFileSystemUtils.mkdirIfNotExists(innerDirPath, testConf);
+      Assert.assertTrue(mTfs.mount(new TachyonURI("/mid"), new TachyonURI(midDirPath)));
+      // Cannot mount suffix of already-mounted directory
+      Assert.assertFalse(mTfs.mount(new TachyonURI("/inner"), new TachyonURI(innerDirPath)));
+      // Cannot mount prefix of already-mounted directory
+      Assert.assertFalse(mTfs.mount(new TachyonURI("/root"), new TachyonURI(alternateUfsRoot)));
+    } finally {
+      destroyAlternateUfs(alternateUfsRoot);
+    }
+  }
+
+  @Test
+  public void mountShadowUfsTest() throws Exception {
+    TachyonConf testConf = mLocalTachyonClusterResource.getTestConf();
+    String ufsRoot = testConf.get(Constants.UNDERFS_ADDRESS);
+    String ufsSubdir = PathUtils.concatPath(ufsRoot, "dir1");
+    UnderFileSystemUtils.mkdirIfNotExists(ufsSubdir, testConf);
+
+    String alternateUfsRoot = createAlternateUfs();
+    try {
+      String subdirPath = PathUtils.concatPath(alternateUfsRoot, "subdir");
+      UnderFileSystemUtils.mkdirIfNotExists(subdirPath, testConf);
+      // Cannot mount to path that shadows a file in the primary UFS
+      Assert.assertFalse(mTfs.mount(new TachyonURI("/dir1"), new TachyonURI(subdirPath)));
+    } finally {
+      destroyAlternateUfs(alternateUfsRoot);
+    }
   }
 }

--- a/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/TachyonFileSystemIntegrationTest.java
@@ -177,7 +177,7 @@ public class TachyonFileSystemIntegrationTest {
 
   /**
    * Creates another directory on the local filesystem, alongside the existing Ufs, to be used as a
-   * second Ufs
+   * second Ufs.
    * @return the path of the alternate Ufs directory
    * @throws InvalidPathException if the UNDERFS_ADDRESS is not properly formed
    * @throws IOException if a UnderFS I/O error occurs
@@ -193,7 +193,7 @@ public class TachyonFileSystemIntegrationTest {
   }
 
   /**
-   * Deletes the alternate under file system directory
+   * Deletes the alternate under file system directory.
    * @param alternateUfsRoot the root of the alternate Ufs
    * @throws IOException if an UnderFS I/O error occurs
    */

--- a/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
+++ b/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
@@ -50,9 +50,9 @@ import tachyon.security.LoginUser;
 import tachyon.security.authentication.AuthType;
 import tachyon.shell.command.CommandUtils;
 import tachyon.thrift.FileInfo;
-import tachyon.underfs.UnderFileSystem;
 import tachyon.util.CommonUtils;
 import tachyon.util.FormatUtils;
+import tachyon.util.UnderFileSystemUtils;
 import tachyon.util.io.BufferUtils;
 import tachyon.util.io.PathUtils;
 
@@ -176,11 +176,9 @@ public class TfsShellTest {
 
   @Test
   public void lsThenloadMetadataTest() throws IOException, TachyonException {
-    String ufsRoot =
-        PathUtils.concatPath(mLocalTachyonCluster.getMasterTachyonConf().get(
-            Constants.UNDERFS_ADDRESS));
-    UnderFileSystem ufs = UnderFileSystem.get(ufsRoot, mLocalTachyonCluster.getMasterTachyonConf());
-    ufs.mkdirs(PathUtils.concatPath(ufsRoot, "dir1"), false);
+    TachyonConf conf = mLocalTachyonCluster.getMasterTachyonConf();
+    String ufsRoot = conf.get(Constants.UNDERFS_ADDRESS);
+    UnderFileSystemUtils.mkdirIfNotExists(PathUtils.concatPath(ufsRoot, "dir1"), conf);
     // First run ls to create the data
     mFsShell.run("ls", "/dir1");
     Assert.assertTrue(mTfs.getInfo(mTfs.open(new TachyonURI("/dir1"))).isIsPersisted());
@@ -205,11 +203,9 @@ public class TfsShellTest {
     TachyonFSTestUtils.createByteFile(mTfs, "/testDir/testFileA", TachyonStorageType.STORE,
         UnderStorageType.NO_PERSIST, 10);
     Assert.assertFalse(mTfs.getInfo(mTfs.open(new TachyonURI("/testDir"))).isIsPersisted());
-    String ufsRoot =
-        PathUtils.concatPath(mLocalTachyonCluster.getMasterTachyonConf().get(
-            Constants.UNDERFS_ADDRESS));
-    UnderFileSystem ufs = UnderFileSystem.get(ufsRoot, mLocalTachyonCluster.getMasterTachyonConf());
-    ufs.mkdirs(PathUtils.concatPath(ufsRoot, "testDir"), false);
+    TachyonConf conf = mLocalTachyonCluster.getMasterTachyonConf();
+    String ufsRoot = conf.get(Constants.UNDERFS_ADDRESS);
+    UnderFileSystemUtils.mkdirIfNotExists(PathUtils.concatPath(ufsRoot, "testDir"), conf);
     Assert.assertFalse(mTfs.getInfo(mTfs.open(new TachyonURI("/testDir"))).isIsPersisted());
     // Load metadata, which should mark the testDir as persisted
     mFsShell.run("loadMetadata", "/testDir");
@@ -1158,6 +1154,7 @@ public class TfsShellTest {
     Assert.assertEquals(Constants.NO_TTL, mTfs.getInfo(file).getTtl());
   }
 
+  @Test
   public void persistTest() throws IOException, TachyonException {
     String testFilePath = "/testPersist/testFile";
     TachyonFile testFile = TachyonFSTestUtils.createByteFile(mTfs, testFilePath,

--- a/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
@@ -1340,7 +1340,7 @@ public final class FileSystemMaster extends MasterBase {
       throws FileAlreadyExistsException, InvalidPathException, IOException {
     synchronized (mInodeTree) {
       if (mountInternal(tachyonPath, ufsPath)) {
-        boolean loadMetadataSuceeded = true;
+        boolean loadMetadataSuceeded = false;
         try {
           // This will create the directory at tachyonPath
           loadMetadataDirectory(tachyonPath, false);

--- a/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
@@ -1261,7 +1261,7 @@ public final class FileSystemMaster extends MasterBase {
    * @return the file id of the loaded path
    * @throws BlockInfoException if an invalid block size is encountered
    * @throws FileAlreadyExistsException if the object to be loaded already exists
-   * @throws FileDoesNotExistException if a parent directory does not exist and recursive is false
+   * @throws FileDoesNotExistException if there is no UFS path
    * @throws InvalidPathException if invalid path is encountered
    * @throws InvalidFileSizeException if invalid file size is encountered
    * @throws FileAlreadyCompletedException if the file is already completed
@@ -1297,22 +1297,7 @@ public final class FileSystemMaster extends MasterBase {
         completeFile(fileId, completeOptions);
         return fileId;
       } else {
-        MkdirOptions options = new MkdirOptions.Builder(MasterContext.getConf())
-            .setRecursive(recursive).setPersisted(true).build();
-        InodeTree.CreatePathResult result = mkdir(path, options);
-        List<Inode> inodes = null;
-        if (result.getCreated().size() > 0) {
-          inodes = result.getCreated();
-        } else if (result.getPersisted().size() > 0) {
-          inodes = result.getPersisted();
-        } else if (result.getModified().size() > 0) {
-          inodes = result.getModified();
-        }
-        if (inodes == null) {
-          throw new FileAlreadyExistsException(
-              ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(path));
-        }
-        return inodes.get(inodes.size() - 1).getId();
+        return loadMetadataDirectory(path, recursive);
       }
     } catch (IOException e) {
       LOG.error(ExceptionUtils.getStackTrace(e));
@@ -1320,38 +1305,88 @@ public final class FileSystemMaster extends MasterBase {
     }
   }
 
-  public boolean mount(TachyonURI tachyonPath, TachyonURI ufsPath)
-      throws FileAlreadyExistsException, FileDoesNotExistException, InvalidPathException,
-      IOException {
-    synchronized (mInodeTree) {
-      MkdirOptions options =
-          new MkdirOptions.Builder(MasterContext.getConf()).setPersisted(true).build();
-      InodeTree.CreatePathResult createResult = mkdir(tachyonPath, options);
-      if (mountInternal(tachyonPath, ufsPath)) {
-        AddMountPointEntry addMountPoint = AddMountPointEntry.newBuilder()
-            .setTachyonPath(tachyonPath.toString())
-            .setUfsPath(ufsPath.toString())
-            .build();
-        writeJournalEntry(JournalEntry.newBuilder().setAddMountPoint(addMountPoint).build());
-        flushJournal();
-        return true;
+  /**
+   * Loads metadata for the directory identified by the given path from UFS into Tachyon. This does
+   * not actually require looking at the UFS path.
+   *
+   * @param path the path for which metadata should be loaded
+   * @param recursive whether parent directories should be created if they do not already exist
+   * @return the file id of the loaded directory
+   * @throws FileAlreadyExistsException if the object to be loaded already exists
+   * @throws InvalidPathException if invalid path is encountered
+   * @throws IOException if an I/O error occurs
+   */
+  private long loadMetadataDirectory(TachyonURI path, boolean recursive)
+      throws IOException, FileAlreadyExistsException, InvalidPathException {
+    MkdirOptions options =
+        new MkdirOptions.Builder(MasterContext.getConf()).setRecursive(recursive)
+            .setPersisted(true).build();
+    InodeTree.CreatePathResult result = mkdir(path, options);
+    List<Inode> inodes = null;
+    if (result.getCreated().size() > 0) {
+      inodes = result.getCreated();
+    } else if (result.getPersisted().size() > 0) {
+      inodes = result.getPersisted();
+    } else if (result.getModified().size() > 0) {
+      inodes = result.getModified();
+    }
+    if (inodes == null) {
+      throw new FileAlreadyExistsException(ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(path));
+    }
+    return inodes.get(inodes.size() - 1).getId();
+  }
+
+  public synchronized boolean mount(TachyonURI tachyonPath, TachyonURI ufsPath)
+      throws FileAlreadyExistsException, InvalidPathException, IOException {
+    if (mountInternal(tachyonPath, ufsPath)) {
+      boolean loadMetadataSuceeded = true;
+      try {
+        // This will create the directory at tachyonPath
+        loadMetadataDirectory(tachyonPath, false);
+        loadMetadataSuceeded = true;
+      } finally {
+        if (!loadMetadataSuceeded) {
+          // We should be throwing an exception in this scenario
+          unmountInternal(tachyonPath);
+        }
       }
-      // Cleanup created directories in case the mount operation failed.
-      long opTimeMs = System.currentTimeMillis();
-      deleteFileRecursiveInternal(createResult.getCreated().get(0).getId(), false, opTimeMs);
+      AddMountPointEntry addMountPoint =
+          AddMountPointEntry.newBuilder().setTachyonPath(tachyonPath.toString())
+              .setUfsPath(ufsPath.toString()).build();
+      writeJournalEntry(JournalEntry.newBuilder().setAddMountPoint(addMountPoint).build());
+      flushJournal();
+      return true;
     }
     return false;
   }
 
-  void mountFromEntry(AddMountPointEntry entry) throws InvalidPathException {
+  void mountFromEntry(AddMountPointEntry entry) throws InvalidPathException, IOException {
     TachyonURI tachyonURI = new TachyonURI(entry.getTachyonPath());
     TachyonURI ufsURI = new TachyonURI(entry.getUfsPath());
-    if (!mountInternal(tachyonURI, ufsURI)) {
-      LOG.error("Failed to mount {} at {}", ufsURI, tachyonURI);
-    }
+    mountInternal(tachyonURI, ufsURI);
   }
 
-  boolean mountInternal(TachyonURI tachyonPath, TachyonURI ufsPath) throws InvalidPathException {
+  boolean mountInternal(TachyonURI tachyonPath, TachyonURI ufsPath) throws InvalidPathException,
+      IOException {
+    // Check that the ufsPath exists and is a directory
+    UnderFileSystem ufs = UnderFileSystem.get(ufsPath.toString(), MasterContext.getConf());
+    if (!ufs.exists(ufsPath.getPath())) {
+      LOG.warn(ExceptionMessage.UFS_PATH_DOES_NOT_EXIST.getMessage(ufsPath.getPath()));
+      return false;
+    }
+    if (ufs.isFile(ufsPath.getPath())) {
+      LOG.warn(ExceptionMessage.PATH_MUST_BE_DIRECTORY.getMessage(ufsPath.getPath()));
+      return false;
+    }
+    // Check that the tachyonPath we're creating doesn't shadow a path in the default UFS
+    String defaultUfsPath = MasterContext.getConf().get(Constants.UNDERFS_ADDRESS);
+    UnderFileSystem defaultUfs = UnderFileSystem.get(defaultUfsPath, MasterContext.getConf());
+    if (defaultUfs.exists(PathUtils.concatPath(defaultUfsPath, tachyonPath.getPath()))) {
+      LOG.warn(ExceptionMessage.MOUNT_PATH_SHADOWS_DEFAULT_UFS.getMessage(tachyonPath));
+      return false;
+    }
+    // This should check that we are not mounting a prefix of an existing mount, and that no
+    // existing mount is a prefix of this mount.
     return mMountTable.add(tachyonPath, ufsPath);
   }
 

--- a/servers/src/test/java/tachyon/master/file/meta/MountTableTest.java
+++ b/servers/src/test/java/tachyon/master/file/meta/MountTableTest.java
@@ -33,9 +33,7 @@ public class MountTableTest {
   @Test
   public void pathTest() throws TachyonException {
     // Test add()
-    Assert.assertTrue(mMountTable.add(new TachyonURI("/"), new TachyonURI("/")));
     Assert.assertTrue(mMountTable.add(new TachyonURI("/mnt/foo"), new TachyonURI("/foo")));
-    Assert.assertTrue(mMountTable.add(new TachyonURI("/mnt/foo2"), new TachyonURI("/foo/x")));
     Assert.assertFalse(mMountTable.add(new TachyonURI("/mnt/foo"), new TachyonURI("/foo2")));
     Assert.assertTrue(mMountTable.add(new TachyonURI("/mnt/bar"), new TachyonURI("/bar")));
     Assert.assertFalse(mMountTable.add(new TachyonURI("/mnt/bar/baz"), new TachyonURI("/baz")));
@@ -49,7 +47,6 @@ public class MountTableTest {
         .assertEquals(new TachyonURI("/bar/y"), mMountTable.resolve(new TachyonURI("/mnt/bar/y")));
     Assert.assertEquals(new TachyonURI("/bar/baz"),
         mMountTable.resolve(new TachyonURI("/mnt/bar/baz")));
-    Assert.assertEquals(new TachyonURI("/mnt"), mMountTable.resolve(new TachyonURI("/mnt")));
     Assert.assertEquals(new TachyonURI("/foobar"), mMountTable.resolve(new TachyonURI("/foobar")));
     Assert.assertEquals(new TachyonURI("/"), mMountTable.resolve(new TachyonURI("/")));
 
@@ -59,16 +56,14 @@ public class MountTableTest {
     Assert.assertEquals("/mnt/bar", mMountTable.getMountPoint(new TachyonURI("/mnt/bar")));
     Assert.assertEquals("/mnt/bar", mMountTable.getMountPoint(new TachyonURI("/mnt/bar/y")));
     Assert.assertEquals("/mnt/bar", mMountTable.getMountPoint(new TachyonURI("/mnt/bar/baz")));
-    Assert.assertEquals("/", mMountTable.getMountPoint(new TachyonURI("/mnt")));
-    Assert.assertEquals("/", mMountTable.getMountPoint(new TachyonURI("/tmp")));
-    Assert.assertEquals("/", mMountTable.getMountPoint(new TachyonURI("/")));
+    Assert.assertNull(mMountTable.getMountPoint(new TachyonURI("/mnt")));
+    Assert.assertNull(mMountTable.getMountPoint(new TachyonURI("/")));
 
     // Test isMountPoint()
-    Assert.assertTrue(mMountTable.isMountPoint(new TachyonURI("/")));
+    Assert.assertFalse(mMountTable.isMountPoint(new TachyonURI("/")));
     Assert.assertTrue(mMountTable.isMountPoint(new TachyonURI("/mnt/foo")));
     Assert.assertFalse(mMountTable.isMountPoint(new TachyonURI("/mnt/foo/bar")));
     Assert.assertFalse(mMountTable.isMountPoint(new TachyonURI("/mnt")));
-    Assert.assertTrue(mMountTable.isMountPoint(new TachyonURI("/mnt/foo2")));
     Assert.assertFalse(mMountTable.isMountPoint(new TachyonURI("/mnt/foo3")));
     Assert.assertTrue(mMountTable.isMountPoint(new TachyonURI("/mnt/bar")));
     Assert.assertFalse(mMountTable.isMountPoint(new TachyonURI("/mnt/bar/baz")));
@@ -76,7 +71,6 @@ public class MountTableTest {
     // Test delete()
     Assert.assertTrue(mMountTable.delete(new TachyonURI("/mnt/bar")));
     Assert.assertTrue(mMountTable.delete(new TachyonURI("/mnt/foo")));
-    Assert.assertTrue(mMountTable.delete(new TachyonURI("/mnt/foo2")));
     Assert.assertFalse(mMountTable.delete(new TachyonURI("/mnt/foo")));
     Assert.assertFalse(mMountTable.delete(new TachyonURI("/")));
   }
@@ -84,12 +78,8 @@ public class MountTableTest {
   @Test
   public void uriTest() throws TachyonException {
     // Test add()
-    Assert.assertTrue(mMountTable.add(new TachyonURI("tachyon://localhost:1234/"),
-        new TachyonURI("hdfs://localhost:5678/")));
     Assert.assertTrue(mMountTable.add(new TachyonURI("tachyon://localhost:1234/mnt/foo"),
         new TachyonURI("hdfs://localhost:5678/foo")));
-    Assert.assertTrue(mMountTable.add(new TachyonURI("tachyon://localhost:1234/mnt/foo2"),
-        new TachyonURI("hdfs://localhost:5678/foo/x")));
     Assert.assertFalse(mMountTable.add(new TachyonURI("tachyon://localhost:1234/mnt/foo"),
         new TachyonURI("hdfs://localhost:5678/foo2")));
     Assert.assertTrue(mMountTable.add(new TachyonURI("tachyon://localhost:1234/mnt/bar"),
@@ -100,57 +90,42 @@ public class MountTableTest {
     // Test resolve()
     Assert.assertEquals(new TachyonURI("hdfs://localhost:5678/foo"),
         mMountTable.resolve(new TachyonURI("tachyon://localhost:1234/mnt/foo")));
-    Assert.assertEquals(new TachyonURI("hdfs://localhost:5678/foo/x"),
-        mMountTable.resolve(new TachyonURI("tachyon://localhost:1234/mnt/foo/x")));
     Assert.assertEquals(new TachyonURI("hdfs://localhost:5678/bar"),
         mMountTable.resolve(new TachyonURI("tachyon://localhost:1234/mnt/bar")));
     Assert.assertEquals(new TachyonURI("hdfs://localhost:5678/bar/y"),
         mMountTable.resolve(new TachyonURI("tachyon://localhost:1234/mnt/bar/y")));
     Assert.assertEquals(new TachyonURI("hdfs://localhost:5678/bar/baz"),
         mMountTable.resolve(new TachyonURI("tachyon://localhost:1234/mnt/bar/baz")));
-    Assert.assertEquals(new TachyonURI("hdfs://localhost:5678/mnt"),
-        mMountTable.resolve(new TachyonURI("tachyon://localhost:1234/mnt")));
-    Assert.assertEquals(new TachyonURI("hdfs://localhost:5678/foobar"),
-        mMountTable.resolve(new TachyonURI("tachyon://localhost:1234/foobar")));
-    Assert.assertEquals(new TachyonURI("hdfs://localhost:5678/"),
-        mMountTable.resolve(new TachyonURI("tachyon://localhost:1234/")));
 
     // Test getMountPoint()
     Assert.assertEquals("/mnt/foo",
         mMountTable.getMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/foo")));
-    Assert.assertEquals("/mnt/foo",
-        mMountTable.getMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/foo/x")));
     Assert.assertEquals("/mnt/bar",
         mMountTable.getMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/bar")));
     Assert.assertEquals("/mnt/bar",
         mMountTable.getMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/bar/y")));
     Assert.assertEquals("/mnt/bar",
         mMountTable.getMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/bar/baz")));
-    Assert.assertEquals("/",
-        mMountTable.getMountPoint(new TachyonURI("tachyon://localhost:1234/mnt")));
-    Assert.assertEquals("/",
-        mMountTable.getMountPoint(new TachyonURI("tachyon://localhost:1234/tmp")));
-    Assert
-        .assertEquals("/", mMountTable.getMountPoint(new TachyonURI("tachyon://localhost:1234/")));
+    Assert.assertNull(mMountTable.getMountPoint(new TachyonURI("tachyon://localhost:1234/mnt")));
+    Assert.assertNull(mMountTable.getMountPoint(new TachyonURI("tachyon://localhost:1234/")));
 
     // Test isMountPoint()
-    Assert.assertTrue(mMountTable.isMountPoint(new TachyonURI("tachyon://localhost:1234/")));
+    Assert.assertFalse(mMountTable.isMountPoint(new TachyonURI("tachyon://localhost:1234/")));
     Assert.assertTrue(mMountTable.isMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/foo")));
-    Assert.assertFalse(mMountTable.isMountPoint(new TachyonURI(
-        "tachyon://localhost:1234/mnt/foo/bar")));
+    Assert.assertFalse(
+        mMountTable.isMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/foo/bar")));
     Assert.assertFalse(mMountTable.isMountPoint(new TachyonURI("tachyon://localhost:1234/mnt")));
     Assert
-        .assertTrue(mMountTable.isMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/foo2")));
-    Assert.assertFalse(mMountTable
-        .isMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/foo3")));
+        .assertFalse(mMountTable.isMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/foo2")));
+    Assert
+        .assertFalse(mMountTable.isMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/foo3")));
     Assert.assertTrue(mMountTable.isMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/bar")));
-    Assert.assertFalse(mMountTable.isMountPoint(new TachyonURI(
-        "tachyon://localhost:1234/mnt/bar/baz")));
+    Assert.assertFalse(
+        mMountTable.isMountPoint(new TachyonURI("tachyon://localhost:1234/mnt/bar/baz")));
 
     // Test delete()
     Assert.assertTrue(mMountTable.delete(new TachyonURI("tachyon://localhost:1234/mnt/bar")));
     Assert.assertTrue(mMountTable.delete(new TachyonURI("tachyon://localhost:1234/mnt/foo")));
-    Assert.assertTrue(mMountTable.delete(new TachyonURI("tachyon://localhost:1234/mnt/foo2")));
     Assert.assertFalse(mMountTable.delete(new TachyonURI("tachyon://localhost:1234/mnt/foo")));
     Assert.assertFalse(mMountTable.delete(new TachyonURI("tachyon://localhost:1234/")));
   }


### PR DESCRIPTION
For correctness and simplicity, we place a few restrictions on mounting
paths:

1. You cannot mount a UFS path that is a prefix or a suffix of an
already-mounted UFS path
2. You cannot mount to a Tachyon path that shadows a path in the default
underfs
3. The UFS path you are mounting must exist at mount time