### PR TITLE
[TACHYON-1519] Display permission information for ls command

### DIFF
--- a/common/src/main/java/tachyon/Constants.java
+++ b/common/src/main/java/tachyon/Constants.java
@@ -35,15 +35,16 @@ public final class Constants {
   public static final String ANSI_CYAN = "\u001B[36m";
   public static final String ANSI_WHITE = "\u001B[37m";
 
+  public static final String LS_FORMAT_PERMISSION = "%-15s";
   public static final String LS_FORMAT_FILE_SIZE = "%-10s";
   public static final String LS_FORMAT_CREATE_TIME = "%-25s";
   public static final String LS_FORMAT_FILE_TYPE = "%-15s";
   public static final String LS_FORMAT_USER_NAME = "%-15s";
   public static final String LS_FORMAT_GROUP_NAME = "%-15s";
   public static final String LS_FORMAT_FILE_PATH = "%-5s";
-  public static final String COMMAND_FORMAT_LS = LS_FORMAT_FILE_SIZE + LS_FORMAT_CREATE_TIME
-      + LS_FORMAT_FILE_TYPE + LS_FORMAT_USER_NAME + LS_FORMAT_GROUP_NAME + LS_FORMAT_FILE_PATH
-      + "%n";
+  public static final String COMMAND_FORMAT_LS = LS_FORMAT_PERMISSION + LS_FORMAT_USER_NAME
+      + LS_FORMAT_GROUP_NAME + LS_FORMAT_FILE_SIZE + LS_FORMAT_CREATE_TIME + LS_FORMAT_FILE_TYPE
+      + LS_FORMAT_FILE_PATH + "%n";
 
   public static final String MESOS_RESOURCE_CPUS = "cpus";
   public static final String MESOS_RESOURCE_MEM = "mem";

--- a/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
+++ b/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
@@ -915,7 +915,7 @@ public class TfsShellTest {
       String testUser, String testGroup, int permission, boolean isDir)
       throws IOException, TachyonException {
     return String.format(Constants.COMMAND_FORMAT_LS,
-        CommandUtils.convertPermission(permission, isDir),
+        CommandUtils.formatPermission(permission, isDir),
         testUser, testGroup, FormatUtils.getSizeFromBytes(size),
         CommandUtils.convertMsToDate(createTime), fileType, path);
   }

--- a/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
+++ b/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
@@ -529,16 +529,16 @@ public class TfsShellTest {
     String expected = "";
     expected +=
         getLsResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10, "In Memory",
-            testUser, testUser);
+            testUser, testUser, files[0].getPermission(), files[0].isFolder);
     expected +=
         getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 0, "", testUser,
-            testUser);
+            testUser, files[1].getPermission(), files[1].isFolder);
     expected +=
         getLsResultStr("/testRoot/testDir/testFileB", files[2].getCreationTimeMs(), 20,
-            "In Memory", testUser, testUser);
+            "In Memory", testUser, testUser, files[2].getPermission(), files[2].isFolder);
     expected +=
         getLsResultStr("/testRoot/testFileC", files[3].getCreationTimeMs(), 30, "Not In Memory",
-            testUser, testUser);
+            testUser, testUser, files[3].getPermission(), files[3].isFolder);
     Assert.assertEquals(expected, mOutput.toString());
     // clear testing username
     System.clearProperty(Constants.SECURITY_LOGIN_USERNAME);
@@ -568,13 +568,13 @@ public class TfsShellTest {
     String expected = "";
     expected +=
         getLsResultStr("/testRoot/testFileA", files[0].getCreationTimeMs(), 10, "In Memory",
-            testUser, testUser);
+            testUser, testUser, files[0].getPermission(), files[0].isFolder);
     expected +=
         getLsResultStr("/testRoot/testDir", files[1].getCreationTimeMs(), 0, "", testUser,
-            testUser);
+            testUser, files[1].getPermission(), files[1].isFolder);
     expected +=
         getLsResultStr("/testRoot/testFileC", files[2].getCreationTimeMs(), 30, "Not In Memory",
-            testUser, testUser);
+            testUser, testUser, files[2].getPermission(), files[2].isFolder);
     Assert.assertEquals(expected, mOutput.toString());
     // clear testing username
     System.clearProperty(Constants.SECURITY_LOGIN_USERNAME);
