### PR TITLE
[SMALLFIX] Switch to using NetAddress from thrift defined WorkerNetAddress

### DIFF
--- a/integration-tests/src/test/java/tachyon/security/BlockWorkerClientAuthenticationIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/security/BlockWorkerClientAuthenticationIntegrationTest.java
@@ -32,7 +32,6 @@ import tachyon.LocalTachyonClusterResource;
 import tachyon.client.worker.BlockWorkerClient;
 import tachyon.security.MasterClientAuthenticationIntegrationTest.NameMatchAuthenticationProvider;
 import tachyon.worker.ClientMetrics;
-import tachyon.worker.NetAddress;
 
 /**
  * Test RPC authentication between worker and its client, in four modes: NOSASL, SIMPLE, CUSTOM,
@@ -109,7 +108,7 @@ public class BlockWorkerClientAuthenticationIntegrationTest {
     mThrown.expectMessage("Failed to connect to the worker");
 
     BlockWorkerClient blockWorkerClient = new BlockWorkerClient(
-        new NetAddress(mLocalTachyonClusterResource.get().getWorkerAddress()),
+        mLocalTachyonClusterResource.get().getWorkerAddress(),
         mExecutorService, mLocalTachyonClusterResource.get().getWorkerTachyonConf(),
         1 /* fake session id */, true, new ClientMetrics());
     try {
@@ -127,7 +126,7 @@ public class BlockWorkerClientAuthenticationIntegrationTest {
    */
   private void authenticationOperationTest() throws Exception {
     BlockWorkerClient blockWorkerClient = new BlockWorkerClient(
-        new NetAddress(mLocalTachyonClusterResource.get().getWorkerAddress()),
+        mLocalTachyonClusterResource.get().getWorkerAddress(),
         mExecutorService, mLocalTachyonClusterResource.get().getWorkerTachyonConf(),
         1 /* fake session id */, true, new ClientMetrics());
 

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
@@ -85,7 +85,7 @@ public final class LocalTachyonCluster extends AbstractLocalTachyonCluster {
   }
 
   public NetAddress getWorkerAddress() {
-    return mWorker.getWorkerNetAddress();
+    return mWorker.getNetAddress();
   }
 
   @Override

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
@@ -22,7 +22,7 @@ import tachyon.client.ClientContext;
 import tachyon.client.file.TachyonFileSystem;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.ConnectionFailedException;
-import tachyon.thrift.WorkerNetAddress;
+import tachyon.worker.NetAddress;
 import tachyon.worker.TachyonWorker;
 import tachyon.worker.WorkerContext;
 
@@ -84,7 +84,7 @@ public final class LocalTachyonCluster extends AbstractLocalTachyonCluster {
     return mWorkerConf;
   }
 
-  public WorkerNetAddress getWorkerAddress() {
+  public NetAddress getWorkerAddress() {
     return mWorker.getWorkerNetAddress();
   }
 

--- a/servers/src/main/java/tachyon/master/block/BlockMaster.java
+++ b/servers/src/main/java/tachyon/master/block/BlockMaster.java
@@ -107,7 +107,7 @@ public final class BlockMaster extends MasterBase implements ContainerIdGenerabl
       new IndexedSet.FieldIndex<MasterWorkerInfo>() {
         @Override
         public Object getFieldValue(MasterWorkerInfo o) {
-          return o.getAddress();
+          return o.getWorkerAddress();
         }
       };
   /**
@@ -683,7 +683,7 @@ public final class BlockMaster extends MasterBase implements ContainerIdGenerabl
           mWorkers.getFirstByField(mIdIndex, masterBlockLocation.getWorkerId());
       if (workerInfo != null) {
         ret.add(new BlockLocation(masterBlockLocation.getWorkerId(),
-            workerInfo.getAddress().toThrift(), masterBlockLocation.getTierAlias()));
+            workerInfo.getWorkerAddress().toThrift(), masterBlockLocation.getTierAlias()));
       }
     }
     return new BlockInfo(masterBlockInfo.getBlockId(), masterBlockInfo.getLength(), ret);

--- a/servers/src/main/java/tachyon/master/block/BlockMasterWorkerServiceHandler.java
+++ b/servers/src/main/java/tachyon/master/block/BlockMasterWorkerServiceHandler.java
@@ -26,6 +26,7 @@ import tachyon.thrift.BlockMasterWorkerService;
 import tachyon.thrift.Command;
 import tachyon.thrift.TachyonTException;
 import tachyon.thrift.WorkerNetAddress;
+import tachyon.worker.NetAddress;
 
 /**
  * This class is a Thrift handler for block master RPCs invoked by a Tachyon worker.
@@ -50,7 +51,7 @@ public class BlockMasterWorkerServiceHandler implements BlockMasterWorkerService
 
   @Override
   public long getWorkerId(WorkerNetAddress workerNetAddress) {
-    return mBlockMaster.getWorkerId(workerNetAddress);
+    return mBlockMaster.getWorkerId(new NetAddress(workerNetAddress));
   }
 
   @Override

--- a/servers/src/main/java/tachyon/master/block/meta/MasterWorkerInfo.java
+++ b/servers/src/main/java/tachyon/master/block/meta/MasterWorkerInfo.java
@@ -33,8 +33,8 @@ import tachyon.Constants;
 import tachyon.StorageTierAssoc;
 import tachyon.WorkerStorageTierAssoc;
 import tachyon.thrift.WorkerInfo;
-import tachyon.thrift.WorkerNetAddress;
 import tachyon.util.CommonUtils;
+import tachyon.worker.NetAddress;
 
 /**
  * Metadata for a Tachyon worker.
@@ -42,7 +42,7 @@ import tachyon.util.CommonUtils;
 public final class MasterWorkerInfo {
   private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
   /** Worker's address */
-  private final WorkerNetAddress mWorkerAddress;
+  private final NetAddress mWorkerAddress;
   /** The id of the worker */
   private final long mId;
   /** Start time of the worker in ms */
@@ -73,7 +73,7 @@ public final class MasterWorkerInfo {
    * @param id the worker id to use
    * @param address the worker address to use
    */
-  public MasterWorkerInfo(long id, WorkerNetAddress address) {
+  public MasterWorkerInfo(long id, NetAddress address) {
     mWorkerAddress = Preconditions.checkNotNull(address);
     mId = id;
     mStartTimeMs = System.currentTimeMillis();
@@ -177,7 +177,7 @@ public final class MasterWorkerInfo {
   public synchronized WorkerInfo generateClientWorkerInfo() {
     WorkerInfo ret = new WorkerInfo();
     ret.id = mId;
-    ret.address = mWorkerAddress;
+    ret.address = mWorkerAddress.toThrift();
     ret.lastContactSec =
         (int) ((CommonUtils.getCurrentMs() - mLastUpdatedTimeMs) / Constants.SECOND_MS);
     ret.state = "In Service";
@@ -190,7 +190,7 @@ public final class MasterWorkerInfo {
   /**
    * @return the worker's address
    */
-  public WorkerNetAddress getAddress() {
+  public NetAddress getAddress() {
     return mWorkerAddress;
   }
 

--- a/servers/src/main/java/tachyon/master/block/meta/MasterWorkerInfo.java
+++ b/servers/src/main/java/tachyon/master/block/meta/MasterWorkerInfo.java
@@ -190,7 +190,7 @@ public final class MasterWorkerInfo {
   /**
    * @return the worker's address
    */
-  public NetAddress getAddress() {
+  public NetAddress getWorkerAddress() {
     return mWorkerAddress;
   }
 

--- a/servers/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/servers/src/main/java/tachyon/worker/TachyonWorker.java
@@ -73,7 +73,7 @@ public final class TachyonWorker {
   /** The address for the rpc server */
   private InetSocketAddress mWorkerAddress;
   /** Net address of this worker */
-  private NetAddress mWorkerNetAddress;
+  private NetAddress mNetAddress;
   /** Worker start time in milliseconds */
   private long mStartTimeMs;
 
@@ -192,13 +192,13 @@ public final class TachyonWorker {
   }
 
   /**
-   * Gets this worker's {@link tachyon.thrift.WorkerNetAddress}, which is the worker's hostname, rpc
+   * Gets this worker's {@link NetAddress}, which is the worker's hostname, rpc
    * server port, data server port, and web server port.
    *
    * @return the worker's net address
    */
-  public NetAddress getWorkerNetAddress() {
-    return mWorkerNetAddress;
+  public NetAddress getNetAddress() {
+    return mNetAddress;
   }
 
   /**
@@ -219,11 +219,11 @@ public final class TachyonWorker {
     // Set updated net address for this worker in context
     // Requirement: RPC, web, and dataserver ports are updated
     // Consequence: create a NetAddress object and set it into WorkerContext
-    mWorkerNetAddress = new NetAddress(
+    mNetAddress = new NetAddress(
         NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC, mTachyonConf),
         mTachyonConf.getInt(Constants.WORKER_RPC_PORT), getDataLocalPort(),
         mTachyonConf.getInt(Constants.WORKER_WEB_PORT));
-    WorkerContext.setWorkerNetAddress(mWorkerNetAddress);
+    WorkerContext.setWorkerNetAddress(mNetAddress);
 
     // Start each worker
     // Requirement: NetAddress set in WorkerContext, so block worker can initialize BlockMasterSync

--- a/servers/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/servers/src/main/java/tachyon/worker/TachyonWorker.java
@@ -34,7 +34,6 @@ import tachyon.conf.TachyonConf;
 import tachyon.metrics.MetricsSystem;
 import tachyon.security.authentication.AuthenticationUtils;
 import tachyon.thrift.BlockWorkerClientService;
-import tachyon.thrift.WorkerNetAddress;
 import tachyon.util.network.NetworkAddressUtils;
 import tachyon.util.network.NetworkAddressUtils.ServiceType;
 import tachyon.web.UIWebServer;
@@ -74,7 +73,7 @@ public final class TachyonWorker {
   /** The address for the rpc server */
   private InetSocketAddress mWorkerAddress;
   /** Net address of this worker */
-  private WorkerNetAddress mWorkerNetAddress;
+  private NetAddress mWorkerNetAddress;
   /** Worker start time in milliseconds */
   private long mStartTimeMs;
 
@@ -198,7 +197,7 @@ public final class TachyonWorker {
    *
    * @return the worker's net address
    */
-  public WorkerNetAddress getWorkerNetAddress() {
+  public NetAddress getWorkerNetAddress() {
     return mWorkerNetAddress;
   }
 
@@ -220,7 +219,7 @@ public final class TachyonWorker {
     // Set updated net address for this worker in context
     // Requirement: RPC, web, and dataserver ports are updated
     // Consequence: create a NetAddress object and set it into WorkerContext
-    mWorkerNetAddress = new WorkerNetAddress(
+    mWorkerNetAddress = new NetAddress(
         NetworkAddressUtils.getConnectHost(ServiceType.WORKER_RPC, mTachyonConf),
         mTachyonConf.getInt(Constants.WORKER_RPC_PORT), getDataLocalPort(),
         mTachyonConf.getInt(Constants.WORKER_WEB_PORT));

--- a/servers/src/main/java/tachyon/worker/WorkerContext.java
+++ b/servers/src/main/java/tachyon/worker/WorkerContext.java
@@ -16,7 +16,6 @@
 package tachyon.worker;
 
 import tachyon.conf.TachyonConf;
-import tachyon.thrift.WorkerNetAddress;
 
 /**
  * A {@link WorkerContext} object stores {@link TachyonConf}.
@@ -36,7 +35,7 @@ public final class WorkerContext {
   private static WorkerSource sWorkerSource = new WorkerSource();
 
   /** Net address of this worker */
-  private static WorkerNetAddress sWorkerNetAddress;
+  private static NetAddress sWorkerNetAddress;
 
   /**
    * Returns the one and only static {@link TachyonConf} object which is shared among all classes
@@ -59,18 +58,18 @@ public final class WorkerContext {
   }
 
   /**
-   * @return {@link WorkerNetAddress} object of this worker
+   * @return {@link NetAddress} object of this worker
    */
-  public static WorkerNetAddress getWorkerNetAddress() {
+  public static NetAddress getWorkerNetAddress() {
     return sWorkerNetAddress;
   }
 
   /**
    * Sets {@link NetAddress} object of this worker.
    *
-   * @param workerNetAddress {@link WorkerNetAddress} object of this worker
+   * @param workerNetAddress {@link NetAddress} object of this worker
    */
-  public static void setWorkerNetAddress(WorkerNetAddress workerNetAddress) {
+  public static void setWorkerNetAddress(NetAddress workerNetAddress) {
     sWorkerNetAddress = workerNetAddress;
   }
 

--- a/servers/src/main/java/tachyon/worker/WorkerContext.java
+++ b/servers/src/main/java/tachyon/worker/WorkerContext.java
@@ -35,7 +35,7 @@ public final class WorkerContext {
   private static WorkerSource sWorkerSource = new WorkerSource();
 
   /** Net address of this worker */
-  private static NetAddress sWorkerNetAddress;
+  private static NetAddress sNetAddress;
 
   /**
    * Returns the one and only static {@link TachyonConf} object which is shared among all classes
@@ -60,17 +60,17 @@ public final class WorkerContext {
   /**
    * @return {@link NetAddress} object of this worker
    */
-  public static NetAddress getWorkerNetAddress() {
-    return sWorkerNetAddress;
+  public static NetAddress getNetAddress() {
+    return sNetAddress;
   }
 
   /**
    * Sets {@link NetAddress} object of this worker.
    *
-   * @param workerNetAddress {@link NetAddress} object of this worker
+   * @param netAddress {@link NetAddress} object of this worker
    */
-  public static void setWorkerNetAddress(NetAddress workerNetAddress) {
-    sWorkerNetAddress = workerNetAddress;
+  public static void setWorkerNetAddress(NetAddress netAddress) {
+    sNetAddress = netAddress;
   }
 
   /**

--- a/servers/src/main/java/tachyon/worker/WorkerIdRegistry.java
+++ b/servers/src/main/java/tachyon/worker/WorkerIdRegistry.java
@@ -22,7 +22,6 @@ import tachyon.exception.ConnectionFailedException;
 import tachyon.master.block.BlockMaster;
 import tachyon.thrift.Command;
 import tachyon.thrift.CommandType;
-import tachyon.thrift.WorkerNetAddress;
 import tachyon.worker.block.BlockMasterClient;
 import tachyon.worker.block.BlockMasterSync;
 
@@ -57,8 +56,8 @@ public final class WorkerIdRegistry {
    * @throws ConnectionFailedException if network connection failed
    */
   public static void registerWithBlockMaster(BlockMasterClient masterClient,
-      WorkerNetAddress workerAddress) throws IOException, ConnectionFailedException {
-    sWorkerId.set(masterClient.getId(workerAddress));
+      NetAddress workerAddress) throws IOException, ConnectionFailedException {
+    sWorkerId.set(masterClient.getId(workerAddress.toThrift()));
   }
 
   /**

--- a/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
@@ -33,7 +33,7 @@ import tachyon.exception.InvalidWorkerStateException;
 import tachyon.exception.TachyonException;
 import tachyon.heartbeat.HeartbeatExecutor;
 import tachyon.thrift.Command;
-import tachyon.thrift.WorkerNetAddress;
+import tachyon.worker.NetAddress;
 import tachyon.worker.WorkerContext;
 import tachyon.worker.WorkerIdRegistry;
 
@@ -56,7 +56,7 @@ public final class BlockMasterSync implements HeartbeatExecutor {
   /** Block data manager responsible for interacting with Tachyon and UFS storage */
   private final BlockDataManager mBlockDataManager;
   /** The net address of the worker */
-  private final WorkerNetAddress mWorkerAddress;
+  private final NetAddress mWorkerAddress;
   /** Milliseconds between heartbeats before a timeout */
   private final int mHeartbeatTimeoutMs;
   /** Client for all master communication */
@@ -75,7 +75,7 @@ public final class BlockMasterSync implements HeartbeatExecutor {
    * @param workerAddress the net address of the worker
    * @param masterClient the Tachyon master client
    */
-  BlockMasterSync(BlockDataManager blockDataManager, WorkerNetAddress workerAddress,
+  BlockMasterSync(BlockDataManager blockDataManager, NetAddress workerAddress,
       BlockMasterClient masterClient) {
     mBlockDataManager = blockDataManager;
     mWorkerAddress = workerAddress;

--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -137,10 +137,10 @@ public final class BlockWorker extends WorkerBase {
    */
   @Override
   public void start() throws IOException {
-    NetAddress workerNetAddress;
+    NetAddress netAddress;
     try {
-      workerNetAddress = WorkerContext.getWorkerNetAddress();
-      WorkerIdRegistry.registerWithBlockMaster(mBlockMasterClient, workerNetAddress);
+      netAddress = WorkerContext.getNetAddress();
+      WorkerIdRegistry.registerWithBlockMaster(mBlockMasterClient, netAddress);
     } catch (ConnectionFailedException e) {
       LOG.error("Failed to get a worker id from block master", e);
       throw Throwables.propagate(e);
@@ -148,7 +148,7 @@ public final class BlockWorker extends WorkerBase {
 
     // Setup BlockMasterSync
     mBlockMasterSync =
-        new BlockMasterSync(mBlockDataManager, workerNetAddress, mBlockMasterClient);
+        new BlockMasterSync(mBlockDataManager, netAddress, mBlockMasterClient);
 
     // Setup PinListSyncer
     mPinListSync = new PinListSync(mBlockDataManager, mFileSystemMasterClient);

--- a/servers/src/main/java/tachyon/worker/block/BlockWorker.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockWorker.java
@@ -27,12 +27,12 @@ import tachyon.conf.TachyonConf;
 import tachyon.exception.ConnectionFailedException;
 import tachyon.heartbeat.HeartbeatContext;
 import tachyon.heartbeat.HeartbeatThread;
-import tachyon.thrift.WorkerNetAddress;
 import tachyon.util.CommonUtils;
 import tachyon.util.ThreadFactoryUtils;
 import tachyon.util.network.NetworkAddressUtils;
 import tachyon.util.network.NetworkAddressUtils.ServiceType;
 import tachyon.worker.DataServer;
+import tachyon.worker.NetAddress;
 import tachyon.worker.WorkerBase;
 import tachyon.worker.WorkerContext;
 import tachyon.worker.WorkerIdRegistry;
@@ -137,7 +137,7 @@ public final class BlockWorker extends WorkerBase {
    */
   @Override
   public void start() throws IOException {
-    WorkerNetAddress workerNetAddress;
+    NetAddress workerNetAddress;
     try {
       workerNetAddress = WorkerContext.getWorkerNetAddress();
       WorkerIdRegistry.registerWithBlockMaster(mBlockMasterClient, workerNetAddress);

--- a/servers/src/test/java/tachyon/master/MasterSourceTest.java
+++ b/servers/src/test/java/tachyon/master/MasterSourceTest.java
@@ -45,8 +45,8 @@ import tachyon.master.file.options.MkdirOptions;
 import tachyon.master.journal.Journal;
 import tachyon.master.journal.ReadWriteJournal;
 import tachyon.thrift.FileInfo;
-import tachyon.thrift.WorkerNetAddress;
 import tachyon.underfs.UnderFileSystem;
+import tachyon.worker.NetAddress;
 
 /**
  * Unit tests for {@link MasterSource}.
@@ -93,7 +93,7 @@ public final class MasterSourceTest {
     mFileSystemMaster.start(true);
 
     // set up worker
-    mWorkerId = mBlockMaster.getWorkerId(new WorkerNetAddress("localhost", 80, 81, 82));
+    mWorkerId = mBlockMaster.getWorkerId(new NetAddress("localhost", 80, 81, 82));
     mBlockMaster.workerRegister(mWorkerId, Arrays.asList("MEM", "SSD"),
         ImmutableMap.of("MEM", (long) Constants.MB, "SSD", (long) Constants.MB),
         ImmutableMap.of("MEM", (long) Constants.KB, "SSD", (long) Constants.KB),

--- a/servers/src/test/java/tachyon/master/block/BlockMasterTest.java
+++ b/servers/src/test/java/tachyon/master/block/BlockMasterTest.java
@@ -49,16 +49,14 @@ import tachyon.master.journal.ReadWriteJournal;
 import tachyon.thrift.Command;
 import tachyon.thrift.CommandType;
 import tachyon.thrift.WorkerInfo;
-import tachyon.thrift.WorkerNetAddress;
+import tachyon.worker.NetAddress;
 
 /**
  * Unit tests for {@link tachyon.master.block.BlockMaster}.
  */
 public class BlockMasterTest {
-  private static final WorkerNetAddress NET_ADDRESS_1 =
-      new WorkerNetAddress("localhost", 80, 81, 82);
-  private static final WorkerNetAddress NET_ADDRESS_2 =
-      new WorkerNetAddress("localhost", 83, 84, 85);
+  private static final NetAddress NET_ADDRESS_1 = new NetAddress("localhost", 80, 81, 82);
+  private static final NetAddress NET_ADDRESS_2 = new NetAddress("localhost", 83, 84, 85);
 
   private BlockMaster mMaster;
   private PrivateAccess mPrivateAccess;
@@ -125,7 +123,7 @@ public class BlockMasterTest {
 
   @Test
   public void registerLostWorkerTest() throws Exception {
-    final WorkerNetAddress na = NET_ADDRESS_1;
+    final NetAddress na = NET_ADDRESS_1;
     final long expectedId = 1;
     final MasterWorkerInfo workerInfo1 = new MasterWorkerInfo(expectedId, na);
 

--- a/servers/src/test/java/tachyon/master/block/meta/MasterWorkerInfoTest.java
+++ b/servers/src/test/java/tachyon/master/block/meta/MasterWorkerInfoTest.java
@@ -34,6 +34,7 @@ import tachyon.MasterStorageTierAssoc;
 import tachyon.StorageTierAssoc;
 import tachyon.thrift.WorkerInfo;
 import tachyon.thrift.WorkerNetAddress;
+import tachyon.worker.NetAddress;
 
 /**
  * Unit tests for {@link MasterWorkerInfo}.
@@ -55,7 +56,7 @@ public final class MasterWorkerInfoTest {
   @Before
   public void before() {
     // register
-    mInfo = new MasterWorkerInfo(0, new WorkerNetAddress());
+    mInfo = new MasterWorkerInfo(0, new NetAddress(new WorkerNetAddress()));
     mInfo.register(GLOBAL_STORAGE_TIER_ASSOC, STORAGE_TIER_ALIASES, TOTAL_BYTES_ON_TIERS,
         USED_BYTES_ON_TIERS, NEW_BLOCKS);
   }

--- a/servers/src/test/java/tachyon/master/block/meta/MasterWorkerInfoTest.java
+++ b/servers/src/test/java/tachyon/master/block/meta/MasterWorkerInfoTest.java
@@ -113,7 +113,7 @@ public final class MasterWorkerInfoTest {
   public void workerInfoGenerationTest() {
     WorkerInfo workerInfo = mInfo.generateClientWorkerInfo();
     Assert.assertEquals(mInfo.getId(), workerInfo.id);
-    Assert.assertEquals(mInfo.getAddress(), workerInfo.address);
+    Assert.assertEquals(mInfo.getWorkerAddress().toThrift(), workerInfo.address);
     Assert.assertEquals("In Service", workerInfo.state);
     Assert.assertEquals(mInfo.getCapacityBytes(), workerInfo.capacityBytes);
     Assert.assertEquals(mInfo.getUsedBytes(), workerInfo.usedBytes);

--- a/servers/src/test/java/tachyon/master/file/FileSystemMasterTest.java
+++ b/servers/src/test/java/tachyon/master/file/FileSystemMasterTest.java
@@ -56,8 +56,8 @@ import tachyon.master.journal.ReadWriteJournal;
 import tachyon.thrift.CommandType;
 import tachyon.thrift.FileInfo;
 import tachyon.thrift.FileSystemCommand;
-import tachyon.thrift.WorkerNetAddress;
 import tachyon.util.IdUtils;
+import tachyon.worker.NetAddress;
 
 /**
  * Unit tests for {@link FileSystemMaster}.
@@ -115,12 +115,12 @@ public final class FileSystemMasterTest {
     mFileSystemMaster.start(true);
 
     // set up workers
-    mWorkerId1 = mBlockMaster.getWorkerId(new WorkerNetAddress("localhost", 80, 81, 82));
+    mWorkerId1 = mBlockMaster.getWorkerId(new NetAddress("localhost", 80, 81, 82));
     mBlockMaster.workerRegister(mWorkerId1, Arrays.asList("MEM", "SSD"),
         ImmutableMap.of("MEM", Constants.MB * 1L, "SSD", Constants.MB * 1L),
         ImmutableMap.of("MEM", Constants.KB * 1L, "SSD", Constants.KB * 1L),
         Maps.<String, List<Long>>newHashMap());
-    mWorkerId2 = mBlockMaster.getWorkerId(new WorkerNetAddress("remote", 80, 81, 82));
+    mWorkerId2 = mBlockMaster.getWorkerId(new NetAddress("remote", 80, 81, 82));
     mBlockMaster.workerRegister(mWorkerId2, Arrays.asList("MEM", "SSD"),
         ImmutableMap.of("MEM", Constants.MB * 1L, "SSD", Constants.MB * 1L),
         ImmutableMap.of("MEM", Constants.KB * 1L, "SSD", Constants.KB * 1L),


### PR DESCRIPTION
Purpose of this PR is to use `NetAddress` which is a defined class, rather than thrift-derived class, as possible in the code. So the detail of RPC framework is abstracted away  