### PR TITLE
[SMALLFIX] Test documented lineage code

### DIFF
--- a/clients/unshaded/src/main/java/tachyon/client/lineage/LineageMasterClient.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/LineageMasterClient.java
@@ -27,6 +27,7 @@ import tachyon.Constants;
 import tachyon.MasterClientBase;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.ConnectionFailedException;
+import tachyon.exception.LineageDoesNotExistException;
 import tachyon.exception.TachyonException;
 import tachyon.job.CommandLineJob;
 import tachyon.thrift.LineageInfo;
@@ -126,7 +127,7 @@ public final class LineageMasterClient extends MasterClientBase {
    * @throws TachyonException if a Tachyon exception occurs
    */
   public synchronized long reinitializeFile(final String path, final long blockSizeBytes,
-      final long ttl) throws IOException, TachyonException {
+      final long ttl) throws IOException, LineageDoesNotExistException, TachyonException {
     return retryRPC(new RpcCallableThrowsTachyonTException<Long>() {
       @Override
       public Long call() throws TachyonTException, TException {

--- a/clients/unshaded/src/main/java/tachyon/client/lineage/LineageMasterClient.java
+++ b/clients/unshaded/src/main/java/tachyon/client/lineage/LineageMasterClient.java
@@ -124,6 +124,7 @@ public final class LineageMasterClient extends MasterClientBase {
    * @param ttl the time to live for the file
    * @return the value of the lineage creation result
    * @throws IOException if a non-Tachyon exception occurs
+   * @throws LineageDoesNotExistException if the file does not exist
    * @throws TachyonException if a Tachyon exception occurs
    */
   public synchronized long reinitializeFile(final String path, final long blockSizeBytes,

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -122,6 +122,7 @@ public enum ExceptionMessage {
   LINEAGE_DOES_NOT_EXIST("The lineage {0} does not exist"),
   LINEAGE_INPUT_FILE_NOT_EXIST("The lineage input file {0} does not exist"),
   LINEAGE_OUTPUT_FILE_NOT_EXIST("No lineage has output file {0}"),
+  MISSING_REINITIALIZE_FILE("Cannot reinitialize file {0} because it does not exist"),
   UNKNOWN_LINEAGE_FILE_STATE("Unknown LineageFileState: {0}"),
 
   // client

--- a/common/src/main/java/tachyon/exception/ExceptionMessage.java
+++ b/common/src/main/java/tachyon/exception/ExceptionMessage.java
@@ -122,7 +122,7 @@ public enum ExceptionMessage {
   LINEAGE_DOES_NOT_EXIST("The lineage {0} does not exist"),
   LINEAGE_INPUT_FILE_NOT_EXIST("The lineage input file {0} does not exist"),
   LINEAGE_OUTPUT_FILE_NOT_EXIST("No lineage has output file {0}"),
-  MISSING_REINITIALIZE_FILE("Cannot reinitialize file {0} because it does not exist"),
+  MISSING_REINITIALIZE_FILE("Cannot reinitialize file {0} because its lineage does not exist"),
   UNKNOWN_LINEAGE_FILE_STATE("Unknown LineageFileState: {0}"),
 
   // client

--- a/docs/Lineage-API.md
+++ b/docs/Lineage-API.md
@@ -20,7 +20,7 @@ handle divergent outputs.
 
 # Enable Lineage
 
-By default, lineage is not enabled. It can be enabled by setting the 
+By default, lineage is not enabled. It can be enabled by setting the
 `tachyon.user.lineage.enabled` property to `true` in the configuration file.
 
 # Lineage API
@@ -40,13 +40,17 @@ TachyonLineage tl = TachyonLineage.get();
 Lineage can be created by calling
 `TachyonLineage#createLineage(List<TachyonURI>, List<TachyonURI>, Job)`. A lineage record takes (1)
 a list of URIs of the input files, (2) a list of URIs of the output files, and (3) a *job*. A job
-is description of a program that can be run by Tachyon to recompute the output files given the input 
-files. *Note: In the current alpha version, only a built-in `CommandLineJob` is supported, which 
-simply takes a command String that can be run in a terminal. The user needs to provide the necessary 
-configurations and execution environments to ensure the command can be executed both at the client 
+is description of a program that can be run by Tachyon to recompute the output files given the input
+files. *Note: In the current alpha version, only a built-in `CommandLineJob` is supported, which
+simply takes a command String that can be run in a terminal. The user needs to provide the necessary
+configurations and execution environments to ensure the command can be executed both at the client
 and at Tachyon master (during recomputation).*
 
 For example,
+<!---
+NOTE: This code is tested in LineageMasterIntegrationTest, so if you update it here make sure to
+update it there as well.
+-->
 
 ```java
 TachyonLineage tl = TachyonLineage.get();
@@ -64,7 +68,7 @@ long lineageId = tl.createLineage(inputFiles, outputFiles, job);
 ```
 
 The `createLineage` function returns the id of the newly created lineage record. Before creating a
-lineage record, make sure that all the input files are either persisted, or specified as an output 
+lineage record, make sure that all the input files are either persisted, or specified as an output
 file in another lineage record.
 
 ### Specifying Operation Options
@@ -91,9 +95,8 @@ flag. For example:
 
 ```java
 TachyonLineage tl = TachyonLineage.get();
-DeleteLineageOptions options =
-    new DeleteLineageOptions.Builder(new TachyonConf()).setCascade(true).build();
-tl.deleteLineage(1, options);
+DeleteLineageOptions options = DeleteLineageOptions.defaults().setCascade(true);
+tl.deleteLineage(lineageId, options);
 ```
 
 # Configuration Parameters For Lineage

--- a/integration-tests/src/test/java/tachyon/master/lineage/LineageMasterIntegrationTest.java
+++ b/integration-tests/src/test/java/tachyon/master/lineage/LineageMasterIntegrationTest.java
@@ -204,6 +204,8 @@ public final class LineageMasterIntegrationTest {
   /**
    * Runs code given in the docs (http://tachyon-project.org/documentation/Lineage-API.html) to make
    * sure it actually runs.
+   *
+   * If you need to update the doc-code here, make sure you also update it in the docs.
    */
   @Test
   public void docExampleTest() throws Exception {

--- a/servers/src/main/java/tachyon/master/lineage/LineageMaster.java
+++ b/servers/src/main/java/tachyon/master/lineage/LineageMaster.java
@@ -279,16 +279,19 @@ public final class LineageMaster extends MasterBase {
    * @param ttl the TTL
    * @return the id of the reinitialized file when the file is lost or not completed, -1 otherwise
    * @throws InvalidPathException the file path is invalid
-   * @throws FileDoesNotExistException when the file does not exist
+   * @throws LineageDoesNotExistException when the file does not exist
    * @throws AccessControlException if permission checking fails
    */
   public synchronized long reinitializeFile(String path, long blockSizeBytes, long ttl)
-      throws InvalidPathException, FileDoesNotExistException, AccessControlException {
+      throws InvalidPathException, LineageDoesNotExistException, AccessControlException {
     long fileId = mFileSystemMaster.getFileId(new TachyonURI(path));
-    if (fileId == -1) {
-      throw new FileDoesNotExistException(ExceptionMessage.MISSING_REINITIALIZE_FILE.getMessage(path));
+    FileInfo fileInfo;
+    try {
+      fileInfo = mFileSystemMaster.getFileInfo(fileId);
+    } catch (FileDoesNotExistException e) {
+      throw new LineageDoesNotExistException(
+          ExceptionMessage.MISSING_REINITIALIZE_FILE.getMessage(path));
     }
-    FileInfo fileInfo = mFileSystemMaster.getFileInfo(fileId);
     if (!fileInfo.isCompleted || mFileSystemMaster.getLostFiles().contains(fileId)) {
       LOG.info("Recreate the file {} with block size of {} bytes", path, blockSizeBytes);
       return mFileSystemMaster.reinitializeFile(new TachyonURI(path), blockSizeBytes, ttl);

--- a/servers/src/main/java/tachyon/master/lineage/LineageMaster.java
+++ b/servers/src/main/java/tachyon/master/lineage/LineageMaster.java
@@ -285,6 +285,9 @@ public final class LineageMaster extends MasterBase {
   public synchronized long reinitializeFile(String path, long blockSizeBytes, long ttl)
       throws InvalidPathException, FileDoesNotExistException, AccessControlException {
     long fileId = mFileSystemMaster.getFileId(new TachyonURI(path));
+    if (fileId == -1) {
+      throw new FileDoesNotExistException(ExceptionMessage.MISSING_REINITIALIZE_FILE.getMessage(path));
+    }
     FileInfo fileInfo = mFileSystemMaster.getFileInfo(fileId);
     if (!fileInfo.isCompleted || mFileSystemMaster.getLostFiles().contains(fileId)) {
       LOG.info("Recreate the file {} with block size of {} bytes", path, blockSizeBytes);


### PR DESCRIPTION
This also fixes an issue where creating a file through the lineage file system would throw an exception if the file wasn't already an output file of a lineage.