### PR TITLE
[TACHYON-1355] Remove unnecessary parens in NetworkAddressUtils.isValidAddress

### DIFF
--- a/common/src/main/java/tachyon/util/network/NetworkAddressUtils.java
+++ b/common/src/main/java/tachyon/util/network/NetworkAddressUtils.java
@@ -435,9 +435,9 @@ public final class NetworkAddressUtils {
    * @throws IOException if the address resolution fails
    */
   private static boolean isValidAddress(InetAddress address, int timeout) throws IOException {
-    return (!address.isAnyLocalAddress() && !address.isLinkLocalAddress()
+    return !address.isAnyLocalAddress() && !address.isLinkLocalAddress()
         && !address.isLoopbackAddress() && address.isReachable(timeout)
-        && (address instanceof Inet4Address));
+        && (address instanceof Inet4Address);
   }
 
   /**


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1355
The outer parens in NetworkAddressUtils.isValidAddress were unnecessary and have been removed