### PR TITLE
[TACHYON-1606] Name exceptions "e"

### DIFF
--- a/build/checkstyle/tachyon_checks.xml
+++ b/build/checkstyle/tachyon_checks.xml
@@ -6,10 +6,10 @@
 <!--
 
     Checkstyle configurartion that checks the Google coding conventions from:
-    
+
     -  Google Java Style
        https://google-styleguide.googlecode.com/svn-history/r130/trunk/javaguide.html
-       
+
     Checkstyle is very configurable. Be sure to read the documentation at
     http://checkstyle.sf.net (or in your downloaded distribution).
 
@@ -18,7 +18,7 @@
     To completely disable a check, just comment it out or delete it from the file.
 
     Copied from https://github.com/checkstyle/checkstyle/blob/master/google_checks.xml
-    
+
  -->
 
 <module name = "Checker">
@@ -192,6 +192,8 @@
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="CustomImportOrder">
+      <!-- The default of .*java.* matches many packages which are not standard -->
+      <property name="standardPackageRegExp" value="^(java|javax)\..*"/>
       <property name="thirdPartyPackageRegExp" value="^com\..*|^org\..*|^io\..*"/>
       <property name="specialImportsRegExp" value="tachyon"/>
       <property name="sortImportsInGroupAlphabetically" value="false"/>

--- a/build/checkstyle/tachyon_checks.xml
+++ b/build/checkstyle/tachyon_checks.xml
@@ -192,7 +192,9 @@
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="CustomImportOrder">
-      <!-- The default of .*java.* matches many packages which are not standard -->
+      <!-- The default of java|javax matches many packages which are not standard -->
+      <!-- TODO(andrew): checkstyle 2.17 fixes this but requires java 7, so we can
+           upgrade checkstyle and remove this line when we go to java 7. -->
       <property name="standardPackageRegExp" value="^(java|javax)\..*"/>
       <property name="thirdPartyPackageRegExp" value="^com\..*|^org\..*|^io\..*"/>
       <property name="specialImportsRegExp" value="tachyon"/>

--- a/clients/unshaded/src/main/java/tachyon/client/block/LocalBlockOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/block/LocalBlockOutStream.java
@@ -69,9 +69,9 @@ public final class LocalBlockOutStream extends BufferedBlockOutStream {
       // Change the permission of the temporary file in order that the worker can move it.
       FileUtils.changeLocalFileToFullPermission(blockPath);
       LOG.info("LocalBlockOutStream created new file block, block path: {}", blockPath);
-    } catch (IOException ioe) {
+    } catch (IOException e) {
       mContext.releaseWorkerClient(mBlockWorkerClient);
-      throw ioe;
+      throw e;
     }
   }
 

--- a/clients/unshaded/src/main/java/tachyon/client/file/FileInStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/FileInStream.java
@@ -128,8 +128,8 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
     if (mShouldCacheCurrentBlock) {
       try {
         mCurrentCacheStream.write(data);
-      } catch (IOException ioe) {
-        LOG.warn(BLOCK_ID_NOT_CACHED, getCurrentBlockId(), ioe);
+      } catch (IOException e) {
+        LOG.warn(BLOCK_ID_NOT_CACHED, getCurrentBlockId(), e);
         mShouldCacheCurrentBlock = false;
       }
     }
@@ -164,8 +164,8 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
       if (bytesRead > 0 && mShouldCacheCurrentBlock) {
         try {
           mCurrentCacheStream.write(b, currentOffset, bytesRead);
-        } catch (IOException ioe) {
-          LOG.warn(BLOCK_ID_NOT_CACHED, getCurrentBlockId(), ioe);
+        } catch (IOException e) {
+          LOG.warn(BLOCK_ID_NOT_CACHED, getCurrentBlockId(), e);
           mShouldCacheCurrentBlock = false;
         }
       }
@@ -239,8 +239,8 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
               mContext.getTachyonBlockStore().getWorkerInfoList(), blockSize);
           mCurrentCacheStream =
               mContext.getTachyonBlockStore().getOutStream(currentBlockId, blockSize, address);
-        } catch (IOException ioe) {
-          LOG.warn(BLOCK_ID_NOT_CACHED, currentBlockId, ioe);
+        } catch (IOException e) {
+          LOG.warn(BLOCK_ID_NOT_CACHED, currentBlockId, e);
           mShouldCacheCurrentBlock = false;
         } catch (TachyonException e) {
           LOG.warn(BLOCK_ID_NOT_CACHED, currentBlockId, e);
@@ -312,8 +312,8 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
               mContext.getTachyonBlockStore().getWorkerInfoList(), blockSize);
           mCurrentCacheStream =
               mContext.getTachyonBlockStore().getOutStream(currentBlockId, blockSize, address);
-        } catch (IOException ioe) {
-          LOG.warn(BLOCK_ID_NOT_CACHED, getCurrentBlockId(), ioe);
+        } catch (IOException e) {
+          LOG.warn(BLOCK_ID_NOT_CACHED, getCurrentBlockId(), e);
           mShouldCacheCurrentBlock = false;
         } catch (TachyonException e) {
           LOG.warn(BLOCK_ID_NOT_CACHED, currentBlockId, e);
@@ -341,21 +341,21 @@ public class FileInStream extends InputStream implements BoundedStream, Seekable
       if (mTachyonStorageType.isPromote()) {
         try {
           mContext.getTachyonBlockStore().promote(blockId);
-        } catch (IOException ioe) {
+        } catch (IOException e) {
           // Failed to promote
-          LOG.warn("Promotion of block with ID {} failed.", blockId);
+          LOG.warn("Promotion of block with ID {} failed.", blockId, e);
         }
       }
       mCurrentBlockInStream = mContext.getTachyonBlockStore().getInStream(blockId);
       mShouldCacheCurrentBlock =
           !(mCurrentBlockInStream instanceof LocalBlockInStream) && mTachyonStorageType.isStore();
-    } catch (IOException ioe) {
+    } catch (IOException e) {
       LOG.debug("Failed to get BlockInStream for block with ID {}, using UFS instead. {}",
-          blockId, ioe);
+          blockId, e);
       if (!mFileInfo.isPersisted) {
         LOG.error("Could not obtain data for block with ID {} from Tachyon."
             + " The block will not be persisted in the under file storage.", blockId);
-        throw ioe;
+        throw e;
       }
       long blockStart = BlockId.getSequenceNumber(blockId) * mBlockSize;
       mCurrentBlockInStream =

--- a/clients/unshaded/src/main/java/tachyon/client/file/FileOutStream.java
+++ b/clients/unshaded/src/main/java/tachyon/client/file/FileOutStream.java
@@ -162,8 +162,8 @@ public class FileOutStream extends OutStreamBase {
           }
           canComplete = true;
         }
-      } catch (IOException ioe) {
-        handleCacheWriteException(ioe);
+      } catch (IOException e) {
+        handleCacheWriteException(e);
       }
     }
 
@@ -200,8 +200,8 @@ public class FileOutStream extends OutStreamBase {
           getNextBlock();
         }
         mCurrentBlockOutStream.write(b);
-      } catch (IOException ioe) {
-        handleCacheWriteException(ioe);
+      } catch (IOException e) {
+        handleCacheWriteException(e);
       }
     }
 
@@ -242,8 +242,8 @@ public class FileOutStream extends OutStreamBase {
             tLen -= currentBlockLeftBytes;
           }
         }
-      } catch (IOException ioe) {
-        handleCacheWriteException(ioe);
+      } catch (IOException e) {
+        handleCacheWriteException(e);
       }
     }
 
@@ -285,12 +285,12 @@ public class FileOutStream extends OutStreamBase {
     }
   }
 
