### PR TITLE
[TACHYON-1376] added two test cases for pin tfs command

### DIFF
--- a/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
+++ b/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
@@ -1252,4 +1252,53 @@ public class TfsShellTest {
     checkFilePersisted(mTfs.open(new TachyonURI("/testWildCards/foobar4")), 40);
     ClientContext.reset();
   }
+  @Test
+  public void setIsPinnedTest() throws Exception {
+   String filePath = "/testFile";
+   TachyonFile file = TachyonFSTestUtils.createByteFile(mTfs, filePath, TachyonStorageType.STORE,
+       UnderStorageType.NO_PERSIST, 1);
+
+    //Ensure that the file exists first
+   Assert.assertTrue(fileExist(new TachyonURI(filePath)));
+
+    //By default the file in pinned , so must be unpinned first
+   Assert.assertFalse(mTfs.getInfo(file).isPinned);
+   Assert.assertEquals(0, mFsShell.run("unpin", filePath));
+   Assert.assertFalse(mTfs.getInfo(file).isPinned);
+
+    //Now explicitly pin the file
+   Assert.assertEquals(0, mFsShell.run("pin", filePath));
+   Assert.assertEquals(true, mTfs.getInfo(file).isPinned);
+ }
+
+  /*
+   * create three files with initial size of 5MB to be added to Tachyon once the third file is
+   * added Tachyon is forced to evict one file. Since fileA is is pinned it will not be
+   * evicted only fileB
+   */
+ @Test
+  public void setPinTest() throws Exception {
+   String filePathA = "/testFileA";
+   String filePathB = "/testFileB";
+   String filePathC = "/testFileC";
+   int fileSize = 5 * 1024 * 1024 ;
+
+   TachyonFile fileA = TachyonFSTestUtils.createByteFile(mTfs, filePathA, TachyonStorageType.STORE,
+       UnderStorageType.NO_PERSIST, fileSize);
+   Assert.assertTrue(fileExist(new TachyonURI(filePathA)));
+   Assert.assertEquals(0, mFsShell.run("pin", filePathA));
+
+   TachyonFile fileB = TachyonFSTestUtils.createByteFile(mTfs, filePathB, TachyonStorageType.STORE,
+       UnderStorageType.NO_PERSIST, fileSize);
+   Assert.assertTrue(fileExist(new TachyonURI(filePathB)));
+   Assert.assertEquals(0, mFsShell.run("unpin", filePathB));
+
+   TachyonFile fileC = TachyonFSTestUtils.createByteFile(mTfs, filePathC, TachyonStorageType.STORE,
+       UnderStorageType.NO_PERSIST, fileSize);
+   Assert.assertTrue(fileExist(new TachyonURI(filePathC)));
+
+    //fileA is in memory because it is pinned, but not fileB
+   Assert.assertEquals(100, mTfs.getInfo(fileA).inMemoryPercentage);
+   Assert.assertEquals(0, mTfs.getInfo(fileB).inMemoryPercentage);
+ }
 }

