### PR TITLE
[TACHYON-1318] Add a findbug rule of finding unused variables

### DIFF
--- a/build/findbugs/findbugs-exclude.xml
+++ b/build/findbugs/findbugs-exclude.xml
@@ -38,9 +38,18 @@
 	SIC: Could be refactored into a named static inner class
 	UC: Useless non-empty void method
 	UPM: Private method is never called
-	UrF: Unread public/protected field
       -->
-    <Bug code="DC,DE,DLS,Dm,DP,EI,Eq,IS,JLM,LI,Nm,NP,PT,PZLA,RCN,REC,RR,RV,SBSC,Se,SIC,UC,UPM,UrF"/>
+    <Bug code="DC,DE,DLS,Dm,DP,EI,Eq,IS,JLM,LI,Nm,NP,PT,PZLA,RCN,REC,RR,RV,SBSC,Se,SIC,UC,UPM"/>
+  </Match>
+
+  <Match>
+    <!-- This Match uses the BUG_PATTERN for matching.
+
+        URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD: allow unread public/protected variables, but not private ones
+        UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD: allow unused public/protected variables, but not private ones
+
+      -->
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD,UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"/>
   </Match>
 
 </FindBugsFilter>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -40,11 +40,5 @@
       <artifactId>tachyon-servers</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <!-- Dependency for findbugs (SuppressFBWarnings) -->
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -40,5 +40,11 @@
       <artifactId>tachyon-servers</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Dependency for findbugs (SuppressFBWarnings) -->
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
@@ -39,6 +39,7 @@ import tachyon.util.network.NetworkAddressUtils.ServiceType;
  */
 public final class LocalTachyonMaster {
   // TODO(hy): Should this be moved to TachyonURI? Prob after UFS supports it.
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
   private final String mTachyonHome;
   private final String mHostname;
 

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 
 import tachyon.Constants;

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
@@ -38,9 +38,6 @@ import tachyon.util.network.NetworkAddressUtils.ServiceType;
  * Isolated is defined as having its own root directory, and port.
  */
 public final class LocalTachyonMaster {
-  // TODO(hy): Should this be moved to TachyonURI? Prob after UFS supports it.
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
-  private final String mTachyonHome;
   private final String mHostname;
 
   private final String mJournalFolder;
@@ -56,10 +53,8 @@ public final class LocalTachyonMaster {
   };
   private final ClientPool mClientPool = new ClientPool(mClientSupplier);
 
-  private LocalTachyonMaster(final String tachyonHome)
+  private LocalTachyonMaster()
       throws IOException {
-    mTachyonHome = tachyonHome;
-
     TachyonConf tachyonConf = MasterContext.getConf();
     mHostname = NetworkAddressUtils.getConnectHost(ServiceType.MASTER_RPC, tachyonConf);
 
@@ -99,7 +94,7 @@ public final class LocalTachyonMaster {
     // Update Tachyon home in the passed TachyonConf instance.
     tachyonConf.set(Constants.TACHYON_HOME, tachyonHome);
 
-    return new LocalTachyonMaster(tachyonHome);
+    return new LocalTachyonMaster();
   }
 
   /**
@@ -114,7 +109,7 @@ public final class LocalTachyonMaster {
     TachyonConf tachyonConf = MasterContext.getConf();
     UnderFileSystemUtils.mkdirIfNotExists(tachyonHome, tachyonConf);
 
-    return new LocalTachyonMaster(Preconditions.checkNotNull(tachyonHome));
+    return new LocalTachyonMaster();
   }
 
   public void start() {

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,14 @@
         <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>
+
+      <!-- Dependencies used by Plugins -->
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>annotations</artifactId>
+        <version>3.0.1</version>
+        <scope>provided</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -285,9 +285,9 @@
       </dependency>
 
       <!--
-	      Dependency for FindBugs Plugin. This enables @SuppressFBWarnings.
-		  Note that this package does not need to be present at runtime.
-		-->
+          Dependency for FindBugs Plugin. This enables @SuppressFBWarnings.
+          Note that this package does not need to be present at runtime.
+        -->
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>annotations</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -286,14 +286,15 @@
 
       <!--
           Dependency for FindBugs Plugin. This enables @SuppressFBWarnings.
-          Note that this package can be unnecessary for runtime, so the
-          'provided' scope also works.
+          Note that this package can be unnecessary for runtime, and the
+          'provided' scope makes it available for compilation and test,
+          but not be packaged into the jar.
         -->
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>annotations</artifactId>
         <version>3.0.1</version>
-        <scope>compile</scope>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -286,13 +286,14 @@
 
       <!--
           Dependency for FindBugs Plugin. This enables @SuppressFBWarnings.
-          Note that this package does not need to be present at runtime.
+          Note that this package can be unnecessary for runtime, so the
+          'provided' scope also works.
         -->
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>annotations</artifactId>
         <version>3.0.1</version>
-        <scope>provided</scope>
+        <scope>compile</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,10 @@
         <scope>test</scope>
       </dependency>
 
-      <!-- Dependencies used by Plugins -->
+      <!--
+	      Dependency for FindBugs Plugin. This enables @SuppressFBWarnings.
+		  Note that this package does not need to be present at runtime.
+		-->
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>annotations</artifactId>

--- a/servers/pom.xml
+++ b/servers/pom.xml
@@ -135,6 +135,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- Dependency for findbugs (SuppressFBWarnings) -->
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/servers/src/main/java/tachyon/master/block/BlockMaster.java
+++ b/servers/src/main/java/tachyon/master/block/BlockMaster.java
@@ -71,6 +71,8 @@ import tachyon.util.CommonUtils;
 import tachyon.util.FormatUtils;
 import tachyon.util.io.PathUtils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * This master manages the metadata for all the blocks and block workers in Tachyon.
  */
@@ -135,8 +137,7 @@ public final class BlockMaster extends MasterBase implements ContainerIdGenerabl
    * The service that detects lost worker nodes, and tries to restart the failed workers.
    * We store it here so that it can be accessed from tests.
    */
-  @SuppressWarnings("unused")
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
+  @SuppressFBWarnings("URF_UNREAD_FIELD")
   private Future<?> mLostWorkerDetectionService;
   /** The next worker id to use. This state must be journaled. */
   private final AtomicLong mNextWorkerId = new AtomicLong(1);

--- a/servers/src/main/java/tachyon/master/block/BlockMaster.java
+++ b/servers/src/main/java/tachyon/master/block/BlockMaster.java
@@ -136,6 +136,7 @@ public final class BlockMaster extends MasterBase implements ContainerIdGenerabl
    * We store it here so that it can be accessed from tests.
    */
   @SuppressWarnings("unused")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
   private Future<?> mLostWorkerDetectionService;
   /** The next worker id to use. This state must be journaled. */
   private final AtomicLong mNextWorkerId = new AtomicLong(1);

--- a/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
@@ -98,6 +98,8 @@ import tachyon.underfs.UnderFileSystem;
 import tachyon.util.IdUtils;
 import tachyon.util.io.PathUtils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * The master that handles all file system metadata management.
  */
@@ -118,8 +120,7 @@ public final class FileSystemMaster extends MasterBase {
    * The service that tries to check inodefiles with ttl set.
    * We store it here so that it can be accessed from tests.
    */
-  @SuppressWarnings("unused")
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
+  @SuppressFBWarnings("URF_UNREAD_FIELD")
   private Future<?> mTTLCheckerService;
 
   private final TTLBucketList mTTLBuckets = new TTLBucketList();

--- a/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
@@ -119,6 +119,7 @@ public final class FileSystemMaster extends MasterBase {
    * We store it here so that it can be accessed from tests.
    */
   @SuppressWarnings("unused")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
   private Future<?> mTTLCheckerService;
 
   private final TTLBucketList mTTLBuckets = new TTLBucketList();

--- a/servers/src/main/java/tachyon/master/lineage/LineageMaster.java
+++ b/servers/src/main/java/tachyon/master/lineage/LineageMaster.java
@@ -100,11 +100,13 @@ public final class LineageMaster extends MasterBase {
    * The service that checkpoints lineages. We store it here so that it can be accessed from tests.
    */
   @SuppressWarnings("unused")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
   private Future<?> mCheckpointExecutionService;
   /**
    * The service that recomputes lineages. We store it here so that it can be accessed from tests.
    */
   @SuppressWarnings("unused")
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
   private Future<?> mRecomputeExecutionService;
 
   /** Map from worker to the files to checkpoint on that worker. Used by checkpoint service. */

--- a/servers/src/main/java/tachyon/master/lineage/LineageMaster.java
+++ b/servers/src/main/java/tachyon/master/lineage/LineageMaster.java
@@ -84,6 +84,8 @@ import tachyon.thrift.LineageMasterWorkerService;
 import tachyon.util.IdUtils;
 import tachyon.util.io.PathUtils;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * The lineage master stores the lineage metadata in Tachyon, and it contains the components that
  * manage all lineage-related activities.
@@ -99,14 +101,12 @@ public final class LineageMaster extends MasterBase {
   /**
    * The service that checkpoints lineages. We store it here so that it can be accessed from tests.
    */
-  @SuppressWarnings("unused")
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
+  @SuppressFBWarnings("URF_UNREAD_FIELD")
   private Future<?> mCheckpointExecutionService;
   /**
    * The service that recomputes lineages. We store it here so that it can be accessed from tests.
    */
-  @SuppressWarnings("unused")
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
+  @SuppressFBWarnings("URF_UNREAD_FIELD")
   private Future<?> mRecomputeExecutionService;
 
   /** Map from worker to the files to checkpoint on that worker. Used by checkpoint service. */

--- a/servers/src/main/java/tachyon/worker/nio/NIODataServer.java
+++ b/servers/src/main/java/tachyon/worker/nio/NIODataServer.java
@@ -61,6 +61,7 @@ public final class NIODataServer implements Runnable, DataServer {
   private Selector mSelector;
 
   // Instance of TachyonConf
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
   private final TachyonConf mTachyonConf;
 
   private final Map<SocketChannel, DataServerMessage> mSendingData =

--- a/servers/src/main/java/tachyon/worker/nio/NIODataServer.java
+++ b/servers/src/main/java/tachyon/worker/nio/NIODataServer.java
@@ -60,10 +60,6 @@ public final class NIODataServer implements Runnable, DataServer {
   // The selector we will be monitoring.
   private Selector mSelector;
 
-  // Instance of TachyonConf
-  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")
-  private final TachyonConf mTachyonConf;
-
   private final Map<SocketChannel, DataServerMessage> mSendingData =
       Collections.synchronizedMap(new HashMap<SocketChannel, DataServerMessage>());
   private final Map<SocketChannel, DataServerMessage> mReceivingData =
@@ -86,7 +82,6 @@ public final class NIODataServer implements Runnable, DataServer {
   public NIODataServer(final InetSocketAddress address, final BlockDataManager dataManager,
       TachyonConf tachyonConf) {
     LOG.info("Starting DataServer @ {}", address);
-    mTachyonConf = Preconditions.checkNotNull(tachyonConf);
     NetworkAddressUtils.assertValidPort(Preconditions.checkNotNull(address));
     mAddress = address;
     mDataManager = Preconditions.checkNotNull(dataManager);


### PR DESCRIPTION
Add findbug rule for unread/unused private variables. The public/protected ones are allowed since they may be used with classes not seen as part of the analysis.

Also, this PR suppresses the found bugs with `@edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_FIELD")`