### PR TITLE
[SMALLFIX] Fix client heartbeat thread leak

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/ClientContext.java
+++ b/clients/unshaded/src/main/java/tachyon/client/ClientContext.java
@@ -70,7 +70,7 @@ public final class ClientContext {
     sClientMetrics = new ClientMetrics();
 
     if (sExecutorService != null) {
-      sExecutorService.shutdown();
+      sExecutorService.shutdownNow();
     }
     sExecutorService = Executors.newFixedThreadPool(
         sTachyonConf.getInt(Constants.USER_BLOCK_WORKER_CLIENT_THREADS),


### PR DESCRIPTION
Regular shutdown() just prevents more tasks from being started.
shutdownNow() is needed to interrupt existing tasks. If heartbeat
threads aren't interrupted, they will continue until the JVM stops.