### PR TITLE
[TACHYON-1656] Add the Chinese version of documentation page 'Running-Tachyon-on-Virtual-Box'

### DIFF
--- a/docs/_data/table/README.md
+++ b/docs/_data/table/README.md
@@ -1,2 +1,0 @@
-This README file is used to let the empty folder can be put on github.
-Once there exists any file in this folder, delete the README.md

--- a/docs/_includes/README.md
+++ b/docs/_includes/README.md
@@ -1,2 +1,0 @@
-This README file is used to let the empty folder can be put on github.
-Once there exists any file in this folder, delete the README.md

--- a/docs/_includes/Running-Tachyon-on-Virtual-Box/destroy.md
+++ b/docs/_includes/Running-Tachyon-on-Virtual-Box/destroy.md
@@ -1,0 +1,3 @@
+```bash
+$ ./destroy
+```

--- a/docs/_includes/Running-Tachyon-on-Virtual-Box/download-tachyon.md
+++ b/docs/_includes/Running-Tachyon-on-Virtual-Box/download-tachyon.md
@@ -1,0 +1,4 @@
+```bash
+$ wget http://tachyon-project.org/downloads/files/{{site.TACHYON_RELEASED_VERSION}}/tachyon-{{site.TACHYON_RELEASED_VERSION}}-bin.tar.gz
+$ tar xvfz tachyon-{{site.TACHYON_RELEASED_VERSION}}-bin.tar.gz
+```

--- a/docs/_includes/Running-Tachyon-on-Virtual-Box/install-pip.md
+++ b/docs/_includes/Running-Tachyon-on-Virtual-Box/install-pip.md
@@ -1,0 +1,3 @@
+```bash
+$ sudo pip install -r pip-req.txt
+```

--- a/docs/_includes/Running-Tachyon-on-Virtual-Box/install-vagrant.md
+++ b/docs/_includes/Running-Tachyon-on-Virtual-Box/install-vagrant.md
@@ -1,0 +1,3 @@
+```bash
+$ sudo bash bin/install.sh
+```

--- a/docs/_includes/Running-Tachyon-on-Virtual-Box/launch-cluster.md
+++ b/docs/_includes/Running-Tachyon-on-Virtual-Box/launch-cluster.md
@@ -1,0 +1,3 @@
+```bash
+./create <number of machines> vb
+```

--- a/docs/_includes/Running-Tachyon-on-Virtual-Box/runTests.md
+++ b/docs/_includes/Running-Tachyon-on-Virtual-Box/runTests.md
@@ -1,0 +1,3 @@
+```bash
+$ /tachyon/bin/tachyon runTests
+```

--- a/docs/_includes/Running-Tachyon-on-Virtual-Box/shell-output.md
+++ b/docs/_includes/Running-Tachyon-on-Virtual-Box/shell-output.md
@@ -1,0 +1,2 @@
+    >>> TachyonMaster public IP is xxx, visit xxx:19999 for Tachyon web UI<<<
+    >>> visit default port of the web UI of what you deployed <<<

--- a/docs/_includes/Running-Tachyon-on-Virtual-Box/ssh-TachyonMaster.md
+++ b/docs/_includes/Running-Tachyon-on-Virtual-Box/ssh-TachyonMaster.md
@@ -1,0 +1,3 @@
+```bash
+$ vagrant ssh TachyonMaster
+```

--- a/docs/_includes/Running-Tachyon-on-Virtual-Box/ssh-other-node.md
+++ b/docs/_includes/Running-Tachyon-on-Virtual-Box/ssh-other-node.md
@@ -1,0 +1,3 @@
+```bash
+$ ssh TachyonWorker1
+```

--- a/docs/_includes/Running-Tachyon-on-Virtual-Box/ssh.md
+++ b/docs/_includes/Running-Tachyon-on-Virtual-Box/ssh.md
@@ -1,0 +1,3 @@
+```bash
+$ vagrant ssh <node name>
+```

--- a/docs/cn/README.md
+++ b/docs/cn/README.md
@@ -1,2 +1,0 @@
-This README file is used to let the empty folder can be put on github.
-Once there exists any file in this folder, delete the README.md

