### PR TITLE
[TACHYON-1675] Fix a ssh problem when deploying EC2 with Vagrant.

### DIFF
--- a/deploy/vagrant/ansible.cfg
+++ b/deploy/vagrant/ansible.cfg
@@ -7,4 +7,5 @@ scp_if_ssh=True
 
 # Work around a ssh error with ansible due to ec2 name length exceeding
 # Unix socket length limit.
+# http://docs.ansible.com/ansible/intro_configuration.html#control-path
 control_path = %(directory)s/%%h-%%r

--- a/deploy/vagrant/ansible.cfg
+++ b/deploy/vagrant/ansible.cfg
@@ -5,3 +5,6 @@ pipelining = True
 [ssh_connection]
 scp_if_ssh=True
 
+# Work around a ssh error with ansible due to ec2 name length exceeding
+# Unix socket length limit.
+control_path = %(directory)s/%%h-%%r


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1675

EC2 instance DNS name length can exceed Unix socket size limit, causing ssh error.
http://docs.ansible.com/ansible/intro_configuration.html#control-path