-  protected void handleCacheWriteException(IOException ioe) throws IOException {
+  protected void handleCacheWriteException(IOException e) throws IOException {
     if (!mUnderStorageType.isSyncPersist()) {
-      throw new IOException(ExceptionMessage.FAILED_CACHE.getMessage(ioe.getMessage()), ioe);
+      throw new IOException(ExceptionMessage.FAILED_CACHE.getMessage(e.getMessage()), e);
     }
 
-    LOG.warn("Failed to write into TachyonStore, canceling write attempt.", ioe);
+    LOG.warn("Failed to write into TachyonStore, canceling write attempt.", e);
     if (mCurrentBlockOutStream != null) {
       mShouldCacheCurrentBlock = false;
       mCurrentBlockOutStream.cancel();

--- a/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/clients/unshaded/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -39,9 +39,9 @@ import tachyon.Constants;
 import tachyon.TachyonURI;
 import tachyon.client.ClientContext;
 import tachyon.client.file.FileOutStream;
+import tachyon.client.file.FileSystem;
 import tachyon.client.file.FileSystemContext;
 import tachyon.client.file.FileSystemMasterClient;
-import tachyon.client.file.FileSystem;
 import tachyon.client.file.URIStatus;
 import tachyon.client.file.options.CreateDirectoryOptions;
 import tachyon.client.file.options.CreateFileOptions;
@@ -571,8 +571,8 @@ abstract class AbstractTFS extends org.apache.hadoop.fs.FileSystem {
   private void ensureExists(TachyonURI path) throws IOException {
     try {
       mTFS.getStatus(path);
-    } catch (TachyonException te) {
-      throw new IOException(te);
+    } catch (TachyonException e) {
+      throw new IOException(e);
     }
   }
 

--- a/common/src/main/java/tachyon/network/protocol/databuffer/DataFileChannel.java
+++ b/common/src/main/java/tachyon/network/protocol/databuffer/DataFileChannel.java
@@ -63,7 +63,7 @@ public final class DataFileChannel implements DataBuffer {
       while (bytesRemaining > 0 && (bytesRead = mFileChannel.read(buffer)) >= 0) {
         bytesRemaining -= bytesRead;
       }
-    } catch (IOException ioe) {
+    } catch (IOException e) {
       return null;
     }
     ByteBuffer readOnly = buffer.asReadOnlyBuffer();

--- a/common/src/main/java/tachyon/resource/ResourcePool.java
+++ b/common/src/main/java/tachyon/resource/ResourcePool.java
@@ -94,8 +94,8 @@ public abstract class ResourcePool<T> {
       } finally {
         mTakeLock.unlock();
       }
-    } catch (InterruptedException ie) {
-      throw new RuntimeException(ie);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/common/src/main/java/tachyon/security/authentication/CustomAuthenticationProviderImpl.java
+++ b/common/src/main/java/tachyon/security/authentication/CustomAuthenticationProviderImpl.java
@@ -40,7 +40,7 @@ public class CustomAuthenticationProviderImpl implements AuthenticationProvider 
     Class<?> customProviderClass;
     try {
       customProviderClass = Class.forName(providerName);
-    } catch (ClassNotFoundException cfe) {
+    } catch (ClassNotFoundException e) {
       throw new RuntimeException(providerName + " not found");
     }
 

--- a/common/src/main/java/tachyon/security/authorization/FileSystemPermission.java
+++ b/common/src/main/java/tachyon/security/authorization/FileSystemPermission.java
@@ -220,7 +220,7 @@ public final class FileSystemPermission {
     try {
       Integer.parseInt(value);
       return true;
-    } catch (NumberFormatException nfe) {
+    } catch (NumberFormatException e) {
       return false;
     }
   }

--- a/common/src/main/java/tachyon/security/login/AppLoginModule.java
+++ b/common/src/main/java/tachyon/security/login/AppLoginModule.java
@@ -61,10 +61,10 @@ public final class AppLoginModule implements LoginModule {
     callbacks[0] = new NameCallback("user name: ");
     try {
       mCallbackHandler.handle(callbacks);
-    } catch (IOException ioe) {
-      throw new LoginException(ioe.getMessage());
-    } catch (UnsupportedCallbackException uce) {
-      throw new LoginException(uce.getMessage());
+    } catch (IOException e) {
+      throw new LoginException(e.getMessage());
+    } catch (UnsupportedCallbackException e) {
+      throw new LoginException(e.getMessage());
     }
 
     String userName = ((NameCallback) callbacks[0]).getName();

--- a/common/src/main/java/tachyon/thrift/BlockWorkerClientService.java
+++ b/common/src/main/java/tachyon/thrift/BlockWorkerClientService.java
@@ -6,30 +6,26 @@
  */
 package tachyon.thrift;
 
-import org.apache.thrift.scheme.IScheme;
-import org.apache.thrift.scheme.SchemeFactory;
-import org.apache.thrift.scheme.StandardScheme;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
+import javax.annotation.Generated;
+
 import org.apache.thrift.EncodingUtils;
 import org.apache.thrift.TException;
 import org.apache.thrift.async.AsyncMethodCallback;
-import org.apache.thrift.server.AbstractNonblockingServer.*;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import javax.annotation.Generated;
+import org.apache.thrift.protocol.TTupleProtocol;
+import org.apache.thrift.scheme.IScheme;
+import org.apache.thrift.scheme.SchemeFactory;
+import org.apache.thrift.scheme.StandardScheme;
+import org.apache.thrift.scheme.TupleScheme;
+import org.apache.thrift.server.AbstractNonblockingServer.AsyncFrameBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,14 +37,14 @@ public class BlockWorkerClientService {
 
     /**
      * Accesses a block given the block id.
-     * 
+     *
      * @param blockId the id of the block being accessed
      */
     public void accessBlock(long blockId) throws org.apache.thrift.TException;
 
     /**
      * Asynchronously checkpoints a file: returns whether the checkpoint operation succeeded.
-     * 
+     *
      * @param fileId the id of the file being accessed
      */
     public boolean asyncCheckpoint(long fileId) throws tachyon.thrift.TachyonTException, org.apache.thrift.TException;
@@ -57,9 +53,9 @@ public class BlockWorkerClientService {
      * Used to cache a block into Tachyon space, worker will move the temporary block file from session
      * folder to data folder, and update the space usage information related. then update the block
      * information to master.
-     * 
+     *
      * @param sessionId the id of the current session
-     * 
+     *
      * @param blockId the id of the block being accessed
      */
     public void cacheBlock(long sessionId, long blockId) throws tachyon.thrift.TachyonTException, tachyon.thrift.ThriftIOException, org.apache.thrift.TException;
@@ -67,9 +63,9 @@ public class BlockWorkerClientService {
     /**
      * Used to cancel a block which is being written. worker will delete the temporary block file and
      * the location and space information related, then reclaim space allocated to the block.
-     * 
+     *
      * @param sessionId the id of the current session
-     * 
+     *
      * @param blockId the id of the block being accessed
      */
     public void cancelBlock(long sessionId, long blockId) throws tachyon.thrift.TachyonTException, tachyon.thrift.ThriftIOException, org.apache.thrift.TException;
@@ -78,9 +74,9 @@ public class BlockWorkerClientService {
      * Locks the file in Tachyon's space while the session is reading it. If lock succeeds, the path of
      * the block's file along with the internal lock id of locked block will be returned. If the block's file
      * is not found, FileDoesNotExistException will be thrown.
-     * 
+     *
      * @param blockId the id of the block being accessed
-     * 
+     *
      * @param sessionId the id of the current session
      */
     public LockBlockResult lockBlock(long blockId, long sessionId) throws tachyon.thrift.TachyonTException, org.apache.thrift.TException;
@@ -89,7 +85,7 @@ public class BlockWorkerClientService {
      * Used to promote block on under storage layer to top storage layer when there are more than one
      * storage layers in Tachyon's space. return true if the block is successfully promoted, false
      * otherwise.
-     * 
+     *
      * @param blockId the id of the block being accessed
      */
     public boolean promoteBlock(long blockId) throws tachyon.thrift.TachyonTException, tachyon.thrift.ThriftIOException, org.apache.thrift.TException;
@@ -100,11 +96,11 @@ public class BlockWorkerClientService {
      * temporary file path of the block file will be returned. if there is no enough space on Tachyon
      * storage OutOfSpaceException will be thrown, if the file is already being written by the session,
      * FileAlreadyExistsException will be thrown.
-     * 
+     *
      * @param sessionId the id of the current session
-     * 
+     *
      * @param blockId the id of the block being accessed
-     * 
+     *
      * @param initialBytes initial number of bytes requested
      */
     public String requestBlockLocation(long sessionId, long blockId, long initialBytes) throws tachyon.thrift.TachyonTException, tachyon.thrift.ThriftIOException, org.apache.thrift.TException;
@@ -113,11 +109,11 @@ public class BlockWorkerClientService {
      * Used to request space for some block file. return true if the worker successfully allocates
      * space for the block on block’s location, false if there is no enough space, if there is no
      * information of the block on worker, FileDoesNotExistException will be thrown.
-     * 
+     *
      * @param sessionId the id of the current session
-     * 
+     *
      * @param blockId the id of the block being accessed
-     * 
+     *
      * @param requestBytes the number of bytes requested
      */
     public boolean requestSpace(long sessionId, long blockId, long requestBytes) throws tachyon.thrift.TachyonTException, org.apache.thrift.TException;
@@ -125,9 +121,9 @@ public class BlockWorkerClientService {
     /**
      * Local session send heartbeat to local worker to keep its temporary folder. It also sends client
      * metrics to the worker.
-     * 
+     *
      * @param sessionId the id of the current session
-     * 
+     *
      * @param metrics the client metrics
      */
     public void sessionHeartbeat(long sessionId, List<Long> metrics) throws org.apache.thrift.TException;
@@ -136,9 +132,9 @@ public class BlockWorkerClientService {
      * Used to unlock a block after the block is accessed, if the block is to be removed, delete the
      * block file. return true if successfully unlock the block, return false if the block is not
      * found or failed to delete the block.
-     * 
+     *
      * @param blockId the id of the block being accessed
-     * 
+     *
      * @param sessionId the id of the current session
      */
     public boolean unlockBlock(long blockId, long sessionId) throws org.apache.thrift.TException;
@@ -904,8 +900,8 @@ public class BlockWorkerClientService {
           iface.cacheBlock(args.sessionId, args.blockId);
         } catch (tachyon.thrift.TachyonTException e) {
           result.e = e;
-        } catch (tachyon.thrift.ThriftIOException ioe) {
-          result.ioe = ioe;
+        } catch (tachyon.thrift.ThriftIOException e) {
+          result.ioe = e;
         }
         return result;
       }
@@ -930,8 +926,8 @@ public class BlockWorkerClientService {
           iface.cancelBlock(args.sessionId, args.blockId);
         } catch (tachyon.thrift.TachyonTException e) {
           result.e = e;
-        } catch (tachyon.thrift.ThriftIOException ioe) {
-          result.ioe = ioe;
+        } catch (tachyon.thrift.ThriftIOException e) {
+          result.ioe = e;
         }
         return result;
       }
@@ -1117,7 +1113,7 @@ public class BlockWorkerClientService {
 
       public AsyncMethodCallback<Void> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
         final org.apache.thrift.AsyncProcessFunction fcall = this;
-        return new AsyncMethodCallback<Void>() { 
+        return new AsyncMethodCallback<Void>() {
           public void onComplete(Void o) {
             accessBlock_result result = new accessBlock_result();
             try {
@@ -1167,7 +1163,7 @@ public class BlockWorkerClientService {
 
       public AsyncMethodCallback<Boolean> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
         final org.apache.thrift.AsyncProcessFunction fcall = this;
-        return new AsyncMethodCallback<Boolean>() { 
+        return new AsyncMethodCallback<Boolean>() {
           public void onComplete(Boolean o) {
             asyncCheckpoint_result result = new asyncCheckpoint_result();
             result.success = o;
@@ -1189,7 +1185,7 @@ public class BlockWorkerClientService {
                         result.setEIsSet(true);
                         msg = result;
             }
-             else 
+             else
             {
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TBase)new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
@@ -1225,7 +1221,7 @@ public class BlockWorkerClientService {
 
       public AsyncMethodCallback<Void> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
         final org.apache.thrift.AsyncProcessFunction fcall = this;
-        return new AsyncMethodCallback<Void>() { 
+        return new AsyncMethodCallback<Void>() {
           public void onComplete(Void o) {
             cacheBlock_result result = new cacheBlock_result();
             try {
@@ -1250,7 +1246,7 @@ public class BlockWorkerClientService {
                         result.setIoeIsSet(true);
                         msg = result;
             }
-             else 
+             else
             {
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TBase)new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
@@ -1286,7 +1282,7 @@ public class BlockWorkerClientService {
 
       public AsyncMethodCallback<Void> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
         final org.apache.thrift.AsyncProcessFunction fcall = this;
-        return new AsyncMethodCallback<Void>() { 
+        return new AsyncMethodCallback<Void>() {
           public void onComplete(Void o) {
             cancelBlock_result result = new cancelBlock_result();
             try {
@@ -1311,7 +1307,7 @@ public class BlockWorkerClientService {
                         result.setIoeIsSet(true);
                         msg = result;
             }
-             else 
+             else
             {
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TBase)new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
@@ -1347,7 +1343,7 @@ public class BlockWorkerClientService {
 
       public AsyncMethodCallback<LockBlockResult> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
         final org.apache.thrift.AsyncProcessFunction fcall = this;
-        return new AsyncMethodCallback<LockBlockResult>() { 
+        return new AsyncMethodCallback<LockBlockResult>() {
           public void onComplete(LockBlockResult o) {
             lockBlock_result result = new lockBlock_result();
             result.success = o;
@@ -1368,7 +1364,7 @@ public class BlockWorkerClientService {
                         result.setEIsSet(true);
                         msg = result;
             }
-             else 
+             else
             {
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TBase)new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
@@ -1404,7 +1400,7 @@ public class BlockWorkerClientService {
 
       public AsyncMethodCallback<Boolean> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
         final org.apache.thrift.AsyncProcessFunction fcall = this;
-        return new AsyncMethodCallback<Boolean>() { 
+        return new AsyncMethodCallback<Boolean>() {
           public void onComplete(Boolean o) {
             promoteBlock_result result = new promoteBlock_result();
             result.success = o;
@@ -1431,7 +1427,7 @@ public class BlockWorkerClientService {
                         result.setIoeIsSet(true);
                         msg = result;
             }
-             else 
+             else
             {
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TBase)new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
@@ -1467,7 +1463,7 @@ public class BlockWorkerClientService {
 
       public AsyncMethodCallback<String> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
         final org.apache.thrift.AsyncProcessFunction fcall = this;
-        return new AsyncMethodCallback<String>() { 
+        return new AsyncMethodCallback<String>() {
           public void onComplete(String o) {
             requestBlockLocation_result result = new requestBlockLocation_result();
             result.success = o;
@@ -1493,7 +1489,7 @@ public class BlockWorkerClientService {
                         result.setIoeIsSet(true);
                         msg = result;
             }
-             else 
+             else
             {
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TBase)new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
@@ -1529,7 +1525,7 @@ public class BlockWorkerClientService {
 
       public AsyncMethodCallback<Boolean> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
         final org.apache.thrift.AsyncProcessFunction fcall = this;
-        return new AsyncMethodCallback<Boolean>() { 
+        return new AsyncMethodCallback<Boolean>() {
           public void onComplete(Boolean o) {
             requestSpace_result result = new requestSpace_result();
             result.success = o;
@@ -1551,7 +1547,7 @@ public class BlockWorkerClientService {
                         result.setEIsSet(true);
                         msg = result;
             }
-             else 
+             else
             {
               msgType = org.apache.thrift.protocol.TMessageType.EXCEPTION;
               msg = (org.apache.thrift.TBase)new org.apache.thrift.TApplicationException(org.apache.thrift.TApplicationException.INTERNAL_ERROR, e.getMessage());
@@ -1587,7 +1583,7 @@ public class BlockWorkerClientService {
 
       public AsyncMethodCallback<Void> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
         final org.apache.thrift.AsyncProcessFunction fcall = this;
-        return new AsyncMethodCallback<Void>() { 
+        return new AsyncMethodCallback<Void>() {
           public void onComplete(Void o) {
             sessionHeartbeat_result result = new sessionHeartbeat_result();
             try {
@@ -1637,7 +1633,7 @@ public class BlockWorkerClientService {
 
       public AsyncMethodCallback<Boolean> getResultHandler(final AsyncFrameBuffer fb, final int seqid) {
         final org.apache.thrift.AsyncProcessFunction fcall = this;
-        return new AsyncMethodCallback<Boolean>() { 
+        return new AsyncMethodCallback<Boolean>() {
           public void onComplete(Boolean o) {
             unlockBlock_result result = new unlockBlock_result();
             result.success = o;
@@ -1763,7 +1759,7 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(accessBlock_args.class, metaDataMap);
@@ -1981,7 +1977,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -1989,7 +1985,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.blockId = iprot.readI64();
                 struct.setBlockIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -2253,7 +2249,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -2382,7 +2378,7 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.FILE_ID, new org.apache.thrift.meta_data.FieldMetaData("fileId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.FILE_ID, new org.apache.thrift.meta_data.FieldMetaData("fileId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(asyncCheckpoint_args.class, metaDataMap);
@@ -2600,7 +2596,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -2608,7 +2604,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.fileId = iprot.readI64();
                 struct.setFileIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -2752,9 +2748,9 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
-      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(asyncCheckpoint_result.class, metaDataMap);
@@ -3041,7 +3037,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -3049,7 +3045,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
                 struct.success = iprot.readBool();
                 struct.setSuccessIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -3058,7 +3054,7 @@ public class BlockWorkerClientService {
                 struct.e = new tachyon.thrift.TachyonTException();
                 struct.e.read(iprot);
                 struct.setEIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -3233,9 +3229,9 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
-      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(cacheBlock_args.class, metaDataMap);
@@ -3529,7 +3525,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -3537,7 +3533,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.sessionId = iprot.readI64();
                 struct.setSessionIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -3545,7 +3541,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.blockId = iprot.readI64();
                 struct.setBlockIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -3700,9 +3696,9 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
-      tmpMap.put(_Fields.IOE, new org.apache.thrift.meta_data.FieldMetaData("ioe", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.IOE, new org.apache.thrift.meta_data.FieldMetaData("ioe", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(cacheBlock_result.class, metaDataMap);
@@ -3991,7 +3987,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -4000,7 +3996,7 @@ public class BlockWorkerClientService {
                 struct.e = new tachyon.thrift.TachyonTException();
                 struct.e.read(iprot);
                 struct.setEIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -4009,7 +4005,7 @@ public class BlockWorkerClientService {
                 struct.ioe = new tachyon.thrift.ThriftIOException();
                 struct.ioe.read(iprot);
                 struct.setIoeIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -4185,9 +4181,9 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
-      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(cancelBlock_args.class, metaDataMap);
@@ -4481,7 +4477,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -4489,7 +4485,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.sessionId = iprot.readI64();
                 struct.setSessionIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -4497,7 +4493,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.blockId = iprot.readI64();
                 struct.setBlockIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -4652,9 +4648,9 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
-      tmpMap.put(_Fields.IOE, new org.apache.thrift.meta_data.FieldMetaData("ioe", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.IOE, new org.apache.thrift.meta_data.FieldMetaData("ioe", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(cancelBlock_result.class, metaDataMap);
@@ -4943,7 +4939,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -4952,7 +4948,7 @@ public class BlockWorkerClientService {
                 struct.e = new tachyon.thrift.TachyonTException();
                 struct.e.read(iprot);
                 struct.setEIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -4961,7 +4957,7 @@ public class BlockWorkerClientService {
                 struct.ioe = new tachyon.thrift.ThriftIOException();
                 struct.ioe.read(iprot);
                 struct.setIoeIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -5137,9 +5133,9 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
-      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(lockBlock_args.class, metaDataMap);
@@ -5433,7 +5429,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -5441,7 +5437,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.blockId = iprot.readI64();
                 struct.setBlockIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -5449,7 +5445,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.sessionId = iprot.readI64();
                 struct.setSessionIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -5604,9 +5600,9 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, LockBlockResult.class)));
-      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(lockBlock_result.class, metaDataMap);
@@ -5898,7 +5894,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -5907,7 +5903,7 @@ public class BlockWorkerClientService {
                 struct.success = new LockBlockResult();
                 struct.success.read(iprot);
                 struct.setSuccessIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -5916,7 +5912,7 @@ public class BlockWorkerClientService {
                 struct.e = new tachyon.thrift.TachyonTException();
                 struct.e.read(iprot);
                 struct.setEIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -6080,7 +6076,7 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(promoteBlock_args.class, metaDataMap);
@@ -6298,7 +6294,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -6306,7 +6302,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.blockId = iprot.readI64();
                 struct.setBlockIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -6455,11 +6451,11 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
-      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
-      tmpMap.put(_Fields.IOE, new org.apache.thrift.meta_data.FieldMetaData("ioe", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.IOE, new org.apache.thrift.meta_data.FieldMetaData("ioe", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(promoteBlock_result.class, metaDataMap);
@@ -6821,7 +6817,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -6829,7 +6825,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
                 struct.success = iprot.readBool();
                 struct.setSuccessIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -6838,7 +6834,7 @@ public class BlockWorkerClientService {
                 struct.e = new tachyon.thrift.TachyonTException();
                 struct.e.read(iprot);
                 struct.setEIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -6847,7 +6843,7 @@ public class BlockWorkerClientService {
                 struct.ioe = new tachyon.thrift.ThriftIOException();
                 struct.ioe.read(iprot);
                 struct.setIoeIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -7050,11 +7046,11 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
-      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
-      tmpMap.put(_Fields.INITIAL_BYTES, new org.apache.thrift.meta_data.FieldMetaData("initialBytes", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.INITIAL_BYTES, new org.apache.thrift.meta_data.FieldMetaData("initialBytes", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(requestBlockLocation_args.class, metaDataMap);
@@ -7424,7 +7420,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -7432,7 +7428,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.sessionId = iprot.readI64();
                 struct.setSessionIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -7440,7 +7436,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.blockId = iprot.readI64();
                 struct.setBlockIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -7448,7 +7444,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.initialBytes = iprot.readI64();
                 struct.setInitialBytesIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -7621,11 +7617,11 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
-      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
-      tmpMap.put(_Fields.IOE, new org.apache.thrift.meta_data.FieldMetaData("ioe", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.IOE, new org.apache.thrift.meta_data.FieldMetaData("ioe", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(requestBlockLocation_result.class, metaDataMap);
@@ -7989,7 +7985,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -7997,7 +7993,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
                 struct.success = iprot.readString();
                 struct.setSuccessIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -8006,7 +8002,7 @@ public class BlockWorkerClientService {
                 struct.e = new tachyon.thrift.TachyonTException();
                 struct.e.read(iprot);
                 struct.setEIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -8015,7 +8011,7 @@ public class BlockWorkerClientService {
                 struct.ioe = new tachyon.thrift.ThriftIOException();
                 struct.ioe.read(iprot);
                 struct.setIoeIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -8218,11 +8214,11 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
-      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
-      tmpMap.put(_Fields.REQUEST_BYTES, new org.apache.thrift.meta_data.FieldMetaData("requestBytes", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.REQUEST_BYTES, new org.apache.thrift.meta_data.FieldMetaData("requestBytes", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(requestSpace_args.class, metaDataMap);
@@ -8592,7 +8588,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -8600,7 +8596,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.sessionId = iprot.readI64();
                 struct.setSessionIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -8608,7 +8604,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.blockId = iprot.readI64();
                 struct.setBlockIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -8616,7 +8612,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.requestBytes = iprot.readI64();
                 struct.setRequestBytesIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -8786,9 +8782,9 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
-      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.E, new org.apache.thrift.meta_data.FieldMetaData("e", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(requestSpace_result.class, metaDataMap);
@@ -9075,7 +9071,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -9083,7 +9079,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
                 struct.success = iprot.readBool();
                 struct.setSuccessIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -9092,7 +9088,7 @@ public class BlockWorkerClientService {
                 struct.e = new tachyon.thrift.TachyonTException();
                 struct.e.read(iprot);
                 struct.setEIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -9266,10 +9262,10 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
-      tmpMap.put(_Fields.METRICS, new org.apache.thrift.meta_data.FieldMetaData("metrics", org.apache.thrift.TFieldRequirementType.DEFAULT, 
-          new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST, 
+      tmpMap.put(_Fields.METRICS, new org.apache.thrift.meta_data.FieldMetaData("metrics", org.apache.thrift.TFieldRequirementType.DEFAULT,
+          new org.apache.thrift.meta_data.ListMetaData(org.apache.thrift.protocol.TType.LIST,
               new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64))));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(sessionHeartbeat_args.class, metaDataMap);
@@ -9584,7 +9580,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -9592,7 +9588,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.sessionId = iprot.readI64();
                 struct.setSessionIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -9610,7 +9606,7 @@ public class BlockWorkerClientService {
                   iprot.readListEnd();
                 }
                 struct.setMetricsIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -9911,7 +9907,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -10052,9 +10048,9 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.BLOCK_ID, new org.apache.thrift.meta_data.FieldMetaData("blockId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
-      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SESSION_ID, new org.apache.thrift.meta_data.FieldMetaData("sessionId", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(unlockBlock_args.class, metaDataMap);
@@ -10348,7 +10344,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -10356,7 +10352,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.blockId = iprot.readI64();
                 struct.setBlockIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -10364,7 +10360,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
                 struct.sessionId = iprot.readI64();
                 struct.setSessionIdIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;
@@ -10516,7 +10512,7 @@ public class BlockWorkerClientService {
     public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
     static {
       Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
-      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT, 
+      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift.meta_data.FieldMetaData("success", org.apache.thrift.TFieldRequirementType.DEFAULT,
           new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(unlockBlock_result.class, metaDataMap);
@@ -10728,7 +10724,7 @@ public class BlockWorkerClientService {
         while (true)
         {
           schemeField = iprot.readFieldBegin();
-          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) { 
+          if (schemeField.type == org.apache.thrift.protocol.TType.STOP) {
             break;
           }
           switch (schemeField.id) {
@@ -10736,7 +10732,7 @@ public class BlockWorkerClientService {
               if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
                 struct.success = iprot.readBool();
                 struct.setSuccessIsSet(true);
-              } else { 
+              } else {
                 org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
               }
               break;

--- a/common/src/main/java/tachyon/util/ShellUtils.java
+++ b/common/src/main/java/tachyon/util/ShellUtils.java
@@ -105,8 +105,8 @@ public final class ShellUtils {
       if (mExitCode != 0) {
         throw new ExitCodeException(mExitCode, errMsg.toString());
       }
-    } catch (InterruptedException ie) {
-      throw new IOException(ie.toString());
+    } catch (InterruptedException e) {
+      throw new IOException(e);
     } finally {
       // close the input stream
       try {
@@ -121,8 +121,8 @@ public final class ShellUtils {
         synchronized (stdout) {
           inReader.close();
         }
-      } catch (IOException ioe) {
-        LOG.warn("Error while closing the input stream", ioe);
+      } catch (IOException e) {
+        LOG.warn("Error while closing the input stream", e);
       }
       mProcess.destroy();
     }

--- a/common/src/main/java/tachyon/util/io/FileUtils.java
+++ b/common/src/main/java/tachyon/util/io/FileUtils.java
@@ -18,9 +18,10 @@ package tachyon.util.io;
 import java.io.File;
 import java.io.IOException;
 
-import com.google.common.io.Files;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.io.Files;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
@@ -79,7 +80,7 @@ public final class FileUtils {
         Runtime.getRuntime().exec("chmod +t " + dir);
       }
     } catch (IOException e) {
-      LOG.info("Can not set the sticky bit of the directory: {}", dir);
+      LOG.info("Can not set the sticky bit of the directory: {}", dir, e);
     }
   }
 
@@ -95,9 +96,10 @@ public final class FileUtils {
     try {
       createStorageDirPath(PathUtils.getParent(path));
     } catch (InvalidPathException e) {
-      throw new IOException("Failed to create block path, get parent path of " + path + "failed");
-    } catch (IOException ioe) {
-      throw new IOException("Failed to create block path " + path);
+      throw new IOException("Failed to create block path, get parent path of " + path + "failed",
+          e);
+    } catch (IOException e) {
+      throw new IOException("Failed to create block path " + path, e);
     }
   }
 

--- a/common/src/test/java/tachyon/util/io/PathUtilsTest.java
+++ b/common/src/test/java/tachyon/util/io/PathUtilsTest.java
@@ -274,7 +274,7 @@ public class PathUtilsTest {
       try {
         PathUtils.validatePath(invalidPath);
         Assert.fail("validatePath(" + invalidPath + ") did not fail");
-      } catch (InvalidPathException ipe) {
+      } catch (InvalidPathException e) {
         // this is expected
       }
     }

--- a/examples/src/main/java/tachyon/examples/JournalCrashTest.java
+++ b/examples/src/main/java/tachyon/examples/JournalCrashTest.java
@@ -248,7 +248,7 @@ public class JournalCrashTest {
       sTfs = FileSystem.Factory.get();
       try {
         sTfs.delete(new TachyonURI(sTestDir));
-      } catch (Exception ioe) {
+      } catch (Exception e) {
         // Test Directory not exist
       }
 

--- a/integration-tests/src/test/java/tachyon/client/FileSystemIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/client/FileSystemIntegrationTest.java
@@ -137,8 +137,8 @@ public class FileSystemIntegrationTest {
       try {
         mTfs.createDirectory(new TachyonURI(uniqPath + k), options);
         Assert.fail("mkdir should throw FileAlreadyExistsException");
-      } catch (FileAlreadyExistsException faee) {
-        Assert.assertEquals(faee.getMessage(),
+      } catch (FileAlreadyExistsException e) {
+        Assert.assertEquals(e.getMessage(),
             ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(uniqPath + k));
       }
     }

--- a/integration-tests/src/test/java/tachyon/master/JournalShutdownIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/JournalShutdownIntegrationTest.java
@@ -73,7 +73,7 @@ public class JournalShutdownIntegrationTest {
           if (mOpType == 0) {
             try {
               mTfs.createFile(new TachyonURI(TEST_FILE_DIR + mSuccessNum)).close();
-            } catch (IOException ioe) {
+            } catch (IOException e) {
               break;
             }
           } else if (mOpType == 1) {

--- a/integration-tests/src/test/java/tachyon/master/ServiceSocketBindIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/ServiceSocketBindIntegrationTest.java
@@ -215,7 +215,7 @@ public class ServiceSocketBindIntegrationTest {
     try {
       mBlockWorkerClient = BlockStoreContext.INSTANCE.acquireWorkerClient("127.0.0.1");
       Assert.fail("Client should not have successfully connected to Worker RPC service.");
-    } catch (RuntimeException rte) {
+    } catch (RuntimeException e) {
       // This is expected, since Work RPC service is NOT listening on loopback.
     }
 
@@ -226,7 +226,7 @@ public class ServiceSocketBindIntegrationTest {
       mWorkerDataService = SocketChannel.open(workerDataAddr);
       Assert.assertTrue(mWorkerDataService.isConnected());
       Assert.fail("Client should not have successfully connected to Worker RPC service.");
-    } catch (IOException ie) {
+    } catch (IOException e) {
       // This is expected, since Worker data service is NOT listening on loopback.
     }
 
@@ -237,7 +237,7 @@ public class ServiceSocketBindIntegrationTest {
           .openConnection();
       Assert.assertEquals(200, mMasterWebService.getResponseCode());
       Assert.fail("Client should not have successfully connected to Master Web service.");
-    } catch (IOException ie) {
+    } catch (IOException e) {
       // This is expected, since Master Web service is NOT listening on loopback.
     } finally {
       Assert.assertNotNull(mMasterWebService);
@@ -251,7 +251,7 @@ public class ServiceSocketBindIntegrationTest {
               .openConnection();
       Assert.assertEquals(200, mWorkerWebService.getResponseCode());
       Assert.fail("Client should not have successfully connected to Worker Web service.");
-    } catch (IOException ie) {
+    } catch (IOException e) {
       // This is expected, since Worker Web service is NOT listening on loopback.
     } finally {
       mWorkerWebService.disconnect();

--- a/integration-tests/src/test/java/tachyon/network/protocol/MessageSavingHandler.java
+++ b/integration-tests/src/test/java/tachyon/network/protocol/MessageSavingHandler.java
@@ -48,8 +48,8 @@ public class MessageSavingHandler extends SimpleChannelInboundHandler<RPCMessage
       if (!mMessageAvailable.tryAcquire(1, 1, TimeUnit.SECONDS)) {
         Assert.fail("Timed out receiving message.");
       }
-    } catch (InterruptedException ie) {
-      Assert.fail("Failed with exception: " + ie.getMessage());
+    } catch (InterruptedException e) {
+      Assert.fail("Failed with exception: " + e.getMessage());
     }
     return mMessage;
   }

--- a/integration-tests/src/test/java/tachyon/underfs/UnderStorageSystemInterfaceIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/underfs/UnderStorageSystemInterfaceIntegrationTest.java
@@ -110,7 +110,7 @@ public class UnderStorageSystemInterfaceIntegrationTest {
     Assert.assertFalse(mUfs.exists(testDirEmpty));
     try {
       mUfs.delete(testDirNonEmpty, false);
-    } catch (IOException ioe) {
+    } catch (IOException e) {
       // Some File systems may throw IOException
     }
     Assert.assertTrue(mUfs.exists(testDirNonEmpty));

--- a/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueInputFormat.java
+++ b/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueInputFormat.java
@@ -71,8 +71,8 @@ public final class KeyValueInputFormat implements InputFormat {
           splits.add(new KeyValueInputSplit(partitionInfo));
         }
       }
-    } catch (TachyonException te) {
-      throw new IOException(te);
+    } catch (TachyonException e) {
+      throw new IOException(e);
     }
     InputSplit[] ret = new InputSplit[splits.size()];
     return splits.toArray(ret);
@@ -84,8 +84,8 @@ public final class KeyValueInputFormat implements InputFormat {
     if (inputSplit instanceof KeyValueInputSplit) {
       try {
         return new KeyValueRecordReader((KeyValueInputSplit) inputSplit);
-      } catch (TachyonException te) {
-        throw new IOException(te);
+      } catch (TachyonException e) {
+        throw new IOException(e);
       }
     } else {
       throw new IOException("Expected InputSplit to be instance of KeyValueInputSplit.");

--- a/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueInputSplit.java
+++ b/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueInputSplit.java
@@ -63,8 +63,8 @@ final class KeyValueInputSplit implements InputSplit {
         locations[i] = workersInfo.get(i).getNetAddress().getHost();
       }
       return locations;
-    } catch (TachyonException te) {
-      throw new IOException(te);
+    } catch (TachyonException e) {
+      throw new IOException(e);
     }
   }
 

--- a/servers/src/main/java/tachyon/master/MasterBase.java
+++ b/servers/src/main/java/tachyon/master/MasterBase.java
@@ -207,8 +207,8 @@ public abstract class MasterBase implements Master {
     Preconditions.checkNotNull(mJournalWriter, "Cannot write entry: journal writer is null.");
     try {
       mJournalWriter.getEntryOutputStream().writeEntry(entry);
-    } catch (IOException ioe) {
-      throw new RuntimeException(ioe);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 
@@ -219,8 +219,8 @@ public abstract class MasterBase implements Master {
     Preconditions.checkNotNull(mJournalWriter, "Cannot flush journal: journal writer is null.");
     try {
       mJournalWriter.getEntryOutputStream().flush();
-    } catch (IOException ioe) {
-      throw new RuntimeException(ioe);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/servers/src/main/java/tachyon/master/TachyonMaster.java
+++ b/servers/src/main/java/tachyon/master/TachyonMaster.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 
-import com.google.common.collect.Lists;
 import org.apache.thrift.TMultiplexedProcessor;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -35,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
@@ -392,8 +392,8 @@ public class TachyonMaster {
     TTransportFactory transportFactory;
     try {
       transportFactory = AuthenticationUtils.getServerTransportFactory(MasterContext.getConf());
-    } catch (IOException ioe) {
-      throw Throwables.propagate(ioe);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
     }
 
     // create master thrift service with the multiplexed processor.

--- a/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
+++ b/servers/src/main/java/tachyon/master/file/FileSystemMaster.java
@@ -72,9 +72,9 @@ import tachyon.master.file.meta.TtlBucket;
 import tachyon.master.file.meta.TtlBucketList;
 import tachyon.master.file.meta.options.CreatePathOptions;
 import tachyon.master.file.options.CompleteFileOptions;
-import tachyon.master.file.options.SetAclOptions;
-import tachyon.master.file.options.CreateFileOptions;
 import tachyon.master.file.options.CreateDirectoryOptions;
+import tachyon.master.file.options.CreateFileOptions;
+import tachyon.master.file.options.SetAclOptions;
 import tachyon.master.journal.Journal;
 import tachyon.master.journal.JournalOutputStream;
 import tachyon.master.journal.JournalProtoUtils;
@@ -348,7 +348,7 @@ public final class FileSystemMaster extends MasterBase {
       Inode inode;
       try {
         inode = mInodeTree.getInodeById(id);
-      } catch (FileDoesNotExistException fne) {
+      } catch (FileDoesNotExistException e) {
         return false;
       }
       return inode.isDirectory();
@@ -566,8 +566,8 @@ public final class FileSystemMaster extends MasterBase {
     try {
       completeFileInternal(entry.getBlockIdsList(), entry.getId(), entry.getLength(),
           entry.getOpTimeMs());
-    } catch (FileDoesNotExistException fdnee) {
-      throw new RuntimeException(fdnee);
+    } catch (FileDoesNotExistException e) {
+      throw new RuntimeException(e);
     }
   }
 
@@ -927,7 +927,7 @@ public final class FileSystemMaster extends MasterBase {
               resolvedHost = ipport[0];
               resolvedPort = Integer.parseInt(ipport[1]);
             }
-          } catch (NumberFormatException nfe) {
+          } catch (NumberFormatException e) {
             continue;
           }
           // The resolved port is the data transfer port not the rpc port
@@ -1054,10 +1054,10 @@ public final class FileSystemMaster extends MasterBase {
         LOG.debug("flushed journal for mkdir {}", path);
         MasterContext.getMasterSource().incDirectoriesCreated(1);
         return createResult;
-      } catch (BlockInfoException bie) {
+      } catch (BlockInfoException e) {
         // Since we are creating a directory, the block size is ignored, no such exception should
         // happen.
-        Throwables.propagate(bie);
+        Throwables.propagate(e);
       }
     }
     return null;

--- a/servers/src/main/java/tachyon/master/journal/JournalTailer.java
+++ b/servers/src/main/java/tachyon/master/journal/JournalTailer.java
@@ -68,7 +68,7 @@ public final class JournalTailer {
     try {
       mReader.getCheckpointLastModifiedTimeMs();
       return true;
-    } catch (IOException ioe) {
+    } catch (IOException e) {
       return false;
     }
   }

--- a/servers/src/main/java/tachyon/master/journal/JournalTailerThread.java
+++ b/servers/src/main/java/tachyon/master/journal/JournalTailerThread.java
@@ -80,9 +80,8 @@ public final class JournalTailerThread extends Thread {
     try {
       // Wait for the thread to finish.
       join();
-    } catch (InterruptedException ie) {
-      LOG.warn("{}: stopping the journal tailer caused exception: {}", mMaster.getName(),
-          ie.getMessage());
+    } catch (InterruptedException e) {
+      LOG.warn("{}: stopping the journal tailer caused an exception", mMaster.getName(), e);
     }
   }
 
@@ -150,9 +149,9 @@ public final class JournalTailerThread extends Thread {
         LOG.info("{}: The checkpoint is out of date. Will reload the checkpoint file.",
             mMaster.getName());
         CommonUtils.sleepMs(LOG, mJournalTailerSleepTimeMs);
-      } catch (IOException ioe) {
+      } catch (IOException e) {
         // Log the error and continue the loop.
-        LOG.error(ioe.getMessage());
+        LOG.error("Error in journal tailer thread", e);
       }
     }
     LOG.info("{}: Journal tailer has been shutdown.", mMaster.getName());

--- a/servers/src/main/java/tachyon/web/WebInterfaceBrowseLogsServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceBrowseLogsServlet.java
@@ -150,18 +150,18 @@ public final class WebInterfaceBrowseLogsServlet extends HttpServlet {
         int limit = Integer.parseInt(request.getParameter("limit"));
         List<UIFileInfo> sub = fileInfos.subList(offset, offset + limit);
         request.setAttribute("fileInfos", sub);
-      } catch (NumberFormatException nfe) {
+      } catch (NumberFormatException e) {
         request.setAttribute("fatalError",
-                "Error: offset or limit parse error, " + nfe.getLocalizedMessage());
+                "Error: offset or limit parse error, " + e.getLocalizedMessage());
         getServletContext().getRequestDispatcher(mBrowseJsp).forward(request, response);
         return;
-      } catch (IndexOutOfBoundsException iobe) {
+      } catch (IndexOutOfBoundsException e) {
         request.setAttribute("fatalError",
-                "Error: offset or offset + limit is out of bound, " + iobe.getLocalizedMessage());
+                "Error: offset or offset + limit is out of bound, " + e.getLocalizedMessage());
         getServletContext().getRequestDispatcher(mBrowseJsp).forward(request, response);
         return;
-      } catch (IllegalArgumentException iae) {
-        request.setAttribute("fatalError", iae.getLocalizedMessage());
+      } catch (IllegalArgumentException e) {
+        request.setAttribute("fatalError", e.getLocalizedMessage());
         getServletContext().getRequestDispatcher(mBrowseJsp).forward(request, response);
         return;
       }
@@ -185,7 +185,7 @@ public final class WebInterfaceBrowseLogsServlet extends HttpServlet {
           if (offsetParam != null) {
             relativeOffset = Long.parseLong(offsetParam);
           }
-        } catch (NumberFormatException nfe) {
+        } catch (NumberFormatException e) {
           relativeOffset = 0;
         }
         String endParam = request.getParameter("end");
@@ -205,9 +205,9 @@ public final class WebInterfaceBrowseLogsServlet extends HttpServlet {
         displayLocalFile(logFile, request, offset);
         request.setAttribute("viewingOffset", offset);
         getServletContext().getRequestDispatcher(mViewJsp).forward(request, response);
-      } catch (IOException ie) {
+      } catch (IOException e) {
         request.setAttribute("invalidPathError", "Error: File " + logFile + " is not available "
-                + ie.getMessage());
+                + e.getMessage());
         getServletContext().getRequestDispatcher(mViewJsp).forward(request, response);
       }
     }

--- a/servers/src/main/java/tachyon/web/WebInterfaceBrowseServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceBrowseServlet.java
@@ -170,7 +170,7 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
           if (offsetParam != null) {
             relativeOffset = Long.parseLong(offsetParam);
           }
-        } catch (NumberFormatException nfe) {
+        } catch (NumberFormatException e) {
           relativeOffset = 0;
         }
         String endParam = request.getParameter("end");
@@ -189,7 +189,7 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
         try {
           displayFile(new TachyonURI(currentFileInfo.getAbsolutePath()), request, offset);
         } catch (TachyonException e) {
-          throw new IOException(e.getMessage());
+          throw new IOException(e);
         }
         request.setAttribute("viewingOffset", offset);
         getServletContext().getRequestDispatcher("/viewFile.jsp").forward(request, response);
@@ -197,22 +197,22 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
       }
       setPathDirectories(currentPath, request);
       filesInfo = mMaster.getFileSystemMaster().getFileInfoList(currentPath);
-    } catch (FileDoesNotExistException fdne) {
-      request.setAttribute("invalidPathError", "Error: Invalid Path " + fdne.getMessage());
+    } catch (FileDoesNotExistException e) {
+      request.setAttribute("invalidPathError", "Error: Invalid Path " + e.getMessage());
       getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
       return;
-    } catch (InvalidPathException ipe) {
-      request.setAttribute("invalidPathError", "Error: Invalid Path " + ipe.getLocalizedMessage());
+    } catch (InvalidPathException e) {
+      request.setAttribute("invalidPathError", "Error: Invalid Path " + e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
       return;
-    } catch (IOException ie) {
+    } catch (IOException e) {
       request.setAttribute("invalidPathError",
-          "Error: File " + currentPath + " is not available " + ie.getMessage());
+          "Error: File " + currentPath + " is not available " + e.getMessage());
       getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
       return;
-    } catch (AccessControlException ace) {
+    } catch (AccessControlException e) {
       request.setAttribute("invalidPathError",
-          "Error: File " + currentPath + " cannot be accessed " + ace.getMessage());
+          "Error: File " + currentPath + " cannot be accessed " + e.getMessage());
       getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
       return;
     }
@@ -234,14 +234,14 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
           addrs.addAll(blockInfo.getUfsLocations());
           toAdd.setFileLocations(addrs);
         }
-      } catch (FileDoesNotExistException fdne) {
+      } catch (FileDoesNotExistException e) {
         request.setAttribute("FileDoesNotExistException",
-            "Error: non-existing file " + fdne.getMessage());
+            "Error: non-existing file " + e.getMessage());
         getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
         return;
-      } catch (InvalidPathException ipe) {
+      } catch (InvalidPathException e) {
         request.setAttribute("InvalidPathException",
-            "Error: invalid path " + ipe.getMessage());
+            "Error: invalid path " + e.getMessage());
         getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
       }
       fileInfos.add(toAdd);
@@ -261,18 +261,18 @@ public final class WebInterfaceBrowseServlet extends HttpServlet {
       int limit = Integer.parseInt(request.getParameter("limit"));
       List<UIFileInfo> sub = fileInfos.subList(offset, offset + limit);
       request.setAttribute("fileInfos", sub);
-    } catch (NumberFormatException nfe) {
+    } catch (NumberFormatException e) {
       request.setAttribute("fatalError",
-          "Error: offset or limit parse error, " + nfe.getLocalizedMessage());
+          "Error: offset or limit parse error, " + e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
       return;
-    } catch (IndexOutOfBoundsException iobe) {
+    } catch (IndexOutOfBoundsException e) {
       request.setAttribute("fatalError",
-          "Error: offset or offset + limit is out of bound, " + iobe.getLocalizedMessage());
+          "Error: offset or offset + limit is out of bound, " + e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
       return;
-    } catch (IllegalArgumentException iae) {
-      request.setAttribute("fatalError", iae.getLocalizedMessage());
+    } catch (IllegalArgumentException e) {
+      request.setAttribute("fatalError", e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/browse.jsp").forward(request, response);
       return;
     }

--- a/servers/src/main/java/tachyon/web/WebInterfaceDownloadLocalServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceDownloadLocalServlet.java
@@ -72,8 +72,8 @@ public final class WebInterfaceDownloadLocalServlet extends HttpServlet {
     File logFile = new File(logsDir, requestPath);
     try {
       downloadLogFile(logFile, request, response);
-    } catch (FileNotFoundException fnfe) {
-      request.setAttribute("invalidPathError", "Error: Invalid file " + fnfe.getMessage());
+    } catch (FileNotFoundException e) {
+      request.setAttribute("invalidPathError", "Error: Invalid file " + e.getMessage());
       request.setAttribute("currentPath", requestPath);
       request.setAttribute("downloadLogFile", 1);
       request.setAttribute("viewingOffset", 0);

--- a/servers/src/main/java/tachyon/web/WebInterfaceMemoryServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceMemoryServlet.java
@@ -80,14 +80,14 @@ public final class WebInterfaceMemoryServlet extends HttpServlet {
         if (fileInfo != null && fileInfo.getInMemoryPercentage() == 100) {
           fileInfos.add(new UIFileInfo(fileInfo));
         }
-      } catch (FileDoesNotExistException fee) {
+      } catch (FileDoesNotExistException e) {
         request.setAttribute("fatalError",
-            "Error: File does not exist " + fee.getLocalizedMessage());
+            "Error: File does not exist " + e.getLocalizedMessage());
         getServletContext().getRequestDispatcher("/memory.jsp").forward(request, response);
         return;
-      } catch (AccessControlException ace) {
+      } catch (AccessControlException e) {
         request.setAttribute("permissionError",
-            "Error: File " + file + " cannot be accessed " + ace.getMessage());
+            "Error: File " + file + " cannot be accessed " + e.getMessage());
         getServletContext().getRequestDispatcher("/memory.jsp").forward(request, response);
         return;
       }
@@ -106,18 +106,18 @@ public final class WebInterfaceMemoryServlet extends HttpServlet {
       int limit = Integer.parseInt(request.getParameter("limit"));
       List<UIFileInfo> sub = fileInfos.subList(offset, offset + limit);
       request.setAttribute("fileInfos", sub);
-    } catch (NumberFormatException nfe) {
+    } catch (NumberFormatException e) {
       request.setAttribute("fatalError",
-          "Error: offset or limit parse error, " + nfe.getLocalizedMessage());
+          "Error: offset or limit parse error, " + e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/memory.jsp").forward(request, response);
       return;
-    } catch (IndexOutOfBoundsException iobe) {
+    } catch (IndexOutOfBoundsException e) {
       request.setAttribute("fatalError",
-          "Error: offset or offset + limit is out of bound, " + iobe.getLocalizedMessage());
+          "Error: offset or offset + limit is out of bound, " + e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/memory.jsp").forward(request, response);
       return;
-    } catch (IllegalArgumentException iae) {
-      request.setAttribute("fatalError", iae.getLocalizedMessage());
+    } catch (IllegalArgumentException e) {
+      request.setAttribute("fatalError", e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/memory.jsp").forward(request, response);
       return;
     }

--- a/servers/src/main/java/tachyon/web/WebInterfaceWorkerBlockInfoServlet.java
+++ b/servers/src/main/java/tachyon/web/WebInterfaceWorkerBlockInfoServlet.java
@@ -85,19 +85,19 @@ public final class WebInterfaceWorkerBlockInfoServlet extends HttpServlet {
         getServletContext().getRequestDispatcher("/worker/viewFileBlocks.jsp").forward(request,
             response);
         return;
-      } catch (FileDoesNotExistException fdne) {
-        request.setAttribute("fatalError", "Error: Invalid Path " + fdne.getMessage());
+      } catch (FileDoesNotExistException e) {
+        request.setAttribute("fatalError", "Error: Invalid Path " + e.getMessage());
         getServletContext().getRequestDispatcher("/worker/blockInfo.jsp").forward(request,
             response);
         return;
-      } catch (IOException ie) {
+      } catch (IOException e) {
         request.setAttribute("invalidPathError",
-            "Error: File " + filePath + " is not available " + ie.getMessage());
+            "Error: File " + filePath + " is not available " + e.getMessage());
         getServletContext().getRequestDispatcher("/worker/blockInfo.jsp").forward(request,
             response);
         return;
-      } catch (BlockDoesNotExistException bnfe) {
-        request.setAttribute("fatalError", "Error: block not found. " + bnfe.getMessage());
+      } catch (BlockDoesNotExistException e) {
+        request.setAttribute("fatalError", "Error: block not found. " + e.getMessage());
         getServletContext().getRequestDispatcher("/worker/blockInfo.jsp").forward(request,
             response);
         return;
@@ -130,26 +130,26 @@ public final class WebInterfaceWorkerBlockInfoServlet extends HttpServlet {
         uiFileInfos.add(getUiFileInfo(tFS, fileId));
       }
       request.setAttribute("fileInfos", uiFileInfos);
-    } catch (FileDoesNotExistException fdne) {
-      request.setAttribute("fatalError", "Error: Invalid FileId " + fdne.getMessage());
+    } catch (FileDoesNotExistException e) {
+      request.setAttribute("fatalError", "Error: Invalid FileId " + e.getMessage());
       getServletContext().getRequestDispatcher("/worker/blockInfo.jsp").forward(request, response);
       return;
-    } catch (NumberFormatException nfe) {
+    } catch (NumberFormatException e) {
       request.setAttribute("fatalError",
-          "Error: offset or limit parse error, " + nfe.getLocalizedMessage());
+          "Error: offset or limit parse error, " + e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/worker/blockInfo.jsp").forward(request, response);
       return;
-    } catch (IndexOutOfBoundsException iobe) {
+    } catch (IndexOutOfBoundsException e) {
       request.setAttribute("fatalError",
-          "Error: offset or offset + limit is out of bound, " + iobe.getLocalizedMessage());
+          "Error: offset or offset + limit is out of bound, " + e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/worker/blockInfo.jsp").forward(request, response);
       return;
-    } catch (IllegalArgumentException iae) {
-      request.setAttribute("fatalError", iae.getLocalizedMessage());
+    } catch (IllegalArgumentException e) {
+      request.setAttribute("fatalError", e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/worker/blockInfo.jsp").forward(request, response);
       return;
-    } catch (BlockDoesNotExistException bnfe) {
-      request.setAttribute("fatalError", bnfe.getLocalizedMessage());
+    } catch (BlockDoesNotExistException e) {
+      request.setAttribute("fatalError", e.getLocalizedMessage());
       getServletContext().getRequestDispatcher("/worker/blockInfo.jsp").forward(request, response);
       return;
     } catch (TachyonException e) {

--- a/servers/src/main/java/tachyon/worker/TachyonWorker.java
+++ b/servers/src/main/java/tachyon/worker/TachyonWorker.java
@@ -334,8 +334,8 @@ public final class TachyonWorker {
     TTransportFactory tTransportFactory;
     try {
       tTransportFactory = AuthenticationUtils.getServerTransportFactory(mTachyonConf);
-    } catch (IOException ioe) {
-      throw Throwables.propagate(ioe);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
     }
     TThreadPoolServer.Args args = new TThreadPoolServer.Args(mThriftServerSocket)
         .minWorkerThreads(minWorkerThreads).maxWorkerThreads(maxWorkerThreads).processor(processor)
@@ -358,9 +358,9 @@ public final class TachyonWorker {
     try {
       return new TServerSocket(
           NetworkAddressUtils.getBindAddress(ServiceType.WORKER_RPC, mTachyonConf));
-    } catch (TTransportException tte) {
-      LOG.error(tte.getMessage(), tte);
-      throw Throwables.propagate(tte);
+    } catch (TTransportException e) {
+      LOG.error(e.getMessage(), e);
+      throw Throwables.propagate(e);
     }
   }
 

--- a/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockDataManager.java
@@ -149,8 +149,8 @@ public final class BlockDataManager {
       Long bytesUsedOnTier = storeMeta.getUsedBytesOnTiers().get(loc.tierAlias());
       mBlockMasterClient.commitBlock(WorkerIdRegistry.getWorkerId(), bytesUsedOnTier,
           loc.tierAlias(), blockId, length);
-    } catch (IOException ioe) {
-      throw new IOException("Failed to commit block to master.", ioe);
+    } catch (IOException e) {
+      throw new IOException("Failed to commit block to master.", e);
     } catch (ConnectionFailedException e) {
       throw new IOException("Failed to commit block to master.", e);
     } finally {

--- a/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMasterSync.java
@@ -87,9 +87,9 @@ public final class BlockMasterSync implements HeartbeatExecutor {
     try {
       registerWithMaster();
       mLastSuccessfulHeartbeatMs = System.currentTimeMillis();
-    } catch (IOException ioe) {
+    } catch (IOException e) {
       // If failed to register when the thread starts, no retry will happen.
-      throw new RuntimeException("Failed to register with master.", ioe);
+      throw new RuntimeException("Failed to register with master.", e);
     } catch (ConnectionFailedException e) {
       throw new RuntimeException("Failed to register with master.", e);
     }
@@ -109,9 +109,9 @@ public final class BlockMasterSync implements HeartbeatExecutor {
       mMasterClient.register(WorkerIdRegistry.getWorkerId(),
           storageTierAssoc.getOrderedStorageAliases(), storeMeta.getCapacityBytesOnTiers(),
           storeMeta.getUsedBytesOnTiers(), storeMeta.getBlockList());
-    } catch (IOException ioe) {
-      LOG.error("Failed to register with master.", ioe);
-      throw ioe;
+    } catch (IOException e) {
+      LOG.error("Failed to register with master.", e);
+      throw e;
     } catch (TachyonException e) {
       LOG.error("Failed to register with master.", e);
       throw new IOException(e);
@@ -221,12 +221,12 @@ public final class BlockMasterSync implements HeartbeatExecutor {
       try {
         mBlockDataManager.removeBlock(mSessionId, mBlockId);
         LOG.info("Block {} removed at session {}", mBlockId, mSessionId);
-      } catch (IOException ioe) {
-        LOG.warn("Failed master free block cmd for: {} due to concurrent read.", mBlockId);
+      } catch (IOException e) {
+        LOG.warn("Failed master free block cmd for: {} due to concurrent read.", mBlockId, e);
       } catch (InvalidWorkerStateException e) {
-        LOG.warn("Failed master free block cmd for: {} due to block uncommitted.", mBlockId);
+        LOG.warn("Failed master free block cmd for: {} due to block uncommitted.", mBlockId, e);
       } catch (BlockDoesNotExistException e) {
-        LOG.warn("Failed master free block cmd for: {} due to block not found.", mBlockId);
+        LOG.warn("Failed master free block cmd for: {} due to block not found.", mBlockId, e);
       }
     }
   }

--- a/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
+++ b/servers/src/main/java/tachyon/worker/block/BlockMetadataManager.java
@@ -71,12 +71,12 @@ public final class BlockMetadataManager {
       ret.initBlockMetadataManager();
       // caller of newBlockMetadataManager should not be forced to catch and handle these exceptions
       // since it is the responsibility of BlockMetadataManager.
-    } catch (BlockAlreadyExistsException aee) {
-      throw new RuntimeException(aee);
-    } catch (IOException ioe) {
-      throw new RuntimeException(ioe);
-    } catch (WorkerOutOfSpaceException ooe) {
-      throw new RuntimeException(ooe);
+    } catch (BlockAlreadyExistsException e) {
+      throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    } catch (WorkerOutOfSpaceException e) {
+      throw new RuntimeException(e);
     }
     return ret;
   }

--- a/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
+++ b/servers/src/main/java/tachyon/worker/block/TieredBlockStore.java
@@ -370,7 +370,7 @@ public final class TieredBlockStore implements BlockStore {
           if (new File(sessionFolderPath).exists()) {
             FileUtils.delete(sessionFolderPath);
           }
-        } catch (IOException ioe) {
+        } catch (IOException e) {
           // This error means we could not delete the directory but should not affect the
           // correctness of the method since the data has already been deleted. It is not
           // necessary to throw an exception here.
@@ -474,8 +474,8 @@ public final class TieredBlockStore implements BlockStore {
       mMetadataWriteLock.lock();
       try {
         mMetaManager.abortTempBlockMeta(tempBlockMeta);
-      } catch (BlockDoesNotExistException nfe) {
-        throw Throwables.propagate(nfe); // We shall never reach here
+      } catch (BlockDoesNotExistException e) {
+        throw Throwables.propagate(e); // We shall never reach here
       } finally {
         mMetadataWriteLock.unlock();
       }
@@ -524,12 +524,12 @@ public final class TieredBlockStore implements BlockStore {
       mMetadataWriteLock.lock();
       try {
         mMetaManager.commitTempBlockMeta(tempBlockMeta);
-      } catch (BlockAlreadyExistsException aee) {
-        throw Throwables.propagate(aee); // we shall never reach here
-      } catch (BlockDoesNotExistException nfe) {
-        throw Throwables.propagate(nfe); // we shall never reach here
-      } catch (WorkerOutOfSpaceException ose) {
-        throw Throwables.propagate(ose); // we shall never reach here
+      } catch (BlockAlreadyExistsException e) {
+        throw Throwables.propagate(e); // we shall never reach here
+      } catch (BlockDoesNotExistException e) {
+        throw Throwables.propagate(e); // we shall never reach here
+      } catch (WorkerOutOfSpaceException e) {
+        throw Throwables.propagate(e); // we shall never reach here
       } finally {
         mMetadataWriteLock.unlock();
       }
@@ -575,16 +575,16 @@ public final class TieredBlockStore implements BlockStore {
         // Add allocated temp block to metadata manager. This should never fail if allocator
         // correctly assigns a StorageDir.
         mMetaManager.addTempBlockMeta(tempBlock);
-      } catch (WorkerOutOfSpaceException ose) {
+      } catch (WorkerOutOfSpaceException e) {
         // If we reach here, allocator is not working properly
         LOG.error("Unexpected failure: {} bytes allocated at {} by allocator, "
             + "but addTempBlockMeta failed", initialBlockSize, location);
-        throw Throwables.propagate(ose);
-      } catch (BlockAlreadyExistsException aee) {
+        throw Throwables.propagate(e);
+      } catch (BlockAlreadyExistsException e) {
         // If we reach here, allocator is not working properly
         LOG.error("Unexpected failure: {} bytes allocated at {} by allocator, "
             + "but addTempBlockMeta failed", initialBlockSize, location);
-        throw Throwables.propagate(aee);
+        throw Throwables.propagate(e);
       }
       return tempBlock;
     } finally {
@@ -616,8 +616,8 @@ public final class TieredBlockStore implements BlockStore {
       try {
         mMetaManager.resizeTempBlockMeta(tempBlockMeta,
             tempBlockMeta.getBlockSize() + additionalBytes);
-      } catch (InvalidWorkerStateException ise) {
-        throw Throwables.propagate(ise); // we shall never reach here
+      } catch (InvalidWorkerStateException e) {
+        throw Throwables.propagate(e); // we shall never reach here
       }
       return new Pair<Boolean, BlockStoreLocation>(true, null);
     } finally {
@@ -653,11 +653,11 @@ public final class TieredBlockStore implements BlockStore {
     for (Pair<Long, BlockStoreLocation> blockInfo : plan.toEvict()) {
       try {
         removeBlockInternal(sessionId, blockInfo.getFirst(), blockInfo.getSecond());
-      } catch (InvalidWorkerStateException ise) {
+      } catch (InvalidWorkerStateException e) {
         // Evictor is not working properly
         LOG.error("Failed to evict blockId {}, this is temp block", blockInfo.getFirst());
         continue;
-      } catch (BlockDoesNotExistException nfe) {
+      } catch (BlockDoesNotExistException e) {
         LOG.info("Failed to evict blockId {}, it could be already deleted", blockInfo.getFirst());
         continue;
       }
@@ -692,13 +692,13 @@ public final class TieredBlockStore implements BlockStore {
         MoveBlockResult moveResult;
         try {
           moveResult = moveBlockInternal(sessionId, blockId, oldLocation, newLocation);
-        } catch (InvalidWorkerStateException ise) {
+        } catch (InvalidWorkerStateException e) {
           // Evictor is not working properly
           LOG.error("Failed to evict blockId {}, this is temp block", blockId);
           continue;
-        } catch (BlockAlreadyExistsException aee) {
+        } catch (BlockAlreadyExistsException e) {
           continue;
-        } catch (BlockDoesNotExistException nfe) {
+        } catch (BlockDoesNotExistException e) {
           LOG.info("Failed to move blockId {}, it could be already deleted", blockId);
           continue;
         }
@@ -799,14 +799,14 @@ public final class TieredBlockStore implements BlockStore {
         // If this metadata update fails, we panic for now.
         // TODO(bin): Implement rollback scheme to recover from IO failures.
         mMetaManager.moveBlockMeta(srcBlockMeta, dstTempBlock);
-      } catch (BlockAlreadyExistsException aee) {
-        throw Throwables.propagate(aee); // we shall never reach here
-      } catch (BlockDoesNotExistException nfe) {
-        throw Throwables.propagate(nfe); // we shall never reach here
-      } catch (WorkerOutOfSpaceException ose) {
+      } catch (BlockAlreadyExistsException e) {
+        throw Throwables.propagate(e); // we shall never reach here
+      } catch (BlockDoesNotExistException e) {
+        throw Throwables.propagate(e); // we shall never reach here
+      } catch (WorkerOutOfSpaceException e) {
         // Only possible if sessionId gets cleaned between createBlockMetaInternal and
         // moveBlockMeta.
-        throw Throwables.propagate(ose);
+        throw Throwables.propagate(e);
       } finally {
         mMetadataWriteLock.unlock();
       }
@@ -854,8 +854,8 @@ public final class TieredBlockStore implements BlockStore {
       mMetadataWriteLock.lock();
       try {
         mMetaManager.removeBlockMeta(blockMeta);
-      } catch (BlockDoesNotExistException nfe) {
-        throw Throwables.propagate(nfe); // we shall never reach here
+      } catch (BlockDoesNotExistException e) {
+        throw Throwables.propagate(e); // we shall never reach here
       } finally {
         mMetadataWriteLock.unlock();
       }

--- a/servers/src/main/java/tachyon/worker/block/evictor/EvictorBase.java
+++ b/servers/src/main/java/tachyon/worker/block/evictor/EvictorBase.java
@@ -102,8 +102,8 @@ public abstract class EvictorBase extends BlockStoreEventListenerBase implements
                 block.getBlockSize());
           }
         }
-      } catch (BlockDoesNotExistException nfe) {
-        LOG.warn("Remove block {} from evictor cache because {}", blockId, nfe);
+      } catch (BlockDoesNotExistException e) {
+        LOG.warn("Remove block {} from evictor cache because {}", blockId, e);
         it.remove();
         onRemoveBlockFromIterator(blockId);
       }
@@ -130,7 +130,7 @@ public abstract class EvictorBase extends BlockStoreEventListenerBase implements
             plan.toEvict().add(new Pair<Long, BlockStoreLocation>(blockId,
                 candidateDirView.toBlockStoreLocation()));
           }
-        } catch (BlockDoesNotExistException nfe) {
+        } catch (BlockDoesNotExistException e) {
           continue;
         }
       }
@@ -160,7 +160,7 @@ public abstract class EvictorBase extends BlockStoreEventListenerBase implements
               nextDirView.toBlockStoreLocation()));
           candidateDirView.markBlockMoveOut(blockId, block.getBlockSize());
           nextDirView.markBlockMoveIn(blockId, block.getBlockSize());
-        } catch (BlockDoesNotExistException nfe) {
+        } catch (BlockDoesNotExistException e) {
           continue;
         }
       }

--- a/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
+++ b/servers/src/main/java/tachyon/worker/block/meta/StorageDir.java
@@ -125,16 +125,16 @@ public final class StorageDir {
         try {
           // TODO(calvin): Resolve this conflict in class names.
           org.apache.commons.io.FileUtils.deleteDirectory(path);
-        } catch (IOException ioe) {
-          LOG.error("can not delete directory {}", path.getAbsolutePath(), ioe);
+        } catch (IOException e) {
+          LOG.error("can not delete directory {}", path.getAbsolutePath(), e);
         }
       } else {
         try {
           long blockId = Long.parseLong(path.getName());
           addBlockMeta(new BlockMeta(blockId, path.length(), this));
-        } catch (NumberFormatException nfe) {
+        } catch (NumberFormatException e) {
           LOG.error("filename of {} in StorageDir can not be parsed into long",
-              path.getAbsolutePath());
+              path.getAbsolutePath(), e);
           if (path.delete()) {
             LOG.warn("file {} has been deleted", path.getAbsolutePath());
           } else {

--- a/servers/src/main/java/tachyon/worker/file/FileDataManager.java
+++ b/servers/src/main/java/tachyon/worker/file/FileDataManager.java
@@ -198,8 +198,8 @@ public final class FileDataManager {
       for (long lockId : blockIdToLockId.values()) {
         try {
           mBlockDataManager.unlockBlock(lockId);
-        } catch (BlockDoesNotExistException bdnee) {
-          errors.add(bdnee);
+        } catch (BlockDoesNotExistException e) {
+          errors.add(e);
         }
       }
 

--- a/servers/src/main/java/tachyon/worker/netty/DataServerHandler.java
+++ b/servers/src/main/java/tachyon/worker/netty/DataServerHandler.java
@@ -115,10 +115,10 @@ public final class DataServerHandler extends SimpleChannelInboundHandler<RPCMess
     BlockReader reader;
     try {
       reader = mDataManager.readBlockRemote(sessionId, blockId, lockId);
-    } catch (BlockDoesNotExistException nfe) {
-      throw new IOException(nfe);
-    } catch (InvalidWorkerStateException fpe) {
-      throw new IOException(fpe);
+    } catch (BlockDoesNotExistException e) {
+      throw new IOException(e);
+    } catch (InvalidWorkerStateException e) {
+      throw new IOException(e);
     }
     try {
       req.validate();

--- a/servers/src/test/java/tachyon/master/file/meta/InodeTreeTest.java
+++ b/servers/src/test/java/tachyon/master/file/meta/InodeTreeTest.java
@@ -256,8 +256,8 @@ public final class InodeTreeTest {
     try {
       createResult = mTree.createPath(NESTED_URI, sNestedDirectoryOptions);
       Assert.assertTrue("createPath should throw FileAlreadyExistsException", false);
-    } catch (FileAlreadyExistsException faee) {
-      Assert.assertEquals(faee.getMessage(),
+    } catch (FileAlreadyExistsException e) {
+      Assert.assertEquals(e.getMessage(),
           ExceptionMessage.FILE_ALREADY_EXISTS.getMessage(NESTED_URI));
     }
 

--- a/shell/src/main/java/tachyon/shell/TfsShell.java
+++ b/shell/src/main/java/tachyon/shell/TfsShell.java
@@ -23,11 +23,15 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.apache.commons.lang.StringUtils;
 import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 
+import tachyon.Constants;
 import tachyon.client.file.FileSystem;
 import tachyon.conf.TachyonConf;
 import tachyon.shell.command.TfsShellCommand;
@@ -37,6 +41,8 @@ import tachyon.util.CommonUtils;
  * Class for handling command line inputs.
  */
 public class TfsShell implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(Constants.LOGGER_TYPE);
+
   /**
    * Main method, starts a new TfsShell.
    *
@@ -140,6 +146,7 @@ public class TfsShell implements Closeable {
       return 0;
     } catch (IOException e) {
       System.out.println(e.getMessage());
+      LOG.error("Error running " + StringUtils.join(argv, " "), e);
       return -1;
     }
   }

--- a/shell/src/main/java/tachyon/shell/TfsShell.java
+++ b/shell/src/main/java/tachyon/shell/TfsShell.java
@@ -138,8 +138,8 @@ public class TfsShell implements Closeable {
     try {
       command.run(args);
       return 0;
-    } catch (IOException ioe) {
-      System.out.println(ioe.getMessage());
+    } catch (IOException e) {
+      System.out.println(e.getMessage());
       return -1;
     }
   }

--- a/shell/src/main/java/tachyon/shell/TfsShell.java
+++ b/shell/src/main/java/tachyon/shell/TfsShell.java
@@ -139,7 +139,7 @@ public class TfsShell implements Closeable {
       command.run(args);
       return 0;
     } catch (IOException e) {
-      e.printStackTrace();
+      System.out.println(e.getMessage());
       return -1;
     }
   }

--- a/shell/src/main/java/tachyon/shell/TfsShell.java
+++ b/shell/src/main/java/tachyon/shell/TfsShell.java
@@ -139,7 +139,7 @@ public class TfsShell implements Closeable {
       command.run(args);
       return 0;
     } catch (IOException e) {
-      System.out.println(e.getMessage());
+      e.printStackTrace();
       return -1;
     }
   }

--- a/underfs/oss/src/main/java/tachyon/underfs/oss/OSSUnderFileSystem.java
+++ b/underfs/oss/src/main/java/tachyon/underfs/oss/OSSUnderFileSystem.java
@@ -37,7 +37,6 @@ import com.aliyun.oss.model.ObjectMetadata;
 import com.google.common.base.Preconditions;
 
 import tachyon.Constants;
-
 import tachyon.conf.TachyonConf;
 import tachyon.underfs.UnderFileSystem;
 import tachyon.util.io.PathUtils;
@@ -338,8 +337,8 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
       LOG.info("Copying {} to {}", src, dst);
       mOssClient.copyObject(mBucketName, src, mBucketName, dst);
       return true;
-    } catch (ServiceException se) {
-      LOG.error("Failed to rename file {} to {}", src, dst);
+    } catch (ServiceException e) {
+      LOG.error("Failed to rename file {} to {}", src, dst, e);
       return false;
     }
   }
@@ -358,8 +357,8 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
       } else {
         mOssClient.deleteObject(mBucketName, stripPrefixIfPresent(key));
       }
-    } catch (ServiceException se) {
-      LOG.error("Failed to delete {}", key, se);
+    } catch (ServiceException e) {
+      LOG.error("Failed to delete {}", key, e);
       return false;
     }
     return true;
@@ -378,7 +377,7 @@ public final class OSSUnderFileSystem extends UnderFileSystem {
         return mOssClient.getObjectMetadata(mBucketName, stripPrefixIfPresent(key));
       }
     } catch (ServiceException e) {
-      LOG.warn("Failed to get Object {}, return null", key);
+      LOG.warn("Failed to get Object {}, return null", key, e);
       return null;
     }
   }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3InputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3InputStream.java
@@ -103,8 +103,8 @@ public class S3InputStream extends InputStream {
     try {
       mObject = mClient.getObject(mBucketName, mKey, null, null, null, null, mPos, null);
       mInputStream = new BufferedInputStream(mObject.getDataInputStream());
-    } catch (ServiceException se) {
-      throw new IOException(se);
+    } catch (ServiceException e) {
+      throw new IOException(e);
     }
     return n;
   }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3OutputStream.java
@@ -80,8 +80,8 @@ public class S3OutputStream extends OutputStream {
       mHash = MessageDigest.getInstance("MD5");
       mLocalOutputStream =
           new BufferedOutputStream(new DigestOutputStream(new FileOutputStream(mFile), mHash));
-    } catch (NoSuchAlgorithmException nsae) {
-      LOG.warn("Algorithm not available for MD5 hash.", nsae);
+    } catch (NoSuchAlgorithmException e) {
+      LOG.warn("Algorithm not available for MD5 hash.", e);
       mHash = null;
       mLocalOutputStream = new BufferedOutputStream(new FileOutputStream(mFile));
     }
@@ -128,9 +128,9 @@ public class S3OutputStream extends OutputStream {
       }
       mClient.putObject(mBucketName, obj);
       mFile.delete();
-    } catch (ServiceException se) {
+    } catch (ServiceException e) {
       LOG.error("Failed to upload {}. Temporary file @ {}", mKey, mFile.getPath());
-      throw new IOException(se);
+      throw new IOException(e);
     }
   }
 }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystem.java
@@ -290,8 +290,8 @@ public class S3UnderFileSystem extends UnderFileSystem {
     try {
       path = stripPrefixIfPresent(path);
       return new S3InputStream(mBucketName, path, mClient);
-    } catch (ServiceException se) {
-      LOG.error("Failed to open file: {}", path, se);
+    } catch (ServiceException e) {
+      LOG.error("Failed to open file: {}", path, e);
       return null;
     }
   }
@@ -364,8 +364,8 @@ public class S3UnderFileSystem extends UnderFileSystem {
       S3Object obj = new S3Object(dst);
       mClient.copyObject(mBucketName, src, mBucketName, obj, false);
       return true;
-    } catch (ServiceException se) {
-      LOG.error("Failed to rename file {} to {}", src, dst);
+    } catch (ServiceException e) {
+      LOG.error("Failed to rename file {} to {}", src, dst, e);
       return false;
     }
   }
@@ -384,8 +384,8 @@ public class S3UnderFileSystem extends UnderFileSystem {
       } else {
         mClient.deleteObject(mBucketName, stripPrefixIfPresent(key));
       }
-    } catch (ServiceException se) {
-      LOG.error("Failed to delete {}", key, se);
+    } catch (ServiceException e) {
+      LOG.error("Failed to delete {}", key, e);
       return false;
     }
     return true;
@@ -419,7 +419,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
       } else {
         return mClient.getObjectDetails(mBucketName, stripPrefixIfPresent(key));
       }
-    } catch (ServiceException se) {
+    } catch (ServiceException e) {
       return null;
     }
   }
@@ -457,7 +457,7 @@ public class S3UnderFileSystem extends UnderFileSystem {
       mClient.getObjectDetails(mBucketName, keyAsFolder);
       // If no exception is thrown, the key exists as a folder
       return true;
-    } catch (ServiceException se) {
+    } catch (ServiceException s) {
       return false;
     }
   }
@@ -515,8 +515,8 @@ public class S3UnderFileSystem extends UnderFileSystem {
         children.add(child);
       }
       return children.toArray(new String[children.size()]);
-    } catch (ServiceException se) {
-      LOG.error("Failed to list path {}", path);
+    } catch (ServiceException e) {
+      LOG.error("Failed to list path {}", path, e);
       return null;
     }
   }
@@ -537,8 +537,8 @@ public class S3UnderFileSystem extends UnderFileSystem {
       obj.setContentType(Mimetypes.MIMETYPE_BINARY_OCTET_STREAM);
       mClient.putObject(mBucketName, obj);
       return true;
-    } catch (ServiceException se) {
-      LOG.error("Failed to create directory: {}", key, se);
+    } catch (ServiceException e) {
+      LOG.error("Failed to create directory: {}", key, e);
       return false;
     }
   }

--- a/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
+++ b/underfs/s3/src/main/java/tachyon/underfs/s3/S3UnderFileSystemFactory.java
@@ -46,9 +46,9 @@ public class S3UnderFileSystemFactory implements UnderFileSystemFactory {
       TachyonURI uri = new TachyonURI(path);
       try {
         return new S3UnderFileSystem(uri.getHost(), tachyonConf);
-      } catch (ServiceException se) {
-        LOG.error("Failed to create S3UnderFileSystem.", se);
-        throw Throwables.propagate(se);
+      } catch (ServiceException e) {
+        LOG.error("Failed to create S3UnderFileSystem.", e);
+        throw Throwables.propagate(e);
       }
     }
 

--- a/underfs/swift/src/main/java/tachyon/underfs/swift/SwiftUnderFileSystem.java
+++ b/underfs/swift/src/main/java/tachyon/underfs/swift/SwiftUnderFileSystem.java
@@ -24,6 +24,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
 import org.javaswift.joss.client.factory.AccountConfig;
 import org.javaswift.joss.client.factory.AccountFactory;
 import org.javaswift.joss.client.factory.AuthenticationMethod;
@@ -34,11 +36,8 @@ import org.javaswift.joss.model.Directory;
 import org.javaswift.joss.model.DirectoryOrObject;
 import org.javaswift.joss.model.PaginationMap;
 import org.javaswift.joss.model.StoredObject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
 
 import tachyon.Constants;
 import tachyon.conf.TachyonConf;
@@ -373,8 +372,8 @@ public class SwiftUnderFileSystem extends UnderFileSystem {
         children.add(noPrefix);
       }
       return children.toArray(new String[children.size()]);
-    } catch (Exception se) {
-      LOG.error("Failed to list path {}", path);
+    } catch (Exception e) {
+      LOG.error("Failed to list path {}", path, e);
       return null;
     }
   }

--- a/underfs/swift/src/main/java/tachyon/underfs/swift/SwiftUnderFileSystemFactory.java
+++ b/underfs/swift/src/main/java/tachyon/underfs/swift/SwiftUnderFileSystemFactory.java
@@ -17,11 +17,11 @@ package tachyon.underfs.swift;
 
 import java.io.IOException;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
@@ -44,9 +44,9 @@ public class SwiftUnderFileSystemFactory implements UnderFileSystemFactory {
       TachyonURI uri = new TachyonURI(path);
       try {
         return new SwiftUnderFileSystem(uri.getHost(), tachyonConf);
-      } catch (Exception se) {
-        LOG.error("Failed to create SwiftUnderFileSystem.", se);
-        throw Throwables.propagate(se);
+      } catch (Exception e) {
+        LOG.error("Failed to create SwiftUnderFileSystem.", e);
+        throw Throwables.propagate(e);
       }
     }
 


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1606

This commit also improves error propagation in many places, e.g. using `IOException(e)` which gets the same message as `IOException(e.getMessage())`, but also keeps `e` as the cause. 