@@ -906,14 +906,18 @@ public class TfsShellTest {
 
   private String getLsResultStr(TachyonURI tUri, int size, String testUser, String testGroup)
       throws IOException, TachyonException {
-    return getLsResultStr(tUri.getPath(), mTfs.getInfo(mTfs.open(tUri)).getCreationTimeMs(), size,
-        "In Memory", testUser, testGroup);
+    FileInfo fileInfo = mTfs.getInfo(mTfs.open(tUri));
+    return getLsResultStr(tUri.getPath(), fileInfo.getCreationTimeMs(), size,
+        "In Memory", testUser, testGroup, fileInfo.getPermission(), fileInfo.isFolder);
   }
 
   private String getLsResultStr(String path, long createTime, int size, String fileType,
-      String testUser, String testGroup) throws IOException, TachyonException {
-    return String.format(Constants.COMMAND_FORMAT_LS, FormatUtils.getSizeFromBytes(size),
-        CommandUtils.convertMsToDate(createTime), fileType, testUser, testGroup, path);
+      String testUser, String testGroup, int permission, boolean isDir)
+      throws IOException, TachyonException {
+    return String.format(Constants.COMMAND_FORMAT_LS,
+        CommandUtils.convertPermission(permission, isDir),
+        testUser, testGroup, FormatUtils.getSizeFromBytes(size),
+        CommandUtils.convertMsToDate(createTime), fileType, path);
   }
 
   @Test

--- a/integration-tests/src/test/java/tachyon/shell/command/CommandUtilsTest.java
+++ b/integration-tests/src/test/java/tachyon/shell/command/CommandUtilsTest.java
@@ -22,15 +22,15 @@ public class CommandUtilsTest {
 
   @Test
   public void convertPermissionTest() {
-    Assert.assertEquals("-rw-rw-rw-", CommandUtils.convertPermission(0666, false));
-    Assert.assertEquals("drw-rw-rw-", CommandUtils.convertPermission(0666, true));
-    Assert.assertEquals("-rwxrwxrwx", CommandUtils.convertPermission(0777, false));
-    Assert.assertEquals("drwxrwxrwx", CommandUtils.convertPermission(0777, true));
-    Assert.assertEquals("-r--r--r--", CommandUtils.convertPermission(0444, false));
-    Assert.assertEquals("dr--r--r--", CommandUtils.convertPermission(0444, true));
-    Assert.assertEquals("-r-xr-xr-x", CommandUtils.convertPermission(0555, false));
-    Assert.assertEquals("dr-xr-xr-x", CommandUtils.convertPermission(0555, true));
-    Assert.assertEquals("-rwxr-xr--", CommandUtils.convertPermission(0754, false));
-    Assert.assertEquals("drwxr-xr--", CommandUtils.convertPermission(0754, true));
+    Assert.assertEquals("-rw-rw-rw-", CommandUtils.formatPermission(0666, false));
+    Assert.assertEquals("drw-rw-rw-", CommandUtils.formatPermission(0666, true));
+    Assert.assertEquals("-rwxrwxrwx", CommandUtils.formatPermission(0777, false));
+    Assert.assertEquals("drwxrwxrwx", CommandUtils.formatPermission(0777, true));
+    Assert.assertEquals("-r--r--r--", CommandUtils.formatPermission(0444, false));
+    Assert.assertEquals("dr--r--r--", CommandUtils.formatPermission(0444, true));
+    Assert.assertEquals("-r-xr-xr-x", CommandUtils.formatPermission(0555, false));
+    Assert.assertEquals("dr-xr-xr-x", CommandUtils.formatPermission(0555, true));
+    Assert.assertEquals("-rwxr-xr--", CommandUtils.formatPermission(0754, false));
+    Assert.assertEquals("drwxr-xr--", CommandUtils.formatPermission(0754, true));
   }
 }

--- a/integration-tests/src/test/java/tachyon/shell/command/CommandUtilsTest.java
+++ b/integration-tests/src/test/java/tachyon/shell/command/CommandUtilsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.shell.command;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CommandUtilsTest {
+
+  @Test
+  public void convertPermissionTest() {
+    Assert.assertEquals("-rw-rw-rw-", CommandUtils.convertPermission(0666, false));
+    Assert.assertEquals("drw-rw-rw-", CommandUtils.convertPermission(0666, true));
+    Assert.assertEquals("-rwxrwxrwx", CommandUtils.convertPermission(0777, false));
+    Assert.assertEquals("drwxrwxrwx", CommandUtils.convertPermission(0777, true));
+    Assert.assertEquals("-r--r--r--", CommandUtils.convertPermission(0444, false));
+    Assert.assertEquals("dr--r--r--", CommandUtils.convertPermission(0444, true));
+    Assert.assertEquals("-r-xr-xr-x", CommandUtils.convertPermission(0555, false));
+    Assert.assertEquals("dr-xr-xr-x", CommandUtils.convertPermission(0555, true));
+    Assert.assertEquals("-rwxr-xr--", CommandUtils.convertPermission(0754, false));
+    Assert.assertEquals("drwxr-xr--", CommandUtils.convertPermission(0754, true));
+  }
+}

--- a/shell/src/main/java/tachyon/shell/command/AbstractLsCommand.java
+++ b/shell/src/main/java/tachyon/shell/command/AbstractLsCommand.java
@@ -57,7 +57,7 @@ public abstract class AbstractLsCommand extends WithWildCardPathCommand {
         }
       }
       System.out.format(Constants.COMMAND_FORMAT_LS,
-          CommandUtils.convertPermission(file.getPermission(),  file.isFolder), file.getUserName(),
+          CommandUtils.formatPermission(file.getPermission(),  file.isFolder), file.getUserName(),
           file.getGroupName(), FormatUtils.getSizeFromBytes(file.getLength()),
           CommandUtils.convertMsToDate(file.getCreationTimeMs()), inMemory, file.getPath());
       if (recursive && file.isFolder) {

--- a/shell/src/main/java/tachyon/shell/command/AbstractLsCommand.java
+++ b/shell/src/main/java/tachyon/shell/command/AbstractLsCommand.java
@@ -57,9 +57,9 @@ public abstract class AbstractLsCommand extends WithWildCardPathCommand {
         }
       }
       System.out.format(Constants.COMMAND_FORMAT_LS,
-          FormatUtils.getSizeFromBytes(file.getLength()),
-          CommandUtils.convertMsToDate(file.getCreationTimeMs()), inMemory, file.getUserName(),
-          file.getGroupName(), file.getPath());
+          CommandUtils.convertPermission(file.getPermission(),  file.isFolder), file.getUserName(),
+          file.getGroupName(), FormatUtils.getSizeFromBytes(file.getLength()),
+          CommandUtils.convertMsToDate(file.getCreationTimeMs()), inMemory, file.getPath());
       if (recursive && file.isFolder) {
         ls(new TachyonURI(path.getScheme(), path.getAuthority(), file.getPath()), true);
       }

