### PR TITLE
[TACHYON-1404] Remove one unused comment in tachyon/worker/lineage/LineageWorker.java

### DIFF
--- a/servers/src/main/java/tachyon/worker/lineage/LineageWorker.java
+++ b/servers/src/main/java/tachyon/worker/lineage/LineageWorker.java
@@ -39,7 +39,6 @@ import tachyon.worker.block.BlockDataManager;
 public final class LineageWorker extends WorkerBase {
   /** Logic for managing lineage file persistence */
   private final LineageDataManager mLineageDataManager;
-  /** Threadpool for the lineage master sync */
   /** Client for lineage master communication. */
   private final LineageMasterClient mLineageMasterWorkerClient;
   /** Configuration object */


### PR DESCRIPTION
[TACHYON-1404]
Remove the following line in tachyon/worker/lineage/LineageWorker.java because it is no more meaningful.
"/** Threadpool for the lineage master sync */"