### PR TITLE
[TACHYON-1466] bin/tachyon runTest usage help info out of date

### DIFF
--- a/bin/tachyon
+++ b/bin/tachyon
@@ -77,7 +77,7 @@ TACHYON_LIBEXEC_DIR=${TACHYON_LIBEXEC_DIR:-$DEFAULT_LIBEXEC_DIR}
 . ${TACHYON_LIBEXEC_DIR}/tachyon-config.sh
 
 function runTest {
-  Usage="Usage: tachyon runTest <Basic|BasicNonByteBuffer|BasicRawTable> <STORE|NO_STORE> <SYNC_PERSIST|NO_PERSIST>"
+  Usage="Usage: tachyon runTest <Basic|BasicNonByteBuffer|BasicRawTable> <CACHE_PROMOTE|CACHE|NO_CACHE> <MUST_CACHE|CACHE_THROUGH|THROUGH>"
 
   if [[ $# -ne 3 ]]; then
     echo ${Usage}


### PR DESCRIPTION
When I use the bin/tachyon runTest following the runTest task usage help to test the OSSUnderFilssystem in a real environment, the test didn't work, then I found this is because the runTest usage help information is out of date.  

Fix it can help new users escape from been confused