### PR TITLE
[TACHYON-1572] Clean up contract test local clusters

### DIFF
--- a/integration-tests/src/test/java/tachyon/LocalTachyonClusterResource.java
+++ b/integration-tests/src/test/java/tachyon/LocalTachyonClusterResource.java
@@ -65,6 +65,10 @@ import tachyon.master.LocalTachyonCluster;
  */
 public class LocalTachyonClusterResource implements TestRule {
 
+  private static final long DEFAULT_WORKER_CAPACITY_BYTES = 100 * Constants.MB;
+  private static final int DEFAULT_QUOTA_UNIT_BYTES = 100 * Constants.KB;
+  private static final int DEFAULT_USER_BLOCK_SIZE = Constants.KB;
+
   /** The capacity of the worker in bytes */
   private final long mWorkerCapacityBytes;
   /** The quota of space each user can request */
@@ -102,6 +106,10 @@ public class LocalTachyonClusterResource implements TestRule {
     mUserBlockSize = userBlockSize;
     mStartCluster = startCluster;
     mConfParams = confParams;
+  }
+
+  public LocalTachyonClusterResource() {
+    this(DEFAULT_WORKER_CAPACITY_BYTES, DEFAULT_QUOTA_UNIT_BYTES, DEFAULT_USER_BLOCK_SIZE);
   }
 
   public LocalTachyonClusterResource(long workerCapacityBytes, int quotaUnitBytes,

--- a/integration-tests/src/test/java/tachyon/LocalTachyonClusterResource.java
+++ b/integration-tests/src/test/java/tachyon/LocalTachyonClusterResource.java
@@ -108,7 +108,6 @@ public class LocalTachyonClusterResource implements TestRule {
     mConfParams = confParams;
   }
 
-
   /**
    * Create a new {@link LocalTachyonClusterResource} with default configuration.
    */

--- a/integration-tests/src/test/java/tachyon/LocalTachyonClusterResource.java
+++ b/integration-tests/src/test/java/tachyon/LocalTachyonClusterResource.java
@@ -108,6 +108,11 @@ public class LocalTachyonClusterResource implements TestRule {
     mConfParams = confParams;
   }
 
+
+  /**
+   * Create a new {@link LocalTachyonClusterResource} with default configuration.
+   */
+  // TODO(andrew) Go through our integration tests and see how many can use this constructor.
   public LocalTachyonClusterResource() {
     this(DEFAULT_WORKER_CAPACITY_BYTES, DEFAULT_QUOTA_UNIT_BYTES, DEFAULT_USER_BLOCK_SIZE);
   }

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContract.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContract.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 
 import tachyon.Constants;
-import tachyon.exception.ConnectionFailedException;
 import tachyon.hadoop.TFS;
 import tachyon.master.LocalTachyonCluster;
 
@@ -40,10 +39,12 @@ public class TachyonFSContract extends AbstractFSContract {
   public static final String CONTRACT_XML = "contract/tachyonfs.xml";
   public static final String SYSPROP_TEST_BUILD_DATA = "test.build.data";
   public static final String DEFAULT_TEST_BUILD_DATA_DIR = "test/build/data";
+  private LocalTachyonCluster mLocalTachyonCluster;
   private FileSystem mFS;
 
-  public TachyonFSContract(Configuration conf) {
+  public TachyonFSContract(Configuration conf, LocalTachyonCluster cluster) {
     super(conf);
+    mLocalTachyonCluster = cluster;
     //insert the base features
     addConfResource(getContractXml());
   }
@@ -62,14 +63,7 @@ public class TachyonFSContract extends AbstractFSContract {
     Configuration conf = new Configuration();
     conf.set("fs.tachyon.impl", TFS.class.getName());
 
-    // Start local Tachyon cluster
-    LocalTachyonCluster localcluster = new LocalTachyonCluster(100000000, 100000, 1024);
-    try {
-      localcluster.start();
-    } catch (ConnectionFailedException e) {
-      throw new IOException(e);
-    }
-    URI uri = URI.create(localcluster.getMasterUri());
+    URI uri = URI.create(mLocalTachyonCluster.getMasterUri());
 
     mFS = FileSystem.get(uri, conf);
   }

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContract.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContract.java
@@ -42,6 +42,12 @@ public class TachyonFSContract extends AbstractFSContract {
   private LocalTachyonCluster mLocalTachyonCluster;
   private FileSystem mFS;
 
+  /**
+   * Creates a new {@link TachyonFSContract}.
+   *
+   * @param conf configuration for hdfs
+   * @param cluster the Tachyon cluster to test in this contract
+   */
   public TachyonFSContract(Configuration conf, LocalTachyonCluster cluster) {
     super(conf);
     mLocalTachyonCluster = cluster;

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContract.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContract.java
@@ -39,7 +39,7 @@ public class TachyonFSContract extends AbstractFSContract {
   public static final String CONTRACT_XML = "contract/tachyonfs.xml";
   public static final String SYSPROP_TEST_BUILD_DATA = "test.build.data";
   public static final String DEFAULT_TEST_BUILD_DATA_DIR = "test/build/data";
-  private LocalTachyonCluster mLocalTachyonCluster;
+  private final LocalTachyonCluster mLocalTachyonCluster;
   private FileSystem mFS;
 
   /**

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractCreateIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractCreateIntegrationTest.java
@@ -18,10 +18,16 @@ package tachyon.hadoop.contract;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractCreateTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.Rule;
+
+import tachyon.LocalTachyonClusterResource;
 
 public class TachyonFSContractCreateIntegrationTest extends AbstractContractCreateTest {
+  @Rule
+  public LocalTachyonClusterResource mClusterResource = new LocalTachyonClusterResource();
+
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    return new TachyonFSContract(conf);
+    return new TachyonFSContract(conf, mClusterResource.get());
   }
 }

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractDeleteIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractDeleteIntegrationTest.java
@@ -18,10 +18,16 @@ package tachyon.hadoop.contract;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractDeleteTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.Rule;
+
+import tachyon.LocalTachyonClusterResource;
 
 public class TachyonFSContractDeleteIntegrationTest extends AbstractContractDeleteTest {
+  @Rule
+  public LocalTachyonClusterResource mClusterResource = new LocalTachyonClusterResource();
+
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    return new TachyonFSContract(conf);
+    return new TachyonFSContract(conf, mClusterResource.get());
   }
 }

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractLoadedIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractLoadedIntegrationTest.java
@@ -20,13 +20,18 @@ import java.net.URL;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.contract.AbstractFSContractTestBase;
+import org.junit.Rule;
 import org.junit.Test;
 
+import tachyon.LocalTachyonClusterResource;
+
 public class TachyonFSContractLoadedIntegrationTest extends AbstractFSContractTestBase {
+  @Rule
+  public LocalTachyonClusterResource mClusterResource = new LocalTachyonClusterResource();
 
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    return new TachyonFSContract(conf);
+    return new TachyonFSContract(conf, mClusterResource.get());
   }
 
   @Test

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractMkdirIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractMkdirIntegrationTest.java
@@ -18,10 +18,16 @@ package tachyon.hadoop.contract;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractMkdirTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.Rule;
+
+import tachyon.LocalTachyonClusterResource;
 
 public class TachyonFSContractMkdirIntegrationTest extends AbstractContractMkdirTest {
+  @Rule
+  public LocalTachyonClusterResource mClusterResource = new LocalTachyonClusterResource();
+
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    return new TachyonFSContract(conf);
+    return new TachyonFSContract(conf, mClusterResource.get());
   }
 }

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractOpenIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractOpenIntegrationTest.java
@@ -18,10 +18,16 @@ package tachyon.hadoop.contract;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractOpenTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.Rule;
+
+import tachyon.LocalTachyonClusterResource;
 
 public class TachyonFSContractOpenIntegrationTest extends AbstractContractOpenTest {
+  @Rule
+  public LocalTachyonClusterResource mClusterResource = new LocalTachyonClusterResource();
+
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    return new TachyonFSContract(conf);
+    return new TachyonFSContract(conf, mClusterResource.get());
   }
 }

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractRenameIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractRenameIntegrationTest.java
@@ -18,10 +18,16 @@ package tachyon.hadoop.contract;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.Rule;
+
+import tachyon.LocalTachyonClusterResource;
 
 public class TachyonFSContractRenameIntegrationTest extends AbstractContractRenameTest {
+  @Rule
+  public LocalTachyonClusterResource mClusterResource = new LocalTachyonClusterResource();
+
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    return new TachyonFSContract(conf);
+    return new TachyonFSContract(conf, mClusterResource.get());
   }
 }

--- a/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractSeekIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/hadoop/contract/TachyonFSContractSeekIntegrationTest.java
@@ -18,10 +18,16 @@ package tachyon.hadoop.contract;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.contract.AbstractContractSeekTest;
 import org.apache.hadoop.fs.contract.AbstractFSContract;
+import org.junit.Rule;
+
+import tachyon.LocalTachyonClusterResource;
 
 public class TachyonFSContractSeekIntegrationTest extends AbstractContractSeekTest {
+  @Rule
+  public LocalTachyonClusterResource mClusterResource = new LocalTachyonClusterResource();
+
   @Override
   protected AbstractFSContract createContract(Configuration conf) {
-    return new TachyonFSContract(conf);
+    return new TachyonFSContract(conf, mClusterResource.get());
   }
 }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1572

Previously, `LocalTachyonCluster`s were created in `TachyonFSContract`, but there is no hook to clean up these clusters, so this PR moves ownership to the individual contract tests so that they can use `@Rule` to manage cluster creation and cleanup.