### PR TITLE
[SMALLFIX] Fixed documentation links for 'checkUserFileBufferBytes' in TachyonConf

### DIFF
--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -488,7 +488,9 @@ public final class TachyonConf {
   }
 
   /**
-   * {@link Constants.USER_FILE_BUFFER_BYTES} should not bigger than Integer.MAX_VALUE bytes.
+   * {@link Constants#USER_FILE_BUFFER_BYTES} should not bigger than {@link Integer#MAX_VALUE}
+   * bytes.
+   *
    * @throws IllegalArgumentException if USER_FILE_BUFFER_BYTES bigger than Integer.MAX_VALUE
    */
   private void checkUserFileBufferBytes() {


### PR DESCRIPTION
Fixed the ```{@link ...}``` usage in ```checkUserFileBufferBytes``` method in the ```TachyonConf``` class.