### PR TITLE
[TACHYON-1511] Fix tier lookup in RoundRobinAllocator

### DIFF
--- a/servers/src/test/java/tachyon/worker/block/allocator/AllocatorContractTest.java
+++ b/servers/src/test/java/tachyon/worker/block/allocator/AllocatorContractTest.java
@@ -70,7 +70,7 @@ public class AllocatorContractTest extends BaseAllocatorTest {
     for (String strategyName : mStrategies) {
       conf.set(Constants.WORKER_ALLOCATOR_CLASS, strategyName);
       resetManagerView();
-      Allocator allocator = Allocator.Factory.create(conf, mManagerView);
+      Allocator allocator = Allocator.Factory.create(conf, getManagerView());
       assertTempBlockMeta(allocator, mAnyDirInTierLoc1, DEFAULT_RAM_SIZE + 1, false);
       assertTempBlockMeta(allocator, mAnyDirInTierLoc2, DEFAULT_SSD_SIZE + 1, false);
       assertTempBlockMeta(allocator, mAnyDirInTierLoc3, DEFAULT_HDD_SIZE + 1, false);
@@ -85,7 +85,7 @@ public class AllocatorContractTest extends BaseAllocatorTest {
     for (String strategyName : mStrategies) {
       conf.set(Constants.WORKER_ALLOCATOR_CLASS, strategyName);
       resetManagerView();
-      Allocator tierAllocator = Allocator.Factory.create(conf, mManagerView);
+      Allocator tierAllocator = Allocator.Factory.create(conf, getManagerView());
       for (int i = 0; i < DEFAULT_RAM_NUM; i ++) {
         assertTempBlockMeta(tierAllocator, mAnyDirInTierLoc1, DEFAULT_RAM_SIZE - 1, true);
       }
@@ -97,7 +97,7 @@ public class AllocatorContractTest extends BaseAllocatorTest {
       }
 
       resetManagerView();
-      Allocator anyAllocator = Allocator.Factory.create(conf, mManagerView);
+      Allocator anyAllocator = Allocator.Factory.create(conf, getManagerView());
       for (int i = 0; i < DEFAULT_RAM_NUM; i ++) {
         assertTempBlockMeta(anyAllocator, mAnyTierLoc, DEFAULT_RAM_SIZE - 1, true);
       }

--- a/servers/src/test/java/tachyon/worker/block/allocator/BaseAllocatorTest.java
+++ b/servers/src/test/java/tachyon/worker/block/allocator/BaseAllocatorTest.java
@@ -58,7 +58,7 @@ public class BaseAllocatorTest {
   public static final int DEFAULT_SSD_NUM  = TIER_PATH[1].length;
   public static final int DEFAULT_HDD_NUM  = TIER_PATH[2].length;
 
-  protected BlockMetadataManagerView mManagerView = null;
+  protected BlockMetadataManager mManager = null;
   protected Allocator mAllocator = null;
 
   protected BlockStoreLocation mAnyTierLoc = BlockStoreLocation.anyTier();
@@ -78,9 +78,7 @@ public class BaseAllocatorTest {
     String tachyonHome = mTestFolder.newFolder().getAbsolutePath();
     TieredBlockStoreTestUtils.setupTachyonConfWithMultiTier(tachyonHome, TIER_LEVEL, TIER_ALIAS,
         TIER_PATH, TIER_CAPACITY_BYTES, null);
-    BlockMetadataManager metaManager = BlockMetadataManager.newBlockMetadataManager();
-    mManagerView = new BlockMetadataManagerView(metaManager, new HashSet<Long>(),
-        new HashSet<Long>());
+    mManager = BlockMetadataManager.newBlockMetadataManager();
   }
 
   /**
@@ -91,9 +89,8 @@ public class BaseAllocatorTest {
       long blockSize, boolean avail) throws IOException {
 
     mTestBlockId ++;
-
     StorageDirView dirView =
-        allocator.allocateBlockWithView(SESSION_ID, blockSize, location, mManagerView);
+        allocator.allocateBlockWithView(SESSION_ID, blockSize, location, getManagerView());
     TempBlockMeta tempBlockMeta =
         dirView == null ? null : dirView.createTempBlockMeta(SESSION_ID, mTestBlockId, blockSize);
 
@@ -117,7 +114,7 @@ public class BaseAllocatorTest {
     mTestBlockId ++;
 
     StorageDirView dirView =
-        allocator.allocateBlockWithView(SESSION_ID, blockSize, location, mManagerView);
+        allocator.allocateBlockWithView(SESSION_ID, blockSize, location, getManagerView());
     TempBlockMeta tempBlockMeta =
         dirView == null ? null : dirView.createTempBlockMeta(SESSION_ID, mTestBlockId, blockSize);
 
@@ -135,5 +132,9 @@ public class BaseAllocatorTest {
       //update the dir meta info
       pDir.addBlockMeta(new BlockMeta(mTestBlockId, blockSize, pDir));
     }
+  }
+
+  protected BlockMetadataManagerView getManagerView() {
+    return new BlockMetadataManagerView(mManager, new HashSet<Long>(), new HashSet<Long>());
   }
 }

--- a/servers/src/test/java/tachyon/worker/block/allocator/GreedyAllocatorTest.java
+++ b/servers/src/test/java/tachyon/worker/block/allocator/GreedyAllocatorTest.java
@@ -28,7 +28,7 @@ public class GreedyAllocatorTest extends BaseAllocatorTest {
   public void allocateBlockTest() throws Exception {
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.WORKER_ALLOCATOR_CLASS, GreedyAllocator.class.getName());
-    mAllocator = Allocator.Factory.create(conf, mManagerView);
+    mAllocator = Allocator.Factory.create(conf, getManagerView());
     //
     // idx | tier1 | tier2 | tier3
     //  0    1000

--- a/servers/src/test/java/tachyon/worker/block/allocator/MaxFreeAllocatorTest.java
+++ b/servers/src/test/java/tachyon/worker/block/allocator/MaxFreeAllocatorTest.java
@@ -28,7 +28,7 @@ public class MaxFreeAllocatorTest extends BaseAllocatorTest {
   public void allocateBlockTest() throws Exception {
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.WORKER_ALLOCATOR_CLASS, MaxFreeAllocator.class.getName());
-    mAllocator = Allocator.Factory.create(conf, mManagerView);
+    mAllocator = Allocator.Factory.create(conf, getManagerView());
     //
     // idx | tier1 | tier2 | tier3
     //  0    1000

--- a/servers/src/test/java/tachyon/worker/block/allocator/RoundRobinAllocatorTest.java
+++ b/servers/src/test/java/tachyon/worker/block/allocator/RoundRobinAllocatorTest.java
@@ -28,7 +28,7 @@ public class RoundRobinAllocatorTest extends BaseAllocatorTest {
   public void allocateBlockTest() throws Exception {
     TachyonConf conf = new TachyonConf();
     conf.set(Constants.WORKER_ALLOCATOR_CLASS, RoundRobinAllocator.class.getName());
-    mAllocator = Allocator.Factory.create(conf, mManagerView);
+    mAllocator = Allocator.Factory.create(conf, getManagerView());
     //
     // idx | tier1 | tier2 | tier3
     //  0    1000


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1511

Previously we stored a Map from tier to latest directory index
for that tier. However, the keys were references to StorageTierViews,
which are not globally unique. This resulted in lookups always
returning null. This change uses the String tier aliases as keys
instead.