### PR TITLE
[SMALLFIX] Removed public modifier in 'Sink' interface

### DIFF
--- a/servers/src/main/java/tachyon/metrics/sink/Sink.java
+++ b/servers/src/main/java/tachyon/metrics/sink/Sink.java
@@ -22,15 +22,15 @@ public interface Sink {
   /**
    * Starts the reporter polling.
    */
-  public void start();
+  void start();
 
   /**
    * Stops the reporter.
    */
-  public void stop();
+  void stop();
 
   /**
    * Reports the current values of all metrics.
    */
-  public void report();
+  void report();
 }


### PR DESCRIPTION
Removed the unnecessary public modifiers in the ```Sink```  interface.