### PR TITLE
[TACHYON-1508] Create RawTable column directories in client instead of master

### DIFF
--- a/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
+++ b/servers/src/main/java/tachyon/master/file/meta/InodeTree.java
@@ -194,8 +194,8 @@ public final class InodeTree implements JournalCheckpointStreamable {
    * @param options method options
    * @return a {@link CreatePathResult} representing the modified inodes and created inodes during
    *         path creation
-   * @throws FileAlreadyExistsException when there is already a file at path if we want to create a
-   *         directory there
+   * @throws FileAlreadyExistsException when there is already a file at path, or there is already
+   *         a directory at path and allowExists in CreatePathOptions is false
    * @throws BlockInfoException when blockSizeBytes is invalid
    * @throws InvalidPathException when path is invalid, for example, (1) when there is nonexistent
    *         necessary parent directories and recursive is false, (2) when one of the necessary
@@ -291,6 +291,8 @@ public final class InodeTree implements JournalCheckpointStreamable {
         traversalResult.getNonPersisted().add(lastInode);
         toPersistDirectories.add(lastInode);
       } else if (!(lastInode.isDirectory() && options.isAllowExists())) {
+        // A file already exists at path, or a directory exists at path and isAllowExists is false.
+        LOG.info("isDirectory: {}, isAllowExists: {}", lastInode.isDirectory(), options.isAllowExists());
         LOG.info(ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(path));
         throw new FileAlreadyExistsException(ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(path));
       }

--- a/servers/src/main/java/tachyon/master/rawtable/RawTableMaster.java
+++ b/servers/src/main/java/tachyon/master/rawtable/RawTableMaster.java
@@ -170,11 +170,6 @@ public class RawTableMaster extends MasterBase {
       throw new RuntimeException(ExceptionMessage.RAW_TABLE_ID_DUPLICATED.getMessage(id));
     }
 
-    // Create directories in the table directory as columns
-    for (int k = 0; k < columns; k ++) {
-      mFileSystemMaster.mkdir(columnPath(path, k), options);
-    }
-
     LOG.debug("writing journal entry for createRawTable {}", path);
     RawTableEntry rawTable = RawTableEntry.newBuilder()
         .setId(id)
@@ -211,17 +206,6 @@ public class RawTableMaster extends MasterBase {
         .build();
     writeJournalEntry(JournalEntry.newBuilder().setUpdateMetadata(updateMetadata).build());
     flushJournal();
-  }
-
-  /**
-   * Returns the path for the column in the table.
-   *
-   * @param tablePath the path of the table
-   * @param column column number
-   * @return the column path
-   */
-  public TachyonURI columnPath(TachyonURI tablePath, int column) {
-    return tablePath.join(Constants.MASTER_COLUMN_FILE_PREFIX + column);
   }
 
   /**


### PR DESCRIPTION
The bug described in https://tachyon.atlassian.net/browse/TACHYON-1508 is due to that creating 200 directories synchronously to S3 assumes a lot of time which causes RPC connection timeout, then the RPC to create table is retried where the table path has been created in last RPC, so FileAlreadyExistsException is thrown.