### PR TITLE
[TACHYON-1460] Add integration test for the OSS UnderFileSystem

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -194,10 +194,49 @@
                 <!-- Change "myAccessKey" to your access key for this test -->
                 <accessKey>myAccessKey</accessKey>
                 <!-- Change "mySecreteKey" to your secrete key for this test -->
-                <secretKey>mySecretKey</secretKey>
+                <secretKey>mySecreteKey</secretKey>
                 <!-- Change "s3n://my-bucket/tachyon-test" to the name of your
                      S3 bucket for this test -->
                 <s3Bucket>s3n://my-bucket/tachyon-test</s3Bucket>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>ossTest</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.tachyonproject</groupId>
+          <artifactId>tachyon-underfs-oss</artifactId>
+          <version>${project.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+          <version>4.4</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <ufs>tachyon.underfs.oss.OSSUnderStorageCluster</ufs>
+                <!-- Change "myAccessId" to your oss access id for this test -->
+                <fs.oss.accessKeyId>myAccessId</fs.oss.accessKeyId>
+                <!-- Change "mySecretKey" to your oss access secret key for this test -->
+                <fs.oss.accessKeySecret>mySecretKey</fs.oss.accessKeySecret>
+                <!-- Change this endpoint for your oss service address for this test -->
+                <fs.oss.endpoint>http://oss-cn-hangzhou.aliyuncs.com</fs.oss.endpoint>
+                <!-- Change "your-bucket" to your oss bucket for this test -->
+                <ossBucket>oss://your-bucket/tachyon-integration-test/</ossBucket>
               </systemPropertyVariables>
             </configuration>
           </plugin>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -194,7 +194,7 @@
                 <!-- Change "myAccessKey" to your access key for this test -->
                 <accessKey>myAccessKey</accessKey>
                 <!-- Change "mySecreteKey" to your secrete key for this test -->
-                <secretKey>mySecreteKey</secretKey>
+                <secretKey>mySecretKey</secretKey>
                 <!-- Change "s3n://my-bucket/tachyon-test" to the name of your
                      S3 bucket for this test -->
                 <s3Bucket>s3n://my-bucket/tachyon-test</s3Bucket>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -229,10 +229,10 @@
             <configuration>
               <systemPropertyVariables>
                 <ufs>tachyon.underfs.oss.OSSUnderStorageCluster</ufs>
-                <!-- Change "myAccessId" to your oss access id for this test -->
-                <fs.oss.accessKeyId>myAccessId</fs.oss.accessKeyId>
-                <!-- Change "mySecretKey" to your oss access secret key for this test -->
-                <fs.oss.accessKeySecret>mySecretKey</fs.oss.accessKeySecret>
+                <!-- Change "yourAccessId" to your oss access id for this test -->
+                <fs.oss.accessKeyId>yourAccessId</fs.oss.accessKeyId>
+                <!-- Change "yourSecretKey" to your oss access secret key for this test -->
+                <fs.oss.accessKeySecret>yourSecretKey</fs.oss.accessKeySecret>
                 <!-- Change this endpoint for your oss service address for this test -->
                 <fs.oss.endpoint>http://oss-cn-hangzhou.aliyuncs.com</fs.oss.endpoint>
                 <!-- Change "your-bucket" to your oss bucket for this test -->

--- a/integration-tests/src/test/java/tachyon/underfs/oss/OSSUnderStorageCluster.java
+++ b/integration-tests/src/test/java/tachyon/underfs/oss/OSSUnderStorageCluster.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.underfs.oss;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import tachyon.Constants;
+import tachyon.conf.TachyonConf;
+import tachyon.underfs.UnderFileSystem;
+import tachyon.underfs.UnderFileSystemCluster;
+
+public class OSSUnderStorageCluster extends UnderFileSystemCluster {
+
+  //private static final String INTEGRATION_OSS_ACCESS_ID = "accessId";
+  //private static final String INTEGRATION_OSS_ACCESS_KEY = "accessKey";
+  private static final String INTEGRATION_OSS_BUCKET = "ossBucket";
+  //private static final String INTEGRATION_OSS_ENDPOINT = "ossEndpoint";
+
+  private String mOSSBucket;
+
+  public OSSUnderStorageCluster(String baseDir, TachyonConf tachyonConf) {
+    super(baseDir, tachyonConf);
+    /*
+    String ossAccessId = System.getProperty(INTEGRATION_OSS_ACCESS_ID);
+    String ossAccessKey = System.getProperty(INTEGRATION_OSS_ACCESS_KEY);
+    String ossEndpoint = System.getProperty(INTEGRATION_OSS_ENDPOINT);
+    tachyonConf.set(Constants.OSS_ACCESS_KEY, ossAccessId);
+    tachyonConf.set(Constants.OSS_SECRET_KEY, ossAccessKey);
+    tachyonConf.set(Constants.OSS_ENDPOINT_KEY, ossEndpoint);
+    */
+
+    String ossAccessId = System.getProperty(Constants.OSS_ACCESS_KEY);
+    String ossAccessKey = System.getProperty(Constants.OSS_SECRET_KEY);
+    String ossEndpoint = System.getProperty(Constants.OSS_ENDPOINT_KEY);
+    tachyonConf.set(Constants.OSS_ACCESS_KEY, ossAccessId);
+    tachyonConf.set(Constants.OSS_SECRET_KEY, ossAccessKey);
+    tachyonConf.set(Constants.OSS_ENDPOINT_KEY, ossEndpoint);
+    mOSSBucket = System.getProperty(INTEGRATION_OSS_BUCKET);
+    mBaseDir = mOSSBucket + UUID.randomUUID();
+  }
+
+  @Override
+  public void cleanup() throws IOException {
+    String oldTestDir = mBaseDir;
+    mBaseDir = mOSSBucket + UUID.randomUUID();
+    UnderFileSystem ufs = UnderFileSystem.get(mBaseDir, mTachyonConf);
+    ufs.delete(oldTestDir, true);
+  }
+
+  @Override
+  public String getUnderFilesystemAddress() {
+    return mBaseDir;
+  }
+
+  @Override
+  public boolean isStarted() {
+    return true;
+  }
+
+  @Override
+  public void registerJVMOnExistHook() throws IOException {
+    super.registerJVMOnExistHook();
+  }
+
+  @Override
+  public void shutdown() throws IOException {
+  }
+
+  @Override
+  public void start() throws IOException {
+  }
+}

--- a/integration-tests/src/test/java/tachyon/underfs/oss/OSSUnderStorageCluster.java
+++ b/integration-tests/src/test/java/tachyon/underfs/oss/OSSUnderStorageCluster.java
@@ -34,15 +34,6 @@ public class OSSUnderStorageCluster extends UnderFileSystemCluster {
 
   public OSSUnderStorageCluster(String baseDir, TachyonConf tachyonConf) {
     super(baseDir, tachyonConf);
-    /*
-    String ossAccessId = System.getProperty(INTEGRATION_OSS_ACCESS_ID);
-    String ossAccessKey = System.getProperty(INTEGRATION_OSS_ACCESS_KEY);
-    String ossEndpoint = System.getProperty(INTEGRATION_OSS_ENDPOINT);
-    tachyonConf.set(Constants.OSS_ACCESS_KEY, ossAccessId);
-    tachyonConf.set(Constants.OSS_SECRET_KEY, ossAccessKey);
-    tachyonConf.set(Constants.OSS_ENDPOINT_KEY, ossEndpoint);
-    */
-
     String ossAccessId = System.getProperty(Constants.OSS_ACCESS_KEY);
     String ossAccessKey = System.getProperty(Constants.OSS_SECRET_KEY);
     String ossEndpoint = System.getProperty(Constants.OSS_ENDPOINT_KEY);

--- a/integration-tests/src/test/java/tachyon/underfs/oss/OSSUnderStorageCluster.java
+++ b/integration-tests/src/test/java/tachyon/underfs/oss/OSSUnderStorageCluster.java
@@ -25,10 +25,7 @@ import tachyon.underfs.UnderFileSystemCluster;
 
 public class OSSUnderStorageCluster extends UnderFileSystemCluster {
 
-  //private static final String INTEGRATION_OSS_ACCESS_ID = "accessId";
-  //private static final String INTEGRATION_OSS_ACCESS_KEY = "accessKey";
   private static final String INTEGRATION_OSS_BUCKET = "ossBucket";
-  //private static final String INTEGRATION_OSS_ENDPOINT = "ossEndpoint";
 
   private String mOSSBucket;
 


### PR DESCRIPTION
Add the OSSUnderStorageCluster for OSSUnderFilesystem integration test.

we should config the pom.xml in integration-test, change four properties below:
1, fs.oss.accessKeyId (the oss access id)
2, fs.oss.accessKeySecret (the oss access secret key)
3, fs.oss.endpoint (because the uri endpoint are different from range to another range,eg: hangzhou, shanghai, Singapore, HongKong...)
4, ossBucket (the bucket address when the tests run into)

The integration test of OSS is much like the test of S3UnderFileSystem,  but I noticed that in the current master ， the integration tests for S3 cannot run successfully. I use my own aws id and key to run and keeps fail like below:

```java
java.lang.IllegalArgumentException: All eligible Under File Systems were unable to create an instance for the given path: s3n://my-bucket/tachyon-testc23eb0b5-4b3a-42e5-a481-1f2454574b93/journal-290143156907472538
java.lang.RuntimeException: Invalid configuration key fs.s3n.awsAccessKeyId

	at tachyon.underfs.UnderFileSystemRegistry.create(UnderFileSystemRegistry.java:132)
	at tachyon.underfs.UnderFileSystem.get(UnderFileSystem.java:106)
	at tachyon.underfs.UnderFileSystem.get(UnderFileSystem.java:90)
	at tachyon.util.UnderFileSystemUtils.mkdirIfNotExists(UnderFileSystemUtils.java:54)
	at tachyon.master.AbstractLocalTachyonCluster.setupTest(AbstractLocalTachyonCluster.java:251)
	at tachyon.master.AbstractLocalTachyonCluster.start(AbstractLocalTachyonCluster.java:105)
	at tachyon.LocalTachyonClusterResource.apply(LocalTachyonClusterResource.java:167)
```

I think this is probably because the reconstruction of the integration test and the LocalTachyonClusterResource TestRule using. I encounter the same problem when I test OSS. So the integration test of OSS is a little different to the test of S3.

To run the test, people should have a aliyun oss account and get the accessid and accessKey, I have a temp id and key pair, people who wana to use please just require it from me.

After the config done, run the test like below:

    cd integration-tests
    mvn clean -Dtest=UnderStorageSystemInterfaceIntegrationTest -DfailIfNoTests=false test -PossTest

Please confirm this.