### PR TITLE
[TACHYON-1534] Fix flaky tachyon.shell.TfsShellTest#lsTest

### DIFF
--- a/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
+++ b/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
@@ -506,14 +506,17 @@ public class TfsShellTest {
 
   @Test
   public void lsrTest() throws IOException, TachyonException {
-    // clear the loginUser
-    Whitebox.setInternalState(LoginUser.class, "sLoginUser", (String) null);
     MasterContext.getConf().set(Constants.SECURITY_GROUP_MAPPING,
         IdentityUserGroupsMapping.class.getName());
 
     FileInfo[] files = new FileInfo[4];
     String testUser = "test_user_lsr";
-    System.setProperty(Constants.SECURITY_LOGIN_USERNAME, testUser);
+    // clear the loginUser and re-login with new user
+    synchronized (LoginUser.class) {
+      Whitebox.setInternalState(LoginUser.class, "sLoginUser", (String) null);
+      System.setProperty(Constants.SECURITY_LOGIN_USERNAME, testUser);
+      LoginUser.get(ClientContext.getConf());
+    }
 
     TachyonFile fileA = TachyonFSTestUtils.createByteFile(mTfs, "/testRoot/testFileA",
         TachyonStorageType.STORE, UnderStorageType.NO_PERSIST, 10);
@@ -546,14 +549,17 @@ public class TfsShellTest {
 
   @Test
   public void lsTest() throws IOException, TachyonException {
-    // clear the loginUser
-    Whitebox.setInternalState(LoginUser.class, "sLoginUser", (String) null);
     MasterContext.getConf().set(Constants.SECURITY_GROUP_MAPPING,
         IdentityUserGroupsMapping.class.getName());
 
     FileInfo[] files = new FileInfo[4];
     String testUser = "test_user_ls";
-    System.setProperty(Constants.SECURITY_LOGIN_USERNAME, testUser);
+    // clear the loginUser and re-login with new user
+    synchronized (LoginUser.class) {
+      Whitebox.setInternalState(LoginUser.class, "sLoginUser", (String) null);
+      System.setProperty(Constants.SECURITY_LOGIN_USERNAME, testUser);
+      LoginUser.get(ClientContext.getConf());
+    }
 
     TachyonFile fileA = TachyonFSTestUtils.createByteFile(mTfs, "/testRoot/testFileA",
         TachyonStorageType.STORE, UnderStorageType.NO_PERSIST, 10);

--- a/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
+++ b/integration-tests/src/test/java/tachyon/shell/TfsShellTest.java
@@ -511,12 +511,7 @@ public class TfsShellTest {
 
     FileInfo[] files = new FileInfo[4];
     String testUser = "test_user_lsr";
-    // clear the loginUser and re-login with new user
-    synchronized (LoginUser.class) {
-      Whitebox.setInternalState(LoginUser.class, "sLoginUser", (String) null);
-      System.setProperty(Constants.SECURITY_LOGIN_USERNAME, testUser);
-      LoginUser.get(ClientContext.getConf());
-    }
+    cleanAndLogin(testUser);
 
     TachyonFile fileA = TachyonFSTestUtils.createByteFile(mTfs, "/testRoot/testFileA",
         TachyonStorageType.STORE, UnderStorageType.NO_PERSIST, 10);
@@ -554,12 +549,7 @@ public class TfsShellTest {
 
     FileInfo[] files = new FileInfo[4];
     String testUser = "test_user_ls";
-    // clear the loginUser and re-login with new user
-    synchronized (LoginUser.class) {
-      Whitebox.setInternalState(LoginUser.class, "sLoginUser", (String) null);
-      System.setProperty(Constants.SECURITY_LOGIN_USERNAME, testUser);
-      LoginUser.get(ClientContext.getConf());
-    }
+    cleanAndLogin(testUser);
 
     TachyonFile fileA = TachyonFSTestUtils.createByteFile(mTfs, "/testRoot/testFileA",
         TachyonStorageType.STORE, UnderStorageType.NO_PERSIST, 10);
@@ -1230,5 +1220,14 @@ public class TfsShellTest {
     checkFilePersisted(mTfs.open(new TachyonURI("/testWildCards/bar/foobar3")), 30);
     checkFilePersisted(mTfs.open(new TachyonURI("/testWildCards/foobar4")), 40);
     ClientContext.reset();
+  }
+
+  private void cleanAndLogin(String user) throws IOException {
+    // clear the loginUser and re-login with new user
+    synchronized (LoginUser.class) {
+      Whitebox.setInternalState(LoginUser.class, "sLoginUser", (String) null);
+      System.setProperty(Constants.SECURITY_LOGIN_USERNAME, user);
+      LoginUser.get(ClientContext.getConf());
+    }
   }
 }


### PR DESCRIPTION
JIRA: https://tachyon.atlassian.net/browse/TACHYON-1534

Fix flaky tachyon.shell.TfsShellTest#lsTest. The clean and re-login is not a atomic operation, so that the re-login user sometimes is not expected. This patch put them into a synchronized block.

@apc999 , @sundapeng , would you like to take a look at this?