### PR TITLE
[SMALLFIX] Added the usage of the delimiter parameter to the 'getList' method of the 'TachyonConf' class

### DIFF
--- a/common/src/main/java/tachyon/conf/TachyonConf.java
+++ b/common/src/main/java/tachyon/conf/TachyonConf.java
@@ -377,7 +377,8 @@ public final class TachyonConf {
         + "list");
     if (mProperties.containsKey(key)) {
       String rawValue = mProperties.getProperty(key);
-      return Lists.newLinkedList(Splitter.on(',').trimResults().omitEmptyStrings().split(rawValue));
+      return Lists.newLinkedList(Splitter.on(delimiter).trimResults().omitEmptyStrings()
+          .split(rawValue));
     }
     // if key is not found among the default properties
     throw new RuntimeException(ExceptionMessage.INVALID_CONFIGURATION_KEY.getMessage(key));


### PR DESCRIPTION
The ```getList``` method of the ```TachyonConf``` class has a ```delimiter``` parameter, but isn't actually using it. Instead it uses a comma as a hard-coded value. Added the parameter to the ```Splitter.on``` method to make use of it.