### PR TITLE
[TACHYON-1465] TACHYON_RAM_FOLDER in tachyon-env.sh not working

### DIFF
--- a/conf/tachyon-env.sh.template
+++ b/conf/tachyon-env.sh.template
@@ -69,7 +69,7 @@ else
       fi
     fi
   fi
-  if [[ -z ${TACHYON_RAM_FOLDER} ]]; then
+  if [[ -z "${TACHYON_RAM_FOLDER}" ]]; then
     export TACHYON_RAM_FOLDER="/mnt/ramdisk"
   fi
 fi

--- a/conf/tachyon-env.sh.template
+++ b/conf/tachyon-env.sh.template
@@ -69,7 +69,9 @@ else
       fi
     fi
   fi
-  export TACHYON_RAM_FOLDER="/mnt/ramdisk"
+  if [[ -z ${TACHYON_RAM_FOLDER} ]]; then
+    export TACHYON_RAM_FOLDER="/mnt/ramdisk"
+  fi
 fi
 
 if [[ -z "${JAVA_HOME}" ]]; then


### PR DESCRIPTION
In the conf/tachyon-env.sh， TACHYON_RAM_FOLDER should be set to specify the worker's mem dirs. But I noticed that after I set :

TACHYON_RAM_FOLDER="/dev/shm"

in the begin line of tachyon-env.sh, the set never worked.  Look into the tachyon-env.sh, found that this is because the script below:


```shell
JAVA_HOME="/usr/lib/jvm/java"
TACHYON_UNDERFS_ADDRESS="hdfs://rs3g13002:9100/tachyon"
TACHYON_MASTER_ADDRESS="rs3g13002"
TACHYON_WORKER_MEMORY_SIZE="20gb"
TACHYON_RAM_FOLDER="/dev/shm"
#=======  I add some config as above =======

if [[ $(uname -s) == Darwin ]]; then
  # Assuming Mac OS X
  export JAVA_HOME=${JAVA_HOME:-$(/usr/libexec/java_home)}
  export TACHYON_RAM_FOLDER=/Volumes/ramdisk
  export TACHYON_JAVA_OPTS="-Djava.security.krb5.realm= -Djava.security.krb5.kdc="
else
  # Assuming Linux
  if [[ -z "$JAVA_HOME" ]]; then
    if [ -d /usr/lib/jvm/java-7-oracle ]; then
      export JAVA_HOME=/usr/lib/jvm/java-7-oracle
    else
      # openjdk will set this
      if [[ -d /usr/lib/jvm/jre-1.7.0 ]]; then
        export JAVA_HOME=/usr/lib/jvm/jre-1.7.0
      fi
    fi
  fi
  export TACHYON_RAM_FOLDER="/mnt/ramdisk"
fi
```


no matter how people set the TACHYON_RAM_FOLDER, it will be overwritten to '/mnt/ramdisk'， so people have to set TACHYON_RAM_FOLDER below the quoted code.

Could we add a check before set TACHYON_RAM_FOLDER to '/mnt/ramdisk'  ? like below:

```shell
if [[ -z ${TACHYON_RAM_FOLDER} ]]; then
  export TACHYON_RAM_FOLDER="/mnt/ramdisk"
fi
```