### PR TITLE
[SMALLFIX] Removed redundant 'null'

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/block/LocalBlockInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/block/LocalBlockInStream.java
@@ -59,7 +59,7 @@ public final class LocalBlockInStream extends BufferedBlockInStream {
     mCloser = Closer.create();
     mWorkerClient =
         mContext.acquireWorkerClient(NetworkAddressUtils.getLocalHostName(ClientContext.getConf()));
-    FileChannel localFileChannel = null;
+    FileChannel localFileChannel;
 
     try {
       LockBlockResult result = mWorkerClient.lockBlock(blockId);


### PR DESCRIPTION
Removed the redundant ```null``` initialization in ```LocalBlockInStream```.