### PR TITLE
[TACHYON-1528] tachyon-stop.sh should not stop all but print usage by default

### DIFF
--- a/bin/tachyon-stop.sh
+++ b/bin/tachyon-stop.sh
@@ -28,7 +28,7 @@ kill_remote_workers() {
   $LAUNCHER $bin/tachyon-workers.sh $bin/tachyon killAll tachyon.worker.TachyonWorker
 }
 
-WHAT=${1:-all}
+WHAT=${1:--h}
 
 case "$WHAT" in
   master)


### PR DESCRIPTION
When people run bin/tachyon-stop.sh, he(she) may think that the stop shell will print usage as tachyon-start.sh does. And following the usage, people can specify which component(s) he(she) want to stop. 

But now, when people run bin/tachyon-stop.sh, the script will stop master and all workers by default. And this probably is not what people want and all components has been stopped.

Maybe we can follow the tachyon-start.sh custom, print usage by default in tachyon-stop.sh