### PR TITLE
[SMALLFIX] Fix bug in UfsUtilsIntegrationTest

### DIFF
--- a/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
@@ -30,6 +30,7 @@ import tachyon.collections.PrefixList;
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.util.UnderFileSystemUtils;
+import tachyon.util.io.PathUtils;
 
 /**
  * To test the utilities related to under filesystem, including loadufs and etc.
@@ -56,14 +57,16 @@ public class UfsUtilsIntegrationTest {
     String[] exclusions = {"/tachyon", "/exclusions"};
     String[] inclusions = {"/inclusions/sub-1", "/inclusions/sub-2"};
     for (String exclusion : exclusions) {
-      if (!mUfs.exists(mUfsRoot + exclusion)) {
-        mUfs.mkdirs(mUfsRoot + exclusion, true);
+      String path = PathUtils.concatPath(mUfsRoot, exclusion);
+      if (!mUfs.exists(path)) {
+        mUfs.mkdirs(path, true);
       }
     }
 
     for (String inclusion : inclusions) {
-      if (!mUfs.exists(mUfsRoot + inclusion)) {
-        mUfs.mkdirs(mUfsRoot + inclusion, true);
+      String path = PathUtils.concatPath(mUfsRoot, inclusion);
+      if (!mUfs.exists(path)) {
+        mUfs.mkdirs(path, true);
       }
       UnderFileSystemUtils.touch(mUfsRoot + inclusion + "/1",
           mLocalTachyonClusterResource.get().getMasterTachyonConf());

--- a/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/UfsUtilsIntegrationTest.java
@@ -24,9 +24,9 @@ import org.junit.Test;
 
 import tachyon.Constants;
 import tachyon.LocalTachyonClusterResource;
-import tachyon.collections.PrefixList;
 import tachyon.TachyonURI;
 import tachyon.client.file.TachyonFileSystem;
+import tachyon.collections.PrefixList;
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.util.UnderFileSystemUtils;
@@ -56,13 +56,13 @@ public class UfsUtilsIntegrationTest {
     String[] exclusions = {"/tachyon", "/exclusions"};
     String[] inclusions = {"/inclusions/sub-1", "/inclusions/sub-2"};
     for (String exclusion : exclusions) {
-      if (!mUfs.exists(exclusion)) {
+      if (!mUfs.exists(mUfsRoot + exclusion)) {
         mUfs.mkdirs(mUfsRoot + exclusion, true);
       }
     }
 
     for (String inclusion : inclusions) {
-      if (!mUfs.exists(inclusion)) {
+      if (!mUfs.exists(mUfsRoot + inclusion)) {
         mUfs.mkdirs(mUfsRoot + inclusion, true);
       }
       UnderFileSystemUtils.touch(mUfsRoot + inclusion + "/1",


### PR DESCRIPTION
The test was checking the wrong directories for existence, so
a system with a directory at /tachyon would fail the test.