### PR TITLE
[SMALLFIX] Add lineage integration test

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/ClientContext.java
+++ b/clients/unshaded/src/main/java/tachyon/client/ClientContext.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import tachyon.Constants;
 import tachyon.client.block.BlockStoreContext;
 import tachyon.client.file.FileSystemContext;
+import tachyon.client.lineage.LineageContext;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.PreconditionMessage;
 import tachyon.util.ThreadFactoryUtils;
@@ -80,6 +81,7 @@ public final class ClientContext {
     if (sInitialized) {
       BlockStoreContext.INSTANCE.reset();
       FileSystemContext.INSTANCE.reset();
+      LineageContext.INSTANCE.reset();
     }
     sInitialized = true;
   }

--- a/clients/unshaded/src/main/java/tachyon/client/lineage/LineageContext.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/LineageContext.java
@@ -33,7 +33,7 @@ public enum LineageContext {
    * Creates a new lineage context.
    */
   LineageContext() {
-    mLineageMasterClientPool = new LineageMasterClientPool(ClientContext.getMasterAddress());
+    reset();
   }
 
   /**
@@ -52,5 +52,16 @@ public enum LineageContext {
    */
   public void releaseMasterClient(LineageMasterClient masterClient) {
     mLineageMasterClientPool.release(masterClient);
+  }
+
+  /**
+   * Re-initializes the {@link LineageContext}. This method should only be used in
+   * {@link ClientContext}.
+   */
+  public void reset() {
+    if (mLineageMasterClientPool != null) {
+      mLineageMasterClientPool.close();
+    }
+    mLineageMasterClientPool = new LineageMasterClientPool(ClientContext.getMasterAddress());
   }
 }

--- a/integration-tests/src/test/java/tachyon/master/lineage/LineageMasterIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/lineage/LineageMasterIntegrationTest.java
@@ -170,6 +170,8 @@ public final class LineageMasterIntegrationTest {
   @Test(timeout = 20000)
   public void lineageRecoveryTest() throws Exception {
     File logFile = mFolder.newFile();
+    // Delete the log file so that when it starts to exist we know that it was created by the
+    // lineage recompute job
     logFile.delete();
     LineageMasterClient lineageClient = getLineageMasterClient();
     FileSystem fs = FileSystem.Factory.get();
@@ -180,11 +182,11 @@ public final class LineageMasterIntegrationTest {
       out.write("foo".getBytes());
       out.close();
       lineageClient.reportLostFile("/testFile");
-      // Wait for the log file to be created by recompute job
+      // Wait for the log file to be created by the recompute job
       while (!logFile.exists()) {
         CommonUtils.sleepMs(20);
       }
-      // Wait for the output to be written (should be very fast)
+      // Wait for the output to be written (this should be very fast)
       CommonUtils.sleepMs(10);
       BufferedReader reader = new BufferedReader(new FileReader(logFile));
       try {

--- a/integration-tests/src/test/java/tachyon/master/lineage/LineageMasterIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/lineage/LineageMasterIntegrationTest.java
@@ -15,6 +15,9 @@
 
 package tachyon.master.lineage;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -23,7 +26,9 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import tachyon.Constants;
@@ -33,11 +38,12 @@ import tachyon.LocalTachyonClusterResource;
 import tachyon.TachyonURI;
 import tachyon.client.WriteType;
 import tachyon.client.file.FileOutStream;
+import tachyon.client.file.FileSystem;
 import tachyon.client.file.FileSystemMasterClient;
 import tachyon.client.file.URIStatus;
 import tachyon.client.file.options.CreateFileOptions;
-import tachyon.client.lineage.LineageMasterClient;
 import tachyon.client.lineage.LineageFileSystem;
+import tachyon.client.lineage.LineageMasterClient;
 import tachyon.conf.TachyonConf;
 import tachyon.heartbeat.HeartbeatContext;
 import tachyon.heartbeat.HeartbeatScheduler;
@@ -45,6 +51,7 @@ import tachyon.job.CommandLineJob;
 import tachyon.job.JobConf;
 import tachyon.master.file.meta.PersistenceState;
 import tachyon.thrift.LineageInfo;
+import tachyon.util.CommonUtils;
 
 /**
  * Integration tests for the lineage module.
@@ -56,10 +63,15 @@ public final class LineageMasterIntegrationTest {
   private static final int BUFFER_BYTES = 100;
 
   @Rule
+  public TemporaryFolder mFolder = new TemporaryFolder();
+
+  @Rule
   public LocalTachyonClusterResource mLocalTachyonClusterResource = new LocalTachyonClusterResource(
-      WORKER_CAPACITY_BYTES, QUOTA_UNIT_BYTES, BLOCK_SIZE_BYTES, Constants.USER_FILE_BUFFER_BYTES,
-      String.valueOf(BUFFER_BYTES), Constants.WORKER_DATA_SERVER,
-      IntegrationTestConstants.NETTY_DATA_SERVER, Constants.USER_LINEAGE_ENABLED, "true");
+      WORKER_CAPACITY_BYTES, QUOTA_UNIT_BYTES, BLOCK_SIZE_BYTES,
+      Constants.USER_FILE_BUFFER_BYTES, String.valueOf(BUFFER_BYTES),
+      Constants.WORKER_DATA_SERVER, IntegrationTestConstants.NETTY_DATA_SERVER,
+      Constants.USER_LINEAGE_ENABLED, "true",
+      Constants.MASTER_LINEAGE_RECOMPUTE_INTERVAL_MS, "1000");
 
   private static final String OUT_FILE = "/test";
   private TachyonConf mTestConf;
@@ -149,6 +161,39 @@ public final class LineageMasterIntegrationTest {
 
     } finally {
       lineageMasterClient.close();
+    }
+  }
+
+  /**
+   * Tests that a lineage job is executed when the output file for the lineage is reported as lost.
+   */
+  @Test(timeout = 20000)
+  public void lineageRecoveryTest() throws Exception {
+    File logFile = mFolder.newFile();
+    logFile.delete();
+    LineageMasterClient lineageClient = getLineageMasterClient();
+    FileSystem fs = FileSystem.Factory.get();
+    try {
+      lineageClient.createLineage(ImmutableList.<String>of(), ImmutableList.of("/testFile"),
+          new CommandLineJob("echo hello world", new JobConf(logFile.getAbsolutePath())));
+      FileOutStream out = fs.createFile(new TachyonURI("/testFile"));
+      out.write("foo".getBytes());
+      out.close();
+      lineageClient.reportLostFile("/testFile");
+      // Wait for the log file to be created by recompute job
+      while (!logFile.exists()) {
+        CommonUtils.sleepMs(20);
+      }
+      // Wait for the output to be written (should be very fast)
+      CommonUtils.sleepMs(10);
+      BufferedReader reader = new BufferedReader(new FileReader(logFile));
+      try {
+        Assert.assertEquals("hello world", reader.readLine());
+      } finally {
+        reader.close();
+      }
+    } finally {
+      lineageClient.close();
     }
   }
 


### PR DESCRIPTION
Lineage context needs to be reset whenever client context is reset because lineage context depends on the value of `ClientContext.getMasterAddress()`. Without this change, all tests use the cluster created for the first lineage test.