### PR TITLE
[SMALLFIX] Use concatPath for better portability

### DIFF
--- a/servers/src/main/java/tachyon/Format.java
+++ b/servers/src/main/java/tachyon/Format.java
@@ -74,14 +74,17 @@ public class Format {
           Constants.RAW_TABLE_MASTER_NAME,
       };
       for (String masterServiceName : masterServiceNames) {
-        if (!formatFolder(masterServiceName + "JOURNAL_FOLDER", PathUtils.concatPath(masterJournal,
+        if (!formatFolder(masterServiceName + "_JOURNAL_FOLDER", PathUtils.concatPath(masterJournal,
             masterServiceName), tachyonConf)) {
           System.exit(-1);
         }
       }
 
+      // A journal folder is thought to be formatted only when a file with the specific name is
+      // present under the folder.
       UnderFileSystemUtils.touch(
-          masterJournal + Constants.FORMAT_FILE_PREFIX + System.currentTimeMillis(), tachyonConf);
+          PathUtils.concatPath(masterJournal, Constants.FORMAT_FILE_PREFIX
+              + System.currentTimeMillis()), tachyonConf);
     } else if ("WORKER".equals(args[0].toUpperCase())) {
       String workerDataFolder = tachyonConf.get(Constants.WORKER_DATA_FOLDER);
       int storageLevels = tachyonConf.getInt(Constants.WORKER_TIERED_STORE_LEVELS);


### PR DESCRIPTION
If `tachyon.master.journal.folder` is set to `/journal`, the original code will not create `_format_xxx` under the `/journal` directory, which will mislead tachyon to believe that master is not formatted. 