### PR TITLE
[TACHYON-1430] Add the checkstyle rule FinalClass

### DIFF
--- a/build/checkstyle/tachyon_checks.xml
+++ b/build/checkstyle/tachyon_checks.xml
@@ -66,6 +66,8 @@
   </module>
 
   <module name="TreeWalker">
+    <!-- Checks that a class which has only private constructors is declared as final. -->
+    <module name="FinalClass"/>
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
@@ -57,7 +57,7 @@ import tachyon.thrift.FileInfo;
 public class TachyonFileSystem extends AbstractTachyonFileSystem {
   private static TachyonFileSystem sTachyonFileSystem;
 
-  public static class TachyonFileSystemFactory {
+  public static final class TachyonFileSystemFactory {
     private TachyonFileSystemFactory() {} // to prevent initialization
 
     public static synchronized TachyonFileSystem get() {

--- a/clients/unshaded/src/main/java/tachyon/client/table/TachyonRawTables.java
+++ b/clients/unshaded/src/main/java/tachyon/client/table/TachyonRawTables.java
@@ -28,10 +28,10 @@ import tachyon.exception.TachyonException;
  * {@link TachyonRawTablesFactory#get()}.
  */
 @PublicApi
-public class TachyonRawTables extends AbstractTachyonRawTables {
+public final class TachyonRawTables extends AbstractTachyonRawTables {
   private static TachyonRawTables sTachyonRawTables;
 
-  public static class TachyonRawTablesFactory {
+  public static final class TachyonRawTablesFactory {
     private TachyonRawTablesFactory() {} // prevent init
 
     public static synchronized TachyonRawTables get() {

--- a/clients/unshaded/src/main/java/tachyon/hadoop/ConfUtils.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/ConfUtils.java
@@ -30,7 +30,7 @@ import tachyon.conf.TachyonConf;
 /**
  * Utility class for {@link TachyonConf}
  */
-public class ConfUtils {
+public final class ConfUtils {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private ConfUtils() {} // Prevent instantiation.

--- a/common/src/main/java/tachyon/exception/PreconditionMessage.java
+++ b/common/src/main/java/tachyon/exception/PreconditionMessage.java
@@ -20,7 +20,7 @@ package tachyon.exception;
  *
  * Note: To minimize merge conflicts, please sort alphabetically in this section.
  */
-public class PreconditionMessage {
+public final class PreconditionMessage {
 
   public static final String CANNOT_READ_FOLDER = "Cannot read from a folder";
   public static final String CLIENT_CONTEXT_NOT_INITIALIZED = "Client Context not initialized";

--- a/integration-tests/src/test/java/tachyon/client/StreamOptionUtils.java
+++ b/integration-tests/src/test/java/tachyon/client/StreamOptionUtils.java
@@ -24,7 +24,7 @@ import tachyon.util.network.NetworkAddressUtils;
  * A util class to obtain common In/OutStreamOptions for tests
  *
  */
-public class StreamOptionUtils {
+public final class StreamOptionUtils {
   private StreamOptionUtils() {
     // not intended for instantiation
   }

--- a/integration/yarn/src/test/java/tachyon/yarn/ApplicationMasterTest.java
+++ b/integration/yarn/src/test/java/tachyon/yarn/ApplicationMasterTest.java
@@ -386,7 +386,7 @@ public class ApplicationMasterTest {
     };
   }
 
-  private static class ApplicationMasterPrivateAccess {
+  private static final class ApplicationMasterPrivateAccess {
     private final ApplicationMaster mMaster;
 
     private ApplicationMasterPrivateAccess(ApplicationMaster master) {

--- a/servers/src/main/java/tachyon/Format.java
+++ b/servers/src/main/java/tachyon/Format.java
@@ -28,7 +28,7 @@ import tachyon.util.io.PathUtils;
 /**
  * Format Tachyon File System.
  */
-public class Format {
+public final class Format {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   private static final String USAGE = String.format("java -cp %s tachyon.Format <MASTER/WORKER>",
       Version.TACHYON_JAR);

--- a/servers/src/main/java/tachyon/ValidateConf.java
+++ b/servers/src/main/java/tachyon/ValidateConf.java
@@ -30,7 +30,7 @@ import tachyon.conf.TachyonConf;
  * Validate the {@link TachyonConf} object.
  *
  */
-public class ValidateConf {
+public final class ValidateConf {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   private static boolean validate() {

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -118,7 +118,7 @@ public class TachyonMaster {
    * Factory for creating {@link TachyonMaster} or {@link TachyonMasterFaultTolerant} based on
    * {@link TachyonConf}.
    */
-  public static class Factory {
+  public static final class Factory {
     /**
      * @return {@link TachyonMasterFaultTolerant} if tachyonConf is set to use zookeeper, otherwise,
      *         return {@link TachyonMaster}.

--- a/servers/src/main/java/tachyon/master/file/meta/options/CreatePathOptions.java
+++ b/servers/src/main/java/tachyon/master/file/meta/options/CreatePathOptions.java
@@ -20,7 +20,7 @@ import tachyon.conf.TachyonConf;
 import tachyon.master.MasterContext;
 import tachyon.security.authorization.PermissionStatus;
 
-public class CreatePathOptions {
+public final class CreatePathOptions {
   public static class Builder {
     private boolean mAllowExists;
     private long mBlockSizeBytes;

--- a/servers/src/main/java/tachyon/web/WebInterfaceGeneralServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceGeneralServlet.java
@@ -40,7 +40,7 @@ public final class WebInterfaceGeneralServlet extends HttpServlet {
   /**
    * Class to make referencing tiered storage information more intuitive.
    */
-  public static class StorageTierInfo {
+  public static final class StorageTierInfo {
     private final String mStorageTierAlias;
     private final long mCapacityBytes;
     private final long mUsedBytes;

--- a/servers/src/main/java/tachyon/web/WebInterfaceWorkersServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceWorkersServlet.java
@@ -42,7 +42,7 @@ public final class WebInterfaceWorkersServlet extends HttpServlet {
    * Class to make referencing worker nodes more intuitive. Mainly to avoid implicit association by
    * array indexes.
    */
-  public static class NodeInfo implements Comparable<NodeInfo> {
+  public static final class NodeInfo implements Comparable<NodeInfo> {
     private final String mHost;
     private final int mWebPort;
     private final String mLastContactSec;

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -50,7 +50,7 @@ import tachyon.worker.block.meta.TempBlockMeta;
  * {@link StorageDir} should go through this class.
  */
 // TODO(bin): consider how to better expose information to Evictor and Allocator.
-public class BlockMetadataManager {
+public final class BlockMetadataManager {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
 
   /** A list of managed {@link StorageTier}, in order from lowest tier ordinal to greatest */

--- a/servers/src/main/java/tachyon/worker/block/ClientRWLock.java
+++ b/servers/src/main/java/tachyon/worker/block/ClientRWLock.java
@@ -43,7 +43,7 @@ public final class ClientRWLock implements ReadWriteLock {
     return new SessionLock(MAX_AVAILABLE);
   }
 
-  private class SessionLock implements Lock {
+  private final class SessionLock implements Lock {
     private final int mPermits;
 
     private SessionLock(int permits) {

--- a/servers/src/test/java/tachyon/worker/block/BlockLockManagerTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockLockManagerTest.java
@@ -21,12 +21,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mockito;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import tachyon.exception.BlockDoesNotExistException;
 import tachyon.exception.ExceptionMessage;
 import tachyon.exception.InvalidWorkerStateException;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(BlockMetadataManager.class)
 public class BlockLockManagerTest {
   private static final long TEST_SESSION_ID = 2;
   private static final long TEST_BLOCK_ID = 9;
@@ -41,8 +46,10 @@ public class BlockLockManagerTest {
 
   @Before
   public void before() throws Exception {
-    BlockMetadataManager mockMetaManager = Mockito.mock(BlockMetadataManager.class);
-    Mockito.when(mockMetaManager.hasBlockMeta(TEST_BLOCK_ID)).thenReturn(true);
+    //BlockMetadataManager mockMetaManager = Mockito.mock(BlockMetadataManager.class);
+    BlockMetadataManager mockMetaManager = PowerMockito.mock(BlockMetadataManager.class);
+    PowerMockito.when(mockMetaManager.hasBlockMeta(TEST_BLOCK_ID)).thenReturn(true);
+    //Mockito.when(mockMetaManager.hasBlockMeta(TEST_BLOCK_ID)).thenReturn(true);
     mLockManager = new BlockLockManager();
   }
 

--- a/servers/src/test/java/tachyon/worker/block/BlockLockManagerTest.java
+++ b/servers/src/test/java/tachyon/worker/block/BlockLockManagerTest.java
@@ -46,10 +46,8 @@ public class BlockLockManagerTest {
 
   @Before
   public void before() throws Exception {
-    //BlockMetadataManager mockMetaManager = Mockito.mock(BlockMetadataManager.class);
     BlockMetadataManager mockMetaManager = PowerMockito.mock(BlockMetadataManager.class);
     PowerMockito.when(mockMetaManager.hasBlockMeta(TEST_BLOCK_ID)).thenReturn(true);
-    //Mockito.when(mockMetaManager.hasBlockMeta(TEST_BLOCK_ID)).thenReturn(true);
     mLockManager = new BlockLockManager();
   }
 


### PR DESCRIPTION
[TACHYON-1430] Add the checkstyle rule FinalClass

JIRA link https://tachyon.atlassian.net/browse/TACHYON-1430

Add the FinalClass checkstyle module in build/checkstyle/tachyon_checks.xml to enable style checks that a class which has only private constructors is declared as final. And with this check, find several classes not fit the rule.

There are:
clients/unshaded/src/main/java/tachyon/client/file/TachyonFileSystem.java
clients/unshaded/src/main/java/tachyon/client/table/TachyonRawTables.java
clients/unshaded/src/main/java/tachyon/hadoop/ConfUtils.java
common/src/main/java/tachyon/exception/PreconditionMessage.java
integration-tests/src/test/java/tachyon/client/StreamOptionUtils.java
servers/src/main/java/tachyon/Format.java
servers/src/main/java/tachyon/ValidateConf.java
servers/src/main/java/tachyon/master/TachyonMaster.java
servers/src/main/java/tachyon/master/file/meta/options/CreatePathOptions.java
servers/src/main/java/tachyon/web/WebInterfaceGeneralServlet.java
servers/src/main/java/tachyon/web/WebInterfaceWorkersServlet.java
servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
servers/src/main/java/tachyon/worker/block/ClientRWLock.java