### PR TITLE
[TACHYON-1618] Mark members final in tachyon.security.authorization.PermissionStatus

### DIFF
--- a/common/src/main/java/tachyon/security/authorization/PermissionStatus.java
+++ b/common/src/main/java/tachyon/security/authorization/PermissionStatus.java
@@ -33,9 +33,9 @@ import tachyon.util.CommonUtils;
  */
 @ThreadSafe
 public final class PermissionStatus {
-  private String mUserName;
-  private String mGroupName;
-  private FileSystemPermission mPermission;
+  private final String mUserName;
+  private final String mGroupName;
+  private final FileSystemPermission mPermission;
 
   /**
    * Constructs an instance of {@link PermissionStatus}


### PR DESCRIPTION
In tachyon.security.authorization.PermissionStatus, three private members mUserName, mGroupName and mPermission should be marked as final.
https://tachyon.atlassian.net/browse/TACHYON-1618