### PR TITLE
[SMALLFIX] Changed the signature of 'usedInSecurityContextTest' in 'UserTest'

### DIFF
--- a/common/src/test/java/tachyon/security/UserTest.java
+++ b/common/src/test/java/tachyon/security/UserTest.java
@@ -28,10 +28,9 @@ public final class UserTest {
   /**
    * This test verifies whether the {@link tachyon.security.User} could be used in Java security
    * framework.
-   * @throws Exception
    */
   @Test
-  public void usedInSecurityContextTest() throws Exception {
+  public void usedInSecurityContextTest() {
     // add new users into Subject
     Subject subject = new Subject();
     subject.getPrincipals().add(new User("realUser"));


### PR DESCRIPTION
The ```usedInSecurityContextTest``` in the ```UserTest``` doesn't throw an ```Exception```. Removed it from the signature of the method.