### PR TITLE
better error message for cleanDirectBuffer

### DIFF
--- a/common/src/main/java/tachyon/util/io/BufferUtils.java
+++ b/common/src/main/java/tachyon/util/io/BufferUtils.java
@@ -76,6 +76,7 @@ public final class BufferUtils {
         if (buffer.capacity() > 0) {
           LOG.error("Failed to get cleaner for ByteBuffer");
         }
+        // The cleaner could be null when the buffer is initialized as zero capacity.
         return;
       }
       if (sCleanerCleanMethod == null) {

--- a/common/src/main/java/tachyon/util/io/BufferUtils.java
+++ b/common/src/main/java/tachyon/util/io/BufferUtils.java
@@ -73,7 +73,9 @@ public final class BufferUtils {
       }
       final Object cleaner = sByteBufferCleanerMethod.invoke(buffer);
       if (cleaner == null) {
-        LOG.error("Failed to get cleaner for ByteBuffer");
+        if (buffer.capacity() > 0) {
+          LOG.error("Failed to get cleaner for ByteBuffer");
+        }
         return;
       }
       if (sCleanerCleanMethod == null) {


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1442

Only log the error message when the buffer is supposed to have a non-null Cleaner. Otherwise when the buffer is empty, the Cleaner is actually set as null during initialization.