### PR TITLE
[TACHYON-1531] update tachyon-start.sh to meet the tachyon-stop.sh changes

### DIFF
--- a/bin/tachyon-start.sh
+++ b/bin/tachyon-start.sh
@@ -81,7 +81,7 @@ do_mount() {
 }
 
 stop() {
-  $bin/tachyon-stop.sh
+  $bin/tachyon-stop.sh all
 }
 
 

--- a/docs/Building-Tachyon-Master-Branch.md
+++ b/docs/Building-Tachyon-Master-Branch.md
@@ -70,7 +70,7 @@ Passed the test!
 You can also stop the system by using:
 
 ```bash
-$ ./bin/tachyon-stop.sh
+$ ./bin/tachyon-stop.sh all
 ```
 
 # Unit Tests

--- a/docs/Configuring-Tachyon-with-GlusterFS.md
+++ b/docs/Configuring-Tachyon-with-GlusterFS.md
@@ -56,5 +56,5 @@ by Tachyon exist. For this test, you should see files named like:
 To stop Tachyon, you can run:
 
 ```bash
-$ ./bin/tachyon-stop.sh
+$ ./bin/tachyon-stop.sh all
 ```

--- a/docs/Configuring-Tachyon-with-HDFS.md
+++ b/docs/Configuring-Tachyon-with-HDFS.md
@@ -82,5 +82,5 @@ files named like: `/tachyon/data/default_tests_files/BasicFile_STORE_SYNC_PERSIS
 You can stop Tachyon any time by running:
 
 ```bash
-$ ./bin/tachyon-stop.sh
+$ ./bin/tachyon-stop.sh all
 ```

--- a/docs/Configuring-Tachyon-with-OSS.md
+++ b/docs/Configuring-Tachyon-with-OSS.md
@@ -66,4 +66,4 @@ After this succeeds, you can visit your OSS directory OSS_BUCKET/OSS_DIRECTORY t
 
 To stop Tachyon, you can run:
 
-    $ ./bin/tachyon-stop.sh
+    $ ./bin/tachyon-stop.sh all

--- a/docs/Configuring-Tachyon-with-S3.md
+++ b/docs/Configuring-Tachyon-with-S3.md
@@ -166,5 +166,5 @@ and directories created by Tachyon exist. For this test, you should see files na
 To stop Tachyon, you can run:
 
 ```bash
-$ ./bin/tachyon-stop.sh
+$ ./bin/tachyon-stop.sh all
 ```

--- a/docs/Configuring-Tachyon-with-Swift.md
+++ b/docs/Configuring-Tachyon-with-Swift.md
@@ -82,7 +82,7 @@ by Tachyon exist. For this test, you should see files named like:
 To stop Tachyon, you can run:
 
 ```bash
-$ ./bin/tachyon-stop.sh
+$ ./bin/tachyon-stop.sh all
 ```
 # Running functional test with IBM SoftLayer
 

--- a/docs/Running-Hadoop-MapReduce-on-Tachyon.md
+++ b/docs/Running-Hadoop-MapReduce-on-Tachyon.md
@@ -146,7 +146,7 @@ export TACHYON_UNDERFS_ADDRESS=hdfs://localhost:9000
 Start Tachyon locally:
 
 ```bash
-$ ./bin/tachyon-stop.sh
+$ ./bin/tachyon-stop.sh all
 $ ./bin/tachyon-start.sh local
 ```
 

--- a/docs/Running-Tachyon-Locally.md
+++ b/docs/Running-Tachyon-Locally.md
@@ -80,5 +80,5 @@ $ ./bin/tachyon runTests
 You can stop Tachyon any time by running:
 
 ```bash
-$ ./bin/tachyon-stop.sh
+$ ./bin/tachyon-stop.sh all
 ```

--- a/docs/Running-Tachyon-on-EC2-Yarn.md
+++ b/docs/Running-Tachyon-on-EC2-Yarn.md
@@ -137,7 +137,7 @@ ApplicationMaster for Tachyon.
 
 ```bash
 $ cd /tachyon
-$ ./bin/tachyon-stop.sh
+$ ./bin/tachyon-stop.sh all
 $ mvn clean install -Dhadoop.version=2.4.1 -Pyarn -DskipTests -Dfindbugs.skip -Dmaven.javadoc.skip -Dcheckstyle.skip
 ```
 

--- a/examples/src/main/java/tachyon/examples/JournalCrashTest.java
+++ b/examples/src/main/java/tachyon/examples/JournalCrashTest.java
@@ -413,7 +413,7 @@ public class JournalCrashTest {
    */
   private static void stopCluster() {
     String stopClusterCommand = new TachyonConf().get(Constants.TACHYON_HOME)
-        + "/bin/tachyon-stop.sh";
+        + "/bin/tachyon-stop.sh all";
     try {
       Runtime.getRuntime().exec(stopClusterCommand).waitFor();
       CommonUtils.sleepMs(LOG, 1000);


### PR DESCRIPTION
[TACHYON-1528](https://tachyon.atlassian.net/browse/TACHYON-1528) changed the stop logic to print usage info by default when run the `bin/tachyon-stop.sh`. With this update, `bin/tachyon-start.sh`'s logic has been changed when start tachyon because the start should stop all the previously running Tachyon services.

The `bin/tachyon-start.sh` should been updated to meet the logic changes of `bin/tachyon-stop.sh`

Also update the docs.