### PR TITLE
[SMALLFIX] Removed duplicate JUnit dependency

### DIFF
--- a/underfs/swift/pom.xml
+++ b/underfs/swift/pom.xml
@@ -62,11 +62,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    <!-- Test Dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>


### PR DESCRIPTION
Removed the duplicate JUnit dependency declaration in the Swift module.