### PR TITLE
[SMALLFIX] Use S3 as default ufs when provider is ec2 in vagrant module

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -18,7 +18,7 @@ ZookeeperV = ZookeeperVersion.new('conf/zookeeper.yml')
 MesosV = MesosVersion.new('conf/mesos.yml')
 TachyonV = TachyonVersion.new('conf/tachyon.yml')
 SparkV = SparkVersion.new('conf/spark.yml')
-UfsV = UfsVersion.new('conf/ufs.yml')
+UfsV = UfsVersion.new('conf/ufs.yml', Provider)
 
 require "./core/config_#{Provider}"
 

--- a/deploy/vagrant/conf/ufs.yml
+++ b/deploy/vagrant/conf/ufs.yml
@@ -1,5 +1,7 @@
 # hadoop1 | hadoop2 | glusterfs | s3
-Type: hadoop2
+# If it is not specified, a default value is used.
+# For AWS EC2, the default is s3, for other providers, it is hadoop2.
+Type:
 
 Hadoop:
   # apache: http://archive.apache.org/dist/hadoop/common/hadoop-${Version}/hadoop-${Version}.tar.gz

--- a/deploy/vagrant/core/EnvSetup.rb
+++ b/deploy/vagrant/core/EnvSetup.rb
@@ -329,8 +329,24 @@ class S3Version
 end
 
 class UfsVersion
-  def initialize(yaml_path)
+  def get_default_ufs(provider):
+    case provider
+    when 'vb':
+      puts 'use hadoop2 as default ufs'
+      return 'hadoop2'
+    when 'aws':
+      puts 'use s3 as default ufs'
+      return 's3'
+    else
+      return ''
+    end
+  end
+
+  def initialize(yaml_path, provider)
     @yml = YAML.load_file(yaml_path)
+    if @yml['Type'] == nil
+      @yml['Type'] = get_default_ufs(provider)
+    end
     puts @yml
 
     @hadoop = HadoopVersion.new(nil)


### PR DESCRIPTION
But the S3 bucket still needs to be specified since we could not specify a default bucket name.