### PR TITLE
[TACHYON-1527] OSSInputStream should not throw exception in skip()

### DIFF
--- a/underfs/oss/src/main/java/tachyon/underfs/oss/OSSInputStream.java
+++ b/underfs/oss/src/main/java/tachyon/underfs/oss/OSSInputStream.java
@@ -68,6 +68,9 @@ public class OSSInputStream extends InputStream {
 
   @Override
   public long skip(long n) throws IOException {
-    throw new IOException("unsupported skip in OSSInputStream currently.");
+    // TODO(luoli523) currently, the oss sdk doesn't support get the oss Object in a
+    // special position of the stream. It will support this feature in the future.
+    // Now we just read n bytes and discard to skip.
+    return super.skip(n);
   }
 }


### PR DESCRIPTION
OSSInputStream should not throw exception in skip(long n), that will make lots of the integration test of oss fail. And the skip logic can just like the java.io.InputStream: read n bytes and just discards them , just this logic will work.

I added a TODO to remind that after oss sdk support getObject in a special position, I will update the implements of this method.

Please see https://tachyon.atlassian.net/browse/TACHYON-1527