### PR TITLE
[SMALLFIX] Fix AbstractTFS compilation with hdfs1

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -331,7 +331,6 @@ abstract class AbstractTFS extends FileSystem {
    *
    * @see FileSystem#createFileSystem(java.net.URI, org.apache.hadoop.conf.Configuration)
    */
-  @Override
   public abstract String getScheme();
 
   @Override


### PR DESCRIPTION
Hdfs 1.x doesn't have a `FileSystem#getScheme` method, so we can't put `@Override`