### PR TITLE
[TACHYON-1450] TACHYON_WORKER_MEMORY_SIZE does not work as expected when bare metal total memory is over 100GB

### DIFF
--- a/bin/tachyon-mount.sh
+++ b/bin/tachyon-mount.sh
@@ -137,9 +137,9 @@ function mount_ramfs_linux() {
   fi
 
   mem_size_to_bytes
-  FREE_MEM=$(($(cat /proc/meminfo | awk 'NR==1{print $2}') * 1024))
-  if [ $FREE_MEM -lt $BYTE_SIZE ] ; then
-    echo "ERROR: Memory($FREE_MEM) is less than requested ramdisk size($BYTE_SIZE). Please reduce TACHYON_WORKER_MEMORY_SIZE"
+  TOTAL_MEM=$(($(cat /proc/meminfo | awk 'NR==1{print $2}') * 1024))
+  if [ $TOTAL_MEM -lt $BYTE_SIZE ] ; then
+    echo "ERROR: Memory($TOTAL_MEM) is less than requested ramdisk size($BYTE_SIZE). Please reduce TACHYON_WORKER_MEMORY_SIZE"
     exit 1
   fi
 

--- a/bin/tachyon-mount.sh
+++ b/bin/tachyon-mount.sh
@@ -137,7 +137,7 @@ function mount_ramfs_linux() {
   fi
 
   mem_size_to_bytes
-  FREE_MEM=`free -b | grep "^Mem" | awk '{print $2}'`
+  FREE_MEM=$(($(cat /proc/meminfo | awk 'NR==1{print $2}') * 1024))
   if [ $FREE_MEM -lt $BYTE_SIZE ] ; then
     echo "ERROR: Memory($FREE_MEM) is less than requested ramdisk size($BYTE_SIZE). Please reduce TACHYON_WORKER_MEMORY_SIZE"
     exit 1


### PR DESCRIPTION
`free -b` would truncate value if total memory is over 100GB, and TACHYON_WORKER_MEMORY_SIZE will not work as expected.