### PR TITLE
[SMALLFIX] Fixed test in 'NetworkAddressUtilsTest'

### DIFF
--- a/common/src/test/java/tachyon/util/network/NetworkAddressUtilsTest.java
+++ b/common/src/test/java/tachyon/util/network/NetworkAddressUtilsTest.java
@@ -114,11 +114,11 @@ public class NetworkAddressUtilsTest {
   @Test
   public void testGetBindAddress() throws Exception {
     for (ServiceType service : ServiceType.values()) {
-      getConnectAddress(service);
+      getBindAddress(service);
     }
   }
 
-  public void getBindAddress(ServiceType service) throws Exception {
+  private void getBindAddress(ServiceType service) throws Exception {
     TachyonConf conf = new TachyonConf();
     String localHostName = NetworkAddressUtils.getLocalHostName(conf);
     InetSocketAddress workerAddress;
@@ -162,7 +162,25 @@ public class NetworkAddressUtilsTest {
         workerAddress);
 
     // connect host and wildcard bind host with port
-    conf.set(Constants.WORKER_RPC_PORT, "20000");
+    switch (service) {
+      case MASTER_RPC:
+        conf.set(Constants.MASTER_RPC_PORT, "20000");
+        break;
+      case MASTER_WEB:
+        conf.set(Constants.MASTER_WEB_PORT, "20000");
+        break;
+      case WORKER_RPC:
+        conf.set(Constants.WORKER_RPC_PORT, "20000");
+        break;
+      case WORKER_DATA:
+        conf.set(Constants.WORKER_DATA_PORT, "20000");
+        break;
+      case WORKER_WEB:
+        conf.set(Constants.WORKER_WEB_PORT, "20000");
+        break;
+      default:
+        break;
+    }
     workerAddress = NetworkAddressUtils.getBindAddress(service, conf);
     Assert.assertEquals(new InetSocketAddress(NetworkAddressUtils.WILDCARD_ADDRESS, 20000),
         workerAddress);

--- a/common/src/test/java/tachyon/util/network/NetworkAddressUtilsTest.java
+++ b/common/src/test/java/tachyon/util/network/NetworkAddressUtilsTest.java
@@ -179,6 +179,7 @@ public class NetworkAddressUtilsTest {
         conf.set(Constants.WORKER_WEB_PORT, "20000");
         break;
       default:
+        Assert.fail("Unrecognized service type: " + service.toString());
         break;
     }
     workerAddress = NetworkAddressUtils.getBindAddress(service, conf);


### PR DESCRIPTION
The ```testGetBindAddress``` method in the ```NetworkAddressUtilsTest``` wasn't actually testing the binding of the addresses. The test is now pointing to the correct helper method. In this method the different service types are now setting the port for their specific configuration.