### PR TITLE
[SMALLFIX] Prompt users that the mount op in start script will format the RamFS

### DIFF
--- a/bin/tachyon-start.sh
+++ b/bin/tachyon-start.sh
@@ -20,8 +20,8 @@ Where WHAT is one of:
   restart_workers\tRestart any failed workers on worker nodes
 
 MOPT is one of:
-  Mount\t\t\tMount the configured RamFS
-  SudoMount\t\tMount the configured RamFS using sudo
+  Mount\t\t\tMount the configured RamFS. Notice: this will format the existing RamFS.
+  SudoMount\t\tMount the configured RamFS using sudo. Notice: this will format the existing RamFS.
   NoMount\t\tDo not mount the configured RamFS
 
 -f  format Journal, UnderFS Data and Workers Folder on master

--- a/docs/Running-Tachyon-on-a-Cluster.md
+++ b/docs/Running-Tachyon-on-a-Cluster.md
@@ -32,6 +32,7 @@ Now, you can start Tachyon:
 $ cd tachyon
 $ ./bin/tachyon format
 $ ./bin/tachyon-start.sh # use the right parameters here. e.g. all Mount
+# Notice: the Mount and SudoMount parameters will format the existing RamFS.
 ```
 
 To verify that Tachyon is running, you can visit


### PR DESCRIPTION
Some users complain that when they start or restart Tachyon, their data on RAMFS, including the previous data in Tachyon's RAMFS, is lost. Acutally, our tachyon-start.sh comand does not explicitly tell the users about the formating RAMFS operation triggered by the Mount. Thus, the users that familiar with HDFS's or other file systems' commands may hardly be aware of the risk. I think it is necessary to add this prompt in the corresponding script and docs. This SMALLFIX address this issue. @calvinjia 