--- a/docs/cn/Running-Tachyon-on-Virtual-Box.md
+++ b/docs/cn/Running-Tachyon-on-Virtual-Box.md
@@ -1,0 +1,90 @@
+---
+layout: global
+title: 在Virtual Box上运行Tachyon
+nickname: 在Virtual Box上运行Tachyon
+group: User Guide
+priority: 2
+---
+通过Tachyon自带的[Vagrant脚本](https://github.com/amplab/tachyon/tree/master/deploy/vagrant)，你可以将Tachyon部署在本地机器上的[VirtualBox](https://www.virtualbox.org/)中。该脚本允许你创建，配置以及销毁集群，该集群自动配置了HDFS相关项。
+
+# 前期准备
+
+**安装VirtualBox**
+
+下载[VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+
+**安装Vagrant**
+
+下载[Vagrant](https://www.vagrantup.com/downloads.html)
+
+**安装Tachyon**
+
+下载Tachyon到本地，并解压：
+
+{% include Running-Tachyon-on-Virtual-Box/download-tachyon.md %}
+
+**安装python库依赖**
+
+安装[python>=2.7](https://www.python.org/)，注意不是python3.
+
+进入`deploy/vagrant`目录下，运行：
+
+{% include Running-Tachyon-on-Virtual-Box/install-vagrant.md %}
+
+另外，你可以选择手动安装[pip](https://pip.pypa.io/en/latest/installing/)，之后进入`deploy/vagrant`目录，运行：
+
+{% include Running-Tachyon-on-Virtual-Box/install-pip.md %}
+
+# 启动集群
+
+现在你可以以Hadoop2.4.1为底层文件系统启动Tachyon集群了，在`deploy/vagrant`目录下运行：
+
+{% include Running-Tachyon-on-Virtual-Box/launch-cluster.md %}
+
+集群中的每个节点运行一个Tachyon worker，`TachyonMaster`节点上运行Tachyon master.
+
+# 访问cluster
+
+**通过Web UI访问**
+
+命令`./create <number of machines> vb`运行成功后，在shell中会输出类似下面的两条语句。
+
+{% include Running-Tachyon-on-Virtual-Box/shell-output.md %}
+
+Tachyon Web UI的默认端口为**19999**。
+
+Hadoop Web UI的默认端口为**50070**。
+
+在浏览器中输入`http://{MASTER_IP}:{PORT}`地址访问Web UI。
+
+**通过ssh访问**
+
+节点的名称依次被设置成`TachyonMaster`, `TachyonWorker1`, `TachyonWorker2`等等。
+
+通过ssh登陆一个节点，运行：
+
+{% include Running-Tachyon-on-Virtual-Box/ssh.md %}
+
+例如，通过以下命令可以登陆`TachyonMaster`节点：
+
+{% include Running-Tachyon-on-Virtual-Box/ssh-TachyonMaster.md %}
+
+所有的软件都安装在根目录下，例如Tachyon安装在`/tachyon`，Hadoop安装在`/hadoop`。
+
+在`TachyonMaster`节点上，可以对Tachyon运行测试检测其健康状态：
+
+{% include Running-Tachyon-on-Virtual-Box/runTests.md %}
+
+在所有测试完成后，再次访问Tachyon的web UI `http://{MASTER_IP}:19999`，在导航栏中点击`Browse File System`，你应该能看到测试过程中写入到Tachyon的文件。
+
+在集群中的某个节点上，可以通过ssh免密码登陆到集群中的其他节点：
+
+{% include Running-Tachyon-on-Virtual-Box/ssh-other-node.md %}
+
+# 销毁集群
+
+在`deploy/vagrant`目录下运行：
+
+{% include Running-Tachyon-on-Virtual-Box/destroy.md %}
+
+从而销毁之前创建的集群。一次只能创建一个集群。当该命令成功执行后，虚拟机将终止运行。

--- a/docs/en/Running-Tachyon-on-Virtual-Box.md
+++ b/docs/en/Running-Tachyon-on-Virtual-Box.md
@@ -25,10 +25,7 @@ Download [Vagrant](https://www.vagrantup.com/downloads.html)
 
 Download Tachyon to your local machine, and unzip it:
 
-```bash
-$ wget http://tachyon-project.org/downloads/files/{{site.TACHYON_RELEASED_VERSION}}/tachyon-{{site.TACHYON_RELEASED_VERSION}}-bin.tar.gz
-$ tar xvfz tachyon-{{site.TACHYON_RELEASED_VERSION}}-bin.tar.gz
-```
+{% include Running-Tachyon-on-Virtual-Box/download-tachyon.md %}
 
 **Install python library dependencies**
 
@@ -36,25 +33,19 @@ Install [python>=2.7](https://www.python.org/), not python3.
 
 Under `deploy/vagrant` directory in your home directory, run:
 
-```bash
-$ sudo bash bin/install.sh
-```
+{% include Running-Tachyon-on-Virtual-Box/install-vagrant.md %}
 
 Alternatively, you can manually install [pip](https://pip.pypa.io/en/latest/installing/), and then
 in `deploy/vagrant` run:
 
-```bash
-$ sudo pip install -r pip-req.txt
-```
+{% include Running-Tachyon-on-Virtual-Box/install-pip.md %}
 
 # Launch a Cluster
 
 Now you can launch the Tachyon cluster with Hadoop2.4.1 as under filesystem by running the script
 under `deploy/vagrant`:
 
-```bash
-./create <number of machines> vb
-```
+{% include Running-Tachyon-on-Virtual-Box/launch-cluster.md %}
 
 Each node of the cluster runs a Tachyon worker, and the `TachyonMaster` runs a Tachyon master.
 
@@ -65,8 +56,7 @@ Each node of the cluster runs a Tachyon worker, and the `TachyonMaster` runs a T
 After the command `./create <number of machines> vb` succeeds, you can see two green lines like
 below shown at the end of the shell output:
 
-    >>> TachyonMaster public IP is xxx, visit xxx:19999 for Tachyon web UI<<<
-    >>> visit default port of the web UI of what you deployed <<<
+{% include Running-Tachyon-on-Virtual-Box/shell-output.md %}
 
 Default port for Tachyon Web UI is **19999**.
 
@@ -80,24 +70,18 @@ The nodes set up are named as `TachyonMaster`, `TachyonWorker1`, `TachyonWorker2
 
 To ssh into a node, run:
 
-```bash
-$ vagrant ssh <node name>
-```
+{% include Running-Tachyon-on-Virtual-Box/ssh.md %}
 
 For example, you can ssh into `TachyonMaster` with:
 
-```bash
-$ vagrant ssh TachyonMaster
-```
+{% include Running-Tachyon-on-Virtual-Box/ssh-TachyonMaster.md %}
 
 All software is installed under the root directory, e.g. Tachyon is installed in `/tachyon`,
 and Hadoop is installed in `/hadoop`.
 
 On the `TachyonMaster` node, you can run tests against Tachyon to check its health:
 
-```bash
-$ /tachyon/bin/tachyon runTests
-```
+{% include Running-Tachyon-on-Virtual-Box/runTests.md %}
 
 After the tests finish, visit Tachyon web UI at `http://{MASTER_IP}:19999` again. Click `Browse
 File System` in the navigation bar, and you should see the files written to Tachyon by the above
@@ -105,17 +89,13 @@ tests.
 
 From a node in the cluster, you can ssh to other nodes in the cluster without password with:
 
-```bash
-$ ssh TachyonWorker1
-```
+{% include Running-Tachyon-on-Virtual-Box/ssh-other-node.md %}
 
 # Destroy the cluster
 
 Under `deploy/vagrant` directory, you can run:
 
-```bash
-$ ./destroy
-```
+{% include Running-Tachyon-on-Virtual-Box/destroy.md %}
 
 to destroy the cluster that you created. Only one cluster can be created at a time. After the
 command succeeds, the virtual machines are terminated.


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1656
Add the Chinese version of documentation page 'Running-Tachyon-on-Virtual-Box'.
And the code fragments in this page have been extracted into `_includes/Running-Tachyon-on-Virtual-Box/` folder.
A new Running-Tachyon-on-Virtual-Box.md page file of Chinese version has been created in `cn/` folder.