### PR TITLE
[SMALLFIX] Clean up s3 cluster

### DIFF
--- a/integration-tests/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/integration-tests/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.underfs.UnderFileSystemCluster;
+import tachyon.util.io.PathUtils;
 
 /**
  * This class will use Amazon S3 as the backing store. The integration properties should be
@@ -38,14 +39,14 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
   public S3UnderStorageCluster(String baseDir, TachyonConf tachyonConf) {
     super(baseDir, tachyonConf);
     mS3Bucket = System.getProperty(INTEGRATION_S3_BUCKET);
-    mBaseDir = mS3Bucket + UUID.randomUUID();
+    mBaseDir = PathUtils.concatPath(mS3Bucket + UUID.randomUUID());
   }
 
   @Override
   public void cleanup() throws IOException {
     UnderFileSystem ufs = UnderFileSystem.get(mBaseDir, mTachyonConf);
     ufs.delete(mBaseDir, true);
-    mBaseDir = mS3Bucket + UUID.randomUUID();
+    mBaseDir = PathUtils.concatPath(mS3Bucket + UUID.randomUUID());
   }
 
   @Override

--- a/integration-tests/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/integration-tests/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -43,10 +43,9 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
 
   @Override
   public void cleanup() throws IOException {
-    String oldDir = mBaseDir;
-    mBaseDir = mS3Bucket + UUID.randomUUID();
     UnderFileSystem ufs = UnderFileSystem.get(mBaseDir, mTachyonConf);
-    ufs.delete(oldDir, true);
+    ufs.delete(mBaseDir, true);
+    mBaseDir = mS3Bucket + UUID.randomUUID();
   }
 
   @Override

--- a/integration-tests/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
+++ b/integration-tests/src/test/java/tachyon/underfs/s3/S3UnderStorageCluster.java
@@ -39,14 +39,14 @@ public class S3UnderStorageCluster extends UnderFileSystemCluster {
   public S3UnderStorageCluster(String baseDir, TachyonConf tachyonConf) {
     super(baseDir, tachyonConf);
     mS3Bucket = System.getProperty(INTEGRATION_S3_BUCKET);
-    mBaseDir = PathUtils.concatPath(mS3Bucket + UUID.randomUUID());
+    mBaseDir = PathUtils.concatPath(mS3Bucket, UUID.randomUUID());
   }
 
   @Override
   public void cleanup() throws IOException {
     UnderFileSystem ufs = UnderFileSystem.get(mBaseDir, mTachyonConf);
     ufs.delete(mBaseDir, true);
-    mBaseDir = PathUtils.concatPath(mS3Bucket + UUID.randomUUID());
+    mBaseDir = PathUtils.concatPath(mS3Bucket, UUID.randomUUID());
   }
 
   @Override


### PR DESCRIPTION
No longer have weird file names when the user specifies a bucket without a trailing slash.