--- a/shell/src/main/java/tachyon/shell/command/CommandUtils.java
+++ b/shell/src/main/java/tachyon/shell/command/CommandUtils.java
@@ -92,7 +92,7 @@ public final class CommandUtils {
       } else {
         permString.append("-");
       }
-      permission >>= 4;
+      permission >>= 3;
     }
     if (isDir) {
       permString.append("d");

--- a/shell/src/main/java/tachyon/shell/command/CommandUtils.java
+++ b/shell/src/main/java/tachyon/shell/command/CommandUtils.java
@@ -73,7 +73,7 @@ public final class CommandUtils {
    * @param isDir whether the path is a directory
    * @return formatted permission String
    */
-  public static String convertPermission(int permission, boolean isDir) {
+  public static String formatPermission(int permission, boolean isDir) {
     StringBuilder permString = new StringBuilder();
 
     for (int i = 0; i < 3; i ++) {

--- a/shell/src/main/java/tachyon/shell/command/CommandUtils.java
+++ b/shell/src/main/java/tachyon/shell/command/CommandUtils.java
@@ -67,10 +67,11 @@ public final class CommandUtils {
   }
 
   /**
-   * Converts a millisecond number to a formatted date String.
+   * Converts an int permission value to a formatted String.
    *
-   * @param millis a long millisecond number
-   * @return formatted date String
+   * @param permission value of permission for the path
+   * @param isDir whether the path is a directory
+   * @return formatted permission String
    */
   public static String convertPermission(int permission, boolean isDir) {
     StringBuilder permString = new StringBuilder();

--- a/shell/src/main/java/tachyon/shell/command/CommandUtils.java
+++ b/shell/src/main/java/tachyon/shell/command/CommandUtils.java
@@ -67,6 +67,41 @@ public final class CommandUtils {
   }
 
   /**
+   * Converts a millisecond number to a formatted date String.
+   *
+   * @param millis a long millisecond number
+   * @return formatted date String
+   */
+  public static String convertPermission(int permission, boolean isDir) {
+    StringBuilder permString = new StringBuilder();
+
+    for (int i = 0; i < 3; i ++) {
+      if ((permission & 0x01) == 0x01) {
+        permString.append("x");
+      } else {
+        permString.append("-");
+      }
+      if ((permission & 0x02) == 0x02) {
+        permString.append("w");
+      } else {
+        permString.append("-");
+      }
+      if ((permission & 0x04) == 0x04) {
+        permString.append("r");
+      } else {
+        permString.append("-");
+      }
+      permission >>= 4;
+    }
+    if (isDir) {
+      permString.append("d");
+    } else {
+      permString.append("-");
+    }
+    return permString.reverse().toString();
+  }
+
+  /**
    * Sets pin state for the input path
    *
    * @param tfs The {@link TachyonFileSystem} client


### PR DESCRIPTION
Display permission information for ls command
'd' represents it is a directory

d---------                    0.00B     01-07-2016 16:27:55:076                 /test/huge/tachyon-tiered-hdd-patched
d---------                    0.00B     01-07-2016 16:27:56:433                 /test/huge/tachyon-tiered-hdd-new
d---------                    0.00B     01-07-2016 16:27:57:929                 /test/huge/tachyon-tiered
d---------                    0.00B     01-07-2016 16:27:59:329                 /test/huge/mem-and-disk-ser
----------                     9.64MB    01-07-2016 16:28:01:113  In Memory      /test/huge/huge.tar.gz

