### PR TITLE
[SMALLFIX] Changed documentation of CLI copyToLocal command from 'remote source' to 'remote path'

### DIFF
--- a/docs/Command-Line-Interface.md
+++ b/docs/Command-Line-Interface.md
@@ -38,7 +38,7 @@ Or, if no header is provided, the default hostname and port (set in the env file
   <tr>
     <td>copyToLocal</td>
     <td>copyToLocal "remote path" "local path"</td>
-    <td>Copy the specified file from the path specified by "remote source" to a local
+    <td>Copy the specified file from the path specified by "remote path" to a local
     destination.</td>
   </tr>
   <tr>


### PR DESCRIPTION
The documentation on http://tachyon-project.org/documentation/master/Command-Line-Interface.html uses the ```remote source```  parameter instead of ```remote path```.