### PR TITLE
Revert "[TACHYON-987] Enable fault tolerant tests"

### DIFF
--- a/common/src/main/java/tachyon/LeaderInquireClient.java
+++ b/common/src/main/java/tachyon/LeaderInquireClient.java
@@ -65,7 +65,6 @@ public final class LeaderInquireClient {
     mZookeeperAddress = zookeeperAddress;
     mLeaderPath = leaderPath;
 
-    LOG.info("create new zookeeper client. address: {}", mZookeeperAddress);
     mClient =
         CuratorFrameworkFactory.newClient(mZookeeperAddress, new ExponentialBackoffRetry(
             Constants.SECOND_MS, 3));
@@ -110,7 +109,7 @@ public final class LeaderInquireClient {
         CommonUtils.sleepMs(LOG, Constants.SECOND_MS);
       }
     } catch (Exception e) {
-      LOG.error("Error with zookeeper: {} message: {}", mZookeeperAddress, e.getMessage());
+      LOG.error(e.getMessage(), e);
     }
 
     return null;

--- a/integration-tests/src/test/java/tachyon/master/MasterFaultToleranceIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/MasterFaultToleranceIntegrationTest.java
@@ -22,31 +22,28 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 
 import tachyon.Constants;
+import tachyon.collections.Pair;
 import tachyon.TachyonURI;
 import tachyon.client.TachyonFSTestUtils;
 import tachyon.client.UnderStorageType;
 import tachyon.client.block.TachyonBlockStore;
 import tachyon.client.file.TachyonFile;
 import tachyon.client.file.TachyonFileSystem;
-import tachyon.client.file.options.DeleteOptions;
 import tachyon.client.file.options.OutStreamOptions;
-import tachyon.collections.Pair;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.TachyonException;
 import tachyon.thrift.FileInfo;
 import tachyon.util.CommonUtils;
 import tachyon.util.io.PathUtils;
 
+@Ignore("TACHYON-987")
 public class MasterFaultToleranceIntegrationTest {
-  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
-
   private static final long WORKER_CAPACITY_BYTES = 10000;
   private static final int BLOCK_SIZE = 30;
   private static final int MASTERS = 5;
@@ -57,15 +54,10 @@ public class MasterFaultToleranceIntegrationTest {
   @After
   public final void after() throws Exception {
     mLocalTachyonClusterMultiMaster.stop();
-    // Reset the master conf.
-    MasterContext.getConf().merge(new TachyonConf());
   }
 
   @Before
   public final void before() throws Exception {
-    // TODO(gpang): Implement multi-master cluster as a resource.
-    // Reset the master conf.
-    MasterContext.getConf().merge(new TachyonConf());
     mLocalTachyonClusterMultiMaster =
         new LocalTachyonClusterMultiMaster(WORKER_CAPACITY_BYTES, MASTERS, BLOCK_SIZE);
     mLocalTachyonClusterMultiMaster.start();
@@ -144,8 +136,7 @@ public class MasterFaultToleranceIntegrationTest {
         // We can not call mTfs.delete(mTfs.open(new TachyonURI(TachyonURI.SEPARATOR))) because root
         // node can not be deleted.
         for (FileInfo file : mTfs.listStatus(mTfs.open(new TachyonURI(TachyonURI.SEPARATOR)))) {
-          mTfs.delete(new TachyonFile(file.getFileId()),
-              new DeleteOptions.Builder().setRecursive(true).build());
+          mTfs.delete(new TachyonFile(file.getFileId()));
         }
         answer.clear();
         faultTestDataCheck(answer);

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
@@ -44,6 +44,7 @@ import tachyon.worker.lineage.LineageWorker;
  * </pre>
  */
 public final class LocalTachyonCluster extends AbstractLocalTachyonCluster {
+
   private LocalTachyonMaster mMaster;
   private TachyonConf mClientConf;
 

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonMaster.java
@@ -134,15 +134,6 @@ public final class LocalTachyonMaster {
 
   }
 
-  /**
-   * Kill the master thread, by calling {@link Thread#interrupt()}.
-   *
-   * @throws Exception if master thread cannot be interrupted
-   */
-  public void kill() throws Exception {
-    mMasterThread.interrupt();
-  }
-
   public void clearClients() throws IOException {
     mClientPool.close();
   }

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -189,6 +189,10 @@ public class TachyonMaster {
       MasterContext.getMasterSource().registerGauges(this);
       mMasterMetricsSystem = new MetricsSystem("master", MasterContext.getConf());
       mMasterMetricsSystem.registerSource(MasterContext.getMasterSource());
+
+      mWebServer =
+          new MasterUIWebServer(ServiceType.MASTER_WEB, NetworkAddressUtils.getBindAddress(
+              ServiceType.MASTER_WEB, conf), this, conf);
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);
       throw Throwables.propagate(e);
@@ -220,20 +224,14 @@ public class TachyonMaster {
    * @return the actual bind hostname on web service (used by unit test only)
    */
   public String getWebBindHost() {
-    if (mWebServer != null) {
-      return mWebServer.getBindHost();
-    }
-    return "";
+    return mWebServer.getBindHost();
   }
 
   /**
    * @return the actual port that the web service is listening on (used by unit test only)
    */
   public int getWebLocalPort() {
-    if (mWebServer != null) {
-      return mWebServer.getLocalPort();
-    }
-    return -1;
+    return mWebServer.getLocalPort();
   }
 
   /**
@@ -284,13 +282,11 @@ public class TachyonMaster {
    */
   public void stop() throws Exception {
     if (mIsServing) {
-      LOG.info("Stopping RPC server on Tachyon Master @ {}", mMasterAddress);
+      LOG.info("Stopping Tachyon Master @ {}", mMasterAddress);
       stopServing();
       stopMasters();
       mTServerSocket.close();
       mIsServing = false;
-    } else {
-      LOG.info("Stopping Tachyon Master @ {}", mMasterAddress);
     }
   }
 
@@ -340,11 +336,6 @@ public class TachyonMaster {
   }
 
   protected void startServingWebServer() {
-    TachyonConf conf = MasterContext.getConf();
-    mWebServer =
-        new MasterUIWebServer(ServiceType.MASTER_WEB, NetworkAddressUtils.getBindAddress(
-            ServiceType.MASTER_WEB, conf), this, conf);
-
     // Add the metrics servlet to the web server, this must be done after the metrics system starts
     mWebServer.addHandler(mMasterMetricsSystem.getServletHandler());
     // start web ui


### PR DESCRIPTION
Reverts amplab/tachyon#1587

Since merging this the build has been hanging in `MasterFaultToleranceIntegrationTest`

See https://amplab.cs.berkeley.edu/jenkins/view/Tachyon/job/Tachyon-Master/PROFILE=hdfs1Test,label=centos/1649/console and https://amplab.cs.berkeley.edu/jenkins/view/Tachyon/job/Tachyon-Master/PROFILE=hdfs1Test,label=centos/1648/console