--- a/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
+++ b/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
@@ -1254,21 +1254,21 @@ public class TfsShellTest {
   }
   @Test
   public void setIsPinnedTest() throws Exception {
-   String filePath = "/testFile";
-   TachyonFile file = TachyonFSTestUtils.createByteFile(mTfs, filePath, TachyonStorageType.STORE,
-       UnderStorageType.NO_PERSIST, 1);
+    String filePath = "/testFile";
+    TachyonFile file = TachyonFSTestUtils.createByteFile(mTfs, filePath, TachyonStorageType.STORE,
+        UnderStorageType.NO_PERSIST, 1);
 
     //Ensure that the file exists first
-   Assert.assertTrue(fileExist(new TachyonURI(filePath)));
+    Assert.assertTrue(fileExist(new TachyonURI(filePath)));
 
     //By default the file in pinned , so must be unpinned first
-   Assert.assertFalse(mTfs.getInfo(file).isPinned);
-   Assert.assertEquals(0, mFsShell.run("unpin", filePath));
-   Assert.assertFalse(mTfs.getInfo(file).isPinned);
+    Assert.assertFalse(mTfs.getInfo(file).isPinned);
+    Assert.assertEquals(0, mFsShell.run("unpin", filePath));
+    Assert.assertFalse(mTfs.getInfo(file).isPinned);
 
     //Now explicitly pin the file
-   Assert.assertEquals(0, mFsShell.run("pin", filePath));
-   Assert.assertEquals(true, mTfs.getInfo(file).isPinned);
+    Assert.assertEquals(0, mFsShell.run("pin", filePath));
+    Assert.assertEquals(true, mTfs.getInfo(file).isPinned);
  }
 
   /*
@@ -1278,27 +1278,27 @@ public class TfsShellTest {
    */
  @Test
   public void setPinTest() throws Exception {
-   String filePathA = "/testFileA";
-   String filePathB = "/testFileB";
-   String filePathC = "/testFileC";
-   int fileSize = 5 * 1024 * 1024 ;
+    String filePathA = "/testFileA";
+    String filePathB = "/testFileB";
+    String filePathC = "/testFileC";
+    int fileSize = 5 * 1024 * 1024 ;
 
-   TachyonFile fileA = TachyonFSTestUtils.createByteFile(mTfs, filePathA, TachyonStorageType.STORE,
-       UnderStorageType.NO_PERSIST, fileSize);
-   Assert.assertTrue(fileExist(new TachyonURI(filePathA)));
-   Assert.assertEquals(0, mFsShell.run("pin", filePathA));
+    TachyonFile fileA = TachyonFSTestUtils.createByteFile(mTfs, filePathA, TachyonStorageType.STORE,
+        UnderStorageType.NO_PERSIST, fileSize);
+    Assert.assertTrue(fileExist(new TachyonURI(filePathA)));
+    Assert.assertEquals(0, mFsShell.run("pin", filePathA));
 
-   TachyonFile fileB = TachyonFSTestUtils.createByteFile(mTfs, filePathB, TachyonStorageType.STORE,
-       UnderStorageType.NO_PERSIST, fileSize);
-   Assert.assertTrue(fileExist(new TachyonURI(filePathB)));
-   Assert.assertEquals(0, mFsShell.run("unpin", filePathB));
+    TachyonFile fileB = TachyonFSTestUtils.createByteFile(mTfs, filePathB, TachyonStorageType.STORE,
+        UnderStorageType.NO_PERSIST, fileSize);
+    Assert.assertTrue(fileExist(new TachyonURI(filePathB)));
+    Assert.assertEquals(0, mFsShell.run("unpin", filePathB));
 
-   TachyonFile fileC = TachyonFSTestUtils.createByteFile(mTfs, filePathC, TachyonStorageType.STORE,
-       UnderStorageType.NO_PERSIST, fileSize);
-   Assert.assertTrue(fileExist(new TachyonURI(filePathC)));
+    TachyonFile fileC = TachyonFSTestUtils.createByteFile(mTfs, filePathC, TachyonStorageType.STORE,
+        UnderStorageType.NO_PERSIST, fileSize);
+    Assert.assertTrue(fileExist(new TachyonURI(filePathC)));
 
     //fileA is in memory because it is pinned, but not fileB
-   Assert.assertEquals(100, mTfs.getInfo(fileA).inMemoryPercentage);
-   Assert.assertEquals(0, mTfs.getInfo(fileB).inMemoryPercentage);
- }
+    Assert.assertEquals(100, mTfs.getInfo(fileA).inMemoryPercentage);
+    Assert.assertEquals(0, mTfs.getInfo(fileB).inMemoryPercentage);
+  }
 }

--- a/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
+++ b/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
@@ -1252,6 +1252,7 @@ public class TfsShellTest {
     checkFilePersisted(mTfs.open(new TachyonURI("/testWildCards/foobar4")), 40);
     ClientContext.reset();
   }
+
   @Test
   public void setIsPinnedTest() throws Exception {
     String filePath = "/testFile";
@@ -1269,14 +1270,14 @@ public class TfsShellTest {
     //Now explicitly pin the file
     Assert.assertEquals(0, mFsShell.run("pin", filePath));
     Assert.assertEquals(true, mTfs.getInfo(file).isPinned);
- }
+  }
 
   /*
    * create three files with initial size of 5MB to be added to Tachyon once the third file is
    * added Tachyon is forced to evict one file. Since fileA is is pinned it will not be
    * evicted only fileB
    */
- @Test
+  @Test
   public void setPinTest() throws Exception {
     String filePathA = "/testFileA";
     String filePathB = "/testFileB";


### PR DESCRIPTION
regarding test case setIsPinnedTest, I found the file to be already pinned if it was created via TachyonFSTestUtils.createByteFile , but if the file was created via tfs command line it will not be already pinned. 

regarding use case setPinTest() . I assumed that the limit on the tachyon worker memory is 15MB. I am not sure if that is always the case!!! 

