### PR TITLE
[TACHYON-1592] Add unit test coverage for HdfsUnderFileSystem

### DIFF
--- a/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java
@@ -73,7 +73,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
     } else {
       tConf = new Configuration();
     }
-    prepareConfiguration(fsDefaultName, tachyonConf, tConf);
+    prepareConfiguration(tachyonConf, tConf);
     tConf.addResource(new Path(tConf.get(Constants.UNDERFS_HDFS_CONFIGURATION)));
     HdfsUnderFileSystemUtils.addS3Credentials(tConf);
 
@@ -100,10 +100,10 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
    * configuration necessary for obtaining a usable {@linkplain FileSystem} instance.
    * </p>
    *
-   * @param path file system path
+   * @param tachyonConf Tachyon Configuration
    * @param config Hadoop configuration
    */
-  protected void prepareConfiguration(String path, TachyonConf tachyonConf, Configuration config) {
+  protected void prepareConfiguration(TachyonConf tachyonConf, Configuration config) {
     // On Hadoop 2.x this is strictly unnecessary since it uses ServiceLoader to automatically
     // discover available file system implementations. However this configuration setting is
     // required for earlier Hadoop versions plus it is still honoured as an override even in 2.x so

--- a/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java
@@ -100,6 +100,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
    * configuration necessary for obtaining a usable {@linkplain FileSystem} instance.
    * </p>
    *
+   * @param path file system path
    * @param tachyonConf Tachyon Configuration
    * @param config Hadoop configuration
    */

--- a/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java
+++ b/underfs/hdfs/src/main/java/tachyon/underfs/hdfs/HdfsUnderFileSystem.java
@@ -73,7 +73,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
     } else {
       tConf = new Configuration();
     }
-    prepareConfiguration(tachyonConf, tConf);
+    prepareConfiguration(fsDefaultName, tachyonConf, tConf);
     tConf.addResource(new Path(tConf.get(Constants.UNDERFS_HDFS_CONFIGURATION)));
     HdfsUnderFileSystemUtils.addS3Credentials(tConf);
 
@@ -103,7 +103,7 @@ public class HdfsUnderFileSystem extends UnderFileSystem {
    * @param tachyonConf Tachyon Configuration
    * @param config Hadoop configuration
    */
-  protected void prepareConfiguration(TachyonConf tachyonConf, Configuration config) {
+  protected void prepareConfiguration(String path, TachyonConf tachyonConf, Configuration config) {
     // On Hadoop 2.x this is strictly unnecessary since it uses ServiceLoader to automatically
     // discover available file system implementations. However this configuration setting is
     // required for earlier Hadoop versions plus it is still honoured as an override even in 2.x so

--- a/underfs/hdfs/src/test/java/tachyon/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/tachyon/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -51,7 +51,7 @@ public final class HdfsUnderFileSystemTest {
    * Tests the
    * {@link HdfsUnderFileSystem#prepareConfiguration(String, TachyonConf, Configuration)} method.
    *
-   * Check the hdfs implements class and tachyon underfs config setting
+   * Checks the hdfs implements class and tachyon underfs config setting
    *
    * @throws Exception
    */

--- a/underfs/hdfs/src/test/java/tachyon/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/tachyon/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the University of California, Berkeley under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package tachyon.underfs.hdfs;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import tachyon.Constants;
+import tachyon.conf.TachyonConf;
+import tachyon.underfs.UnderFileSystem.UnderFSType;
+
+/**
+ * Tests {@link HdfsUnderFileSystem}.
+ */
+public final class HdfsUnderFileSystemTest {
+
+  private HdfsUnderFileSystem mMockHdfsUnderFileSystem;
+
+  @Before
+  public final void before() throws Exception {
+    mMockHdfsUnderFileSystem = new HdfsUnderFileSystem("file:///", new TachyonConf(), null);
+  }
+
+  @Test
+  public void getUnderFSTypeTest() throws Exception {
+    Assert.assertEquals(UnderFSType.HDFS, mMockHdfsUnderFileSystem.getUnderFSType());
+  }
+
+  @Test
+  public void prepareConfigurationTest() throws Exception {
+    TachyonConf tConf = new TachyonConf();
+    Configuration hConf = new Configuration();
+    mMockHdfsUnderFileSystem.prepareConfiguration(tConf, hConf);
+    Assert.assertEquals("org.apache.hadoop.hdfs.DistributedFileSystem", hConf.get("fs.hdfs.impl"));
+    Assert.assertFalse(hConf.getBoolean("fs.hdfs.impl.disable.cache", false));
+    Assert.assertNotNull(hConf.get(Constants.UNDERFS_HDFS_CONFIGURATION));
+  }
+}

--- a/underfs/hdfs/src/test/java/tachyon/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/tachyon/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem.UnderFSType;
-import tachyon.underfs.s3.S3UnderFileSystem;
 
 /**
  * Tests {@link HdfsUnderFileSystem}.

--- a/underfs/hdfs/src/test/java/tachyon/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/tachyon/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -45,7 +45,7 @@ public final class HdfsUnderFileSystemTest {
   public void prepareConfigurationTest() throws Exception {
     TachyonConf tConf = new TachyonConf();
     Configuration hConf = new Configuration();
-    mMockHdfsUnderFileSystem.prepareConfiguration(tConf, hConf);
+    mMockHdfsUnderFileSystem.prepareConfiguration("", tConf, hConf);
     Assert.assertEquals("org.apache.hadoop.hdfs.DistributedFileSystem", hConf.get("fs.hdfs.impl"));
     Assert.assertFalse(hConf.getBoolean("fs.hdfs.impl.disable.cache", false));
     Assert.assertNotNull(hConf.get(Constants.UNDERFS_HDFS_CONFIGURATION));

--- a/underfs/hdfs/src/test/java/tachyon/underfs/hdfs/HdfsUnderFileSystemTest.java
+++ b/underfs/hdfs/src/test/java/tachyon/underfs/hdfs/HdfsUnderFileSystemTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem.UnderFSType;
+import tachyon.underfs.s3.S3UnderFileSystem;
 
 /**
  * Tests {@link HdfsUnderFileSystem}.
@@ -36,11 +37,25 @@ public final class HdfsUnderFileSystemTest {
     mMockHdfsUnderFileSystem = new HdfsUnderFileSystem("file:///", new TachyonConf(), null);
   }
 
+  /**
+   * Tests the {@link HdfsUnderFileSystem#getUnderFSType()} method.
+   * Confirm the UnderFSType for HdfsUnderFileSystem
+   *
+   * @throws Exception
+   */
   @Test
   public void getUnderFSTypeTest() throws Exception {
     Assert.assertEquals(UnderFSType.HDFS, mMockHdfsUnderFileSystem.getUnderFSType());
   }
 
+  /**
+   * Tests the
+   * {@link HdfsUnderFileSystem#prepareConfiguration(String, TachyonConf, Configuration)} method.
+   *
+   * Check the hdfs implements class and tachyon underfs config setting
+   *
+   * @throws Exception
+   */
   @Test
   public void prepareConfigurationTest() throws Exception {
     TachyonConf tConf = new TachyonConf();


### PR DESCRIPTION
There are really not that much utility methods in HdfsUnderFileSystem good for unit test. The apis of FileSystem are better tested by integration tests.

I added a little tests to check some configuration.