### PR TITLE
[TACHYON-1402] Handle parameter inconsistency between docs and default properties

### DIFF
--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -87,11 +87,6 @@ The common configuration contains constants shared by different components.
   <td>Flag used only during tests to allow special behavior.</td>
 </tr>
 <tr>
-  <td>tachyon.thrift.stop.timeout.seconds</td>
-  <td>60</td>
-  <td>Time to wait for thrift server to stop gracefully, in seconds.</td>
-</tr>
-<tr>
   <td>tachyon.underfs.address</td>
   <td>${tachyon.home}/underFSStorage</td>
   <td>Tachyon folder in the underlayer file system.</td>
@@ -566,7 +561,7 @@ The user configuration specifies values regarding file system access.
 <tr>
   <td>tachyon.user.block.master.client.threads</td>
   <td>10</td>
-  <td>How many threads to use for block master client to talk to block master.</td>
+  <td>The number of threads used by a block master client to talk to the block master.</td>
 </tr>
 <tr>
   <td>tachyon.user.block.worker.client.threads</td>
@@ -607,7 +602,7 @@ The user configuration specifies values regarding file system access.
 <tr>
   <td>tachyon.user.file.master.client.threads</td>
   <td>10</td>
-  <td>How many threads to use for file system master client to talk to block master.</td>
+  <td>The number of threads used by a file master client to talk to the file master.</td>
 </tr>
 <tr>
   <td>tachyon.user.file.waitcompleted.poll.ms</td>
@@ -645,7 +640,7 @@ The user configuration specifies values regarding file system access.
 <tr>
   <td>tachyon.user.lineage.master.client.threads</td>
   <td>10</td>
-  <td>How many threads to use for lineage master client to talk to lineage master.</td>
+  <td>The number of threads used by a lineage master client to talk to the lineage master.</td>
 </tr>
 <tr>
   <td>tachyon.user.network.netty.timeout.ms</td>
@@ -666,7 +661,7 @@ The user configuration specifies values regarding file system access.
 <tr>
   <td>tachyon.user.raw.table.master.client.threads</td>
   <td>10</td>
-  <td>How many threads to use for raw table master client to talk to raw table master.</td>
+  <td>The number of threads used by a raw table master client to talk to the raw table master.</td>
 </tr>
 </table>
 

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -87,6 +87,11 @@ The common configuration contains constants shared by different components.
   <td>Flag used only during tests to allow special behavior.</td>
 </tr>
 <tr>
+  <td>tachyon.thrift.stop.timeout.seconds</td>
+  <td>60</td>
+  <td>Time to wait for thrift server to stop gracefully, in seconds.</td>
+</tr>
+<tr>
   <td>tachyon.underfs.address</td>
   <td>${tachyon.home}/underFSStorage</td>
   <td>Tachyon folder in the underlayer file system.</td>
@@ -638,6 +643,11 @@ The user configuration specifies values regarding file system access.
   <td>Flag to enable lineage feature.</td>
 </tr>
 <tr>
+  <td>tachyon.user.lineage.master.client.threads</td>
+  <td>10</td>
+  <td>How many threads to use for lineage master client to talk to lineage master.</td>
+</tr>
+<tr>
   <td>tachyon.user.network.netty.timeout.ms</td>
   <td>3000</td>
   <td>The maximum number of milliseconds for a netty client (for block reads and block writes) to
@@ -652,6 +662,11 @@ The user configuration specifies values regarding file system access.
   <td>tachyon.user.quota.unit.bytes</td>
   <td>8 MB</td>
   <td>The minimum number of bytes that will be requested from a client to a worker at a time.</td>
+</tr>
+<tr>
+  <td>tachyon.user.raw.table.master.client.threads</td>
+  <td>10</td>
+  <td>How many threads to use for raw table master client to talk to raw table master.</td>
 </tr>
 </table>
 


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1402

I have added some properties to docs to match up with the ones in `tanchyon-default.properties`, except the following ones. The reasons are described as below.

**`tachyon.security.*`** - The security properties are related to [[TACHYON-789](https://tachyon.atlassian.net/browse/TACHYON-789)]Tachyon Security, which is WIP. So, I left them behind. I think when [[TACHYON-789](https://tachyon.atlassian.net/browse/TACHYON-789)]  is finished, we can add the `tachyon.security.*` into docs.

**`tachyon.version`** - This is the project-build property used inside the project, and it cannot be configured. So, we didn't add it into docs.

**`tachyon.*.hostname`** - These default values are undefined in `tachyon-default.properties` but Tachyon will resovle them as the local hostname/address (see `tachyon.util.network.NetworkAddressUtils.getConnectHost()`). I think this is on purpose since the hostname should be resovled automatically, which may not be the exact string "localhost". So, we didn't  put it into the docs.

**`tachyon.fuse.*`** - The FUSE properties are related to Tachyon FUSE Component. The configurations are already shown in `Mounting-Tachyon-FS-with-FUSE.md` page.