### PR TITLE
[SMALLFIX] Sync with OSS when journal flushes to OSS as under FS

### DIFF
--- a/servers/src/main/java/tachyon/master/journal/JournalWriter.java
+++ b/servers/src/main/java/tachyon/master/journal/JournalWriter.java
@@ -362,10 +362,12 @@ public final class JournalWriter {
         ((FSDataOutputStream) mRawOutputStream).sync();
       }
       boolean overSize = mDataOutputStream.size() > mMaxLogSize;
-      if (overSize || mUfs.getUnderFSType() == UnderFileSystem.UnderFSType.S3) {
+      if (overSize || mUfs.getUnderFSType() == UnderFileSystem.UnderFSType.S3
+          || mUfs.getUnderFSType() == UnderFileSystem.UnderFSType.OSS) {
         // (1) The log file is oversize, needs to be rotated. Or
-        // (2) Underfs is S3, flush on S3OutputStream will only flush to local temporary file,
-        //     call close and complete the log to sync the journal entry to S3.
+        // (2) Underfs is S3 or OSS, flush on S3OutputStream/OSSOutputStream will only flush to
+        // local temporary file,
+        // call close and complete the log to sync the journal entry to S3/OSS.
         if (overSize) {
           LOG.info("Rotating log file. size: {} maxSize: {}", mDataOutputStream.size(),
               mMaxLogSize);


### PR DESCRIPTION
This is needed because OSS like S3 doesn't support flush buffering. @calvinjia @luoli523 