### PR TITLE
[SMALLFIX] Update decimal number format

### DIFF
--- a/common/src/main/java/tachyon/util/FormatUtils.java
+++ b/common/src/main/java/tachyon/util/FormatUtils.java
@@ -17,6 +17,7 @@ package tachyon.util;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.util.Locale;
 
 import tachyon.Constants;
 
@@ -101,26 +102,26 @@ public final class FormatUtils {
   public static String getSizeFromBytes(long bytes) {
     double ret = bytes;
     if (ret <= 1024 * 5) {
-      return String.format("%.2fB", ret);
+      return String.format(Locale.ENGLISH, "%.2fB", ret);
     }
     ret /= 1024;
     if (ret <= 1024 * 5) {
-      return String.format("%.2fKB", ret);
+      return String.format(Locale.ENGLISH, "%.2fKB", ret);
     }
     ret /= 1024;
     if (ret <= 1024 * 5) {
-      return String.format("%.2fMB", ret);
+      return String.format(Locale.ENGLISH, "%.2fMB", ret);
     }
     ret /= 1024;
     if (ret <= 1024 * 5) {
-      return String.format("%.2fGB", ret);
+      return String.format(Locale.ENGLISH, "%.2fGB", ret);
     }
     ret /= 1024;
     if (ret <= 1024 * 5) {
-      return String.format("%.2fTB", ret);
+      return String.format(Locale.ENGLISH, "%.2fTB", ret);
     }
     ret /= 1024;
-    return String.format("%.2fPB", ret);
+    return String.format(Locale.ENGLISH, "%.2fPB", ret);
   }
 
   /**


### PR DESCRIPTION
I was receiving the error below when I was executing 'mvn install' under tachyon dir:

getSizeFromBytesTest(tachyon.util.FormatUtilsTest)  Time elapsed: 0.007 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<4[.]00B> but was:<4[,]00B>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at tachyon.util.FormatUtilsTest.getSizeFromBytesTest(FormatUtilsTest.java:188)

So I fixed a Locale output format for the decimal numbers as 'Locale.ENGLISH' .