### PR TITLE
[TACHYON-1354] Remove "public" keywords from DataBuffer interface

### DIFF
--- a/common/src/main/java/tachyon/network/protocol/databuffer/DataBuffer.java
+++ b/common/src/main/java/tachyon/network/protocol/databuffer/DataBuffer.java
@@ -27,24 +27,24 @@ public interface DataBuffer {
    *
    * @return the object to output to Netty. Must be ByteBuf or FileRegion
    */
-  public Object getNettyOutput();
+  Object getNettyOutput();
 
   /**
    * Returns the length of the data.
    *
    * @return the length of the data in bytes
    */
-  public long getLength();
+  long getLength();
 
   /**
    * Returns a {@link ByteBuffer} for read-only access to the data.
    *
    * @return a read-only ByteBuffer representing the data
    */
-  public ByteBuffer getReadOnlyByteBuffer();
+  ByteBuffer getReadOnlyByteBuffer();
 
   /**
    * Release the underlying buffer of this DataBuffer if no longer needed.
    */
-  public void release();
+  void release();
 }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1354

All "public" keywords of methods in DataBuffer interface have been removed