### PR TITLE
[SMALLFIX] Use hdfs1 API in KeyValueOutputCommitter

### DIFF
--- a/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueOutputCommitter.java
+++ b/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueOutputCommitter.java
@@ -47,8 +47,9 @@ class KeyValueOutputCommitter extends FileOutputCommitter {
     return new TachyonURI(FileOutputFormat.getOutputPath(conf).toString());
   }
 
-  private TachyonURI getTaskAttemptOutputURI(TaskAttemptContext context) throws IOException {
-    return new TachyonURI(getTaskAttemptPath(context).toString());
+  private TachyonURI getTaskTempOutputURI(TaskAttemptContext context) throws IOException {
+    return new TachyonURI(KeyValueOutputFormat.getTaskTempOutputDirectoryURI(context.getJobConf())
+        .toString());
   }
 
   /**
@@ -93,7 +94,7 @@ class KeyValueOutputCommitter extends FileOutputCommitter {
   @Override
   public void commitTask(TaskAttemptContext context) throws IOException {
     try {
-      KEY_VALUE_STORES.merge(getTaskAttemptOutputURI(context), getOutputURI(context.getJobConf()));
+      KEY_VALUE_STORES.merge(getTaskTempOutputURI(context), getOutputURI(context.getJobConf()));
     } catch (TachyonException e) {
       throw new IOException(e);
     }
@@ -108,7 +109,7 @@ class KeyValueOutputCommitter extends FileOutputCommitter {
   @Override
   public void abortTask(TaskAttemptContext context) throws IOException {
     try {
-      KEY_VALUE_STORES.delete(new TachyonURI(getTaskAttemptPath(context).toString()));
+      KEY_VALUE_STORES.delete(getTaskTempOutputURI(context));
     } catch (FileDoesNotExistException e) {
       // The goal of deleting the store is to cleanup directories before aborting the task, since
       // the key-value store directory does not exist, it meets the goal, nothing needs to be done.

--- a/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueOutputCommitter.java
+++ b/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueOutputCommitter.java
@@ -48,6 +48,8 @@ class KeyValueOutputCommitter extends FileOutputCommitter {
   }
 
   private TachyonURI getTaskTempOutputURI(TaskAttemptContext context) throws IOException {
+    // We specifically avoid using KeyValueOutputCommitter#getTaskAttemptPath, which exists in the
+    // hdfs2 API but not the hdfs1 API
     return new TachyonURI(KeyValueOutputFormat.getTaskTempOutputDirectoryURI(context.getJobConf())
         .toString());
   }

--- a/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueOutputFormat.java
+++ b/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueOutputFormat.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import javax.annotation.concurrent.ThreadSafe;
 
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapred.FileAlreadyExistsException;
 import org.apache.hadoop.mapred.FileOutputFormat;
@@ -32,8 +31,8 @@ import org.apache.hadoop.util.Progressable;
 
 import tachyon.TachyonURI;
 import tachyon.annotation.PublicApi;
-import tachyon.client.keyvalue.KeyValueStores;
 import tachyon.client.keyvalue.KeyValueStoreWriter;
+import tachyon.client.keyvalue.KeyValueStores;
 import tachyon.exception.TachyonException;
 
 /**
@@ -49,13 +48,17 @@ import tachyon.exception.TachyonException;
 @PublicApi
 @ThreadSafe
 public class KeyValueOutputFormat extends FileOutputFormat<BytesWritable, BytesWritable> {
+  public static TachyonURI getTaskTempOutputDirectoryURI(JobConf conf) throws IOException {
+    return new TachyonURI(FileOutputFormat.getTaskOutputPath(conf, "PLACE_HOLDER").toString())
+        .getParent();
+  }
+
   @Override
   public RecordWriter<BytesWritable, BytesWritable> getRecordWriter(FileSystem ignored,
       JobConf conf, String name, Progressable progress) throws IOException {
-    Path outputPath = FileOutputFormat.getTaskOutputPath(conf, name);
     KeyValueStores kvStore = KeyValueStores.Factory.create();
     try {
-      KeyValueStoreWriter writer = kvStore.create(new TachyonURI(outputPath.toString()));
+      KeyValueStoreWriter writer = kvStore.create(getTaskTempOutputDirectoryURI(conf).join(name));
       return new KeyValueRecordWriter(writer, progress);
     } catch (TachyonException e) {
       throw new IOException(e);

--- a/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueOutputFormat.java
+++ b/keyvalue/clients/src/main/java/tachyon/client/keyvalue/hadoop/KeyValueOutputFormat.java
@@ -48,6 +48,11 @@ import tachyon.exception.TachyonException;
 @PublicApi
 @ThreadSafe
 public class KeyValueOutputFormat extends FileOutputFormat<BytesWritable, BytesWritable> {
+  /**
+   * @param conf the job configuration
+   * @return the temporary output directory for the given job configuration
+   * @throws IOException if the output directory cannot be determined
+   */
   public static TachyonURI getTaskTempOutputDirectoryURI(JobConf conf) throws IOException {
     return new TachyonURI(FileOutputFormat.getTaskOutputPath(conf, "PLACE_HOLDER").toString())
         .getParent();


### PR DESCRIPTION
This is needed to fix the hdfs1 build