### PR TITLE
[TACHYON-1660] Add the Chinese version of documentation page 'Unified-and-Transparent-Namespace'

### DIFF
--- a/docs/_includes/Unified-and-Transparent-Namespace/create-file.md
+++ b/docs/_includes/Unified-and-Transparent-Namespace/create-file.md
@@ -1,0 +1,6 @@
+```bash
+$ ${TACHYON_HOME}/bin/tachyon tfs touch /demo/hello2
+> /demo/hello2 has been created
+$ ls /tmp/tachyon-demo
+> hello hello2
+```

--- a/docs/_includes/Unified-and-Transparent-Namespace/delete.md
+++ b/docs/_includes/Unified-and-Transparent-Namespace/delete.md
@@ -1,0 +1,6 @@
+```bash
+$ ${TACHYON_HOME}/bin/tachyon tfs rm /demo/world
+> /demo/world has been removed
+$ ls /tmp/tachyon-demo
+> hello
+```

--- a/docs/_includes/Unified-and-Transparent-Namespace/ls-demo-hello.md
+++ b/docs/_includes/Unified-and-Transparent-Namespace/ls-demo-hello.md
@@ -1,0 +1,4 @@
+```bash
+$ ${TACHYON_HOME}/bin/tachyon tfs ls /demo/hello
+... # should contain /demo/hello
+```

--- a/docs/_includes/Unified-and-Transparent-Namespace/mkdir.md
+++ b/docs/_includes/Unified-and-Transparent-Namespace/mkdir.md
@@ -1,0 +1,5 @@
+```bash
+$ cd /tmp
+$ mkdir tachyon-demo
+$ touch tachyon-demo/hello
+```

--- a/docs/_includes/Unified-and-Transparent-Namespace/mount-demo.md
+++ b/docs/_includes/Unified-and-Transparent-Namespace/mount-demo.md
@@ -1,0 +1,6 @@
+```bash
+$ ${TACHYON_HOME}/bin/tachyon tfs mount /demo /tmp/tachyon-demo
+> Mounted /tmp/tachyon-demo at /demo
+$ ${TACHYON_HOME}/bin/tachyon tfs lsr /
+... # should contain /demo but not /demo/hello
+```

--- a/docs/_includes/Unified-and-Transparent-Namespace/mounting-API.md
+++ b/docs/_includes/Unified-and-Transparent-Namespace/mounting-API.md
@@ -1,0 +1,4 @@
+```java
+bool mount(String tachyonPath, String ufsPath);
+bool unmount(String tachyonPath);
+```

--- a/docs/_includes/Unified-and-Transparent-Namespace/rename.md
+++ b/docs/_includes/Unified-and-Transparent-Namespace/rename.md
@@ -1,0 +1,6 @@
+```bash
+$ ${TACHYON_HOME}/bin/tachyon tfs mv /demo/hello2 /demo/world
+> Renamed /demo/hello2 to /demo/world
+$ ls /tmp/tachyon-demo
+> hello world
+```

--- a/docs/_includes/Unified-and-Transparent-Namespace/unmount.md
+++ b/docs/_includes/Unified-and-Transparent-Namespace/unmount.md
@@ -1,0 +1,8 @@
+```bash
+${TACHYON_HOME}/bin/tachyon tfs unmount /demo
+> Unmounted /demo
+$ ${TACHYON_HOME}/bin/tachyon tfs lsr /
+... # should not contain /demo
+$ ls /tmp/tachyon-demo
+> hello
+```

--- a/docs/cn/Unified-and-Transparent-Namespace.md
+++ b/docs/cn/Unified-and-Transparent-Namespace.md
@@ -1,0 +1,66 @@
+---
+layout: global
+title: 统一透明命名空间
+nickname: 统一命名空间
+group: Features
+priority: 5
+---
+
+* 内容列表
+{:toc}
+
+通过使用其透明命名机制以及挂载API，Tachyon支持在不同存储系统之间对数据的高效管理。
+
+## 透明命名机制
+
+透明命名机制保证了Tachyon和底层存储系统的命名空间是一致的。
+
+![transparent]({{site.data.img.screenshot_transparent}})
+
+当在Tachyon文件系统中创建对象时，可以选择这些对象是否要在底层存储系统中进行持久化。对于需要持久化的对象，Tachyon会保存底层文件系统存储这些对象的文件夹的路径。例如，一个用户在根目录下创建了一个`Users`目录，其中包含`Alice`和`Bob`两个子目录，底层文件系统（如HDFS或S3）也会保存相同的目录结构和命名。类似的，当用户在Tachyon文件系统中对一个持久化的对象进行重命名或者删除操作时，底层文件系统中对应的对象也会被执行相同的操作。
+
+另外，Tachyon能够搜索到底层文件系统中并非通过Tachyon创建的对象。例如，底层文件系统中包含一个`Data`文件夹，其中包含`Reports`和`Sales`两个文件，它们都不是通过Tachyon创建的，当它们第一次被访问时（例如用户请求打开文件），Tachyon会自动加载这些对象的元数据。然而在该过程中Tachyon不会加载具体文件数据，若要将其加载到Tachyon，可以在第一次读取数据时将`TachyonStorageType`设置成`STORE`，或者通过Tachyon Shell中的`load`命令进行加载。
+
+## 统一命名空间
+
+Tachyon提供了一个挂载API，通过该API能够在Tachyon中访问多个数据源中的数据。
+
+![unified]({{site.data.img.screenshot_unified}})
+
+默认情况下，Tachyon文件系统是挂载到Tachyon配置中`tachyon.underfs.address`指定的目录，该目录代表Tachyon的"primary storage"。另外，用户可以通过挂载API添加和删除数据源。
+
+{% include Unified-and-Transparent-Namespace/mounting-API.md %}
+
+例如，主存储（"primary storage"）可以是HDFS，其中可以包含用户的文件夹；`Data`文件夹可能存储在S3文件系统下，这可以通过`mount(tachyon://host:port/Data, s3://bucket/directory)`命令实现。
+
+## 示例
+
+在该示例中，我们将演示以上提到的特性。该示例假定Tachyon的源代码在`${TACHYON_HOME}`目录中，并且Tachyon正在本地运行。
+
+先在本地文件系统中创建一个临时目录：
+
+{% include Unified-and-Transparent-Namespace/mkdir.md %}
+
+将该目录挂载到Tachyon中，并确认挂载后的目录在Tachyon中存在：
+
+{% include Unified-and-Transparent-Namespace/mount-demo.md %}
+
+验证对于不是通过tachyon创建的对象，当第一次访问它们时，其元数据被加载进入了Tachyon中：
+
+{% include Unified-and-Transparent-Namespace/ls-demo-hello.md %}
+
+在挂载目录下创建一个文件，并确认该文件也被创建在底层文件系统中：
+
+{% include Unified-and-Transparent-Namespace/create-file.md %}
+
+在Tachyon中重命名一个文件，并验证在底层文件系统中该文件也被重命名了：
+
+{% include Unified-and-Transparent-Namespace/rename.md %}
+
+在Tachyon中将该文件删除，然后检查底层文件系统中该文件是否也被删除：
+
+{% include Unified-and-Transparent-Namespace/delete.md %}
+
+最后卸载该挂载目录，并确认该目录已经在Tachyon文件系统中被移除，但原先的数据依然保存在底层文件系统中。
+
+{% include Unified-and-Transparent-Namespace/unmount.md %}

--- a/docs/en/Unified-and-Transparent-Namespace.md
+++ b/docs/en/Unified-and-Transparent-Namespace.md
@@ -47,10 +47,7 @@ By default, Tachyon namespace is mounted onto the directory specified by the
 "primary storage" for Tachyon. In addition, users can use the mounting API to add new and remove
 existing data sources:
 
-```java
-bool mount(String tachyonPath, String ufsPath);
-bool unmount(String tachyonPath);
-```
+{% include Unified-and-Transparent-Namespace/mounting-API.md %}
 
 For example, the primary storage could be HDFS and contains user directories; the `Data` directory
 might be stored in an S3 bucket, which is mounted to the Tachyon namespace through the
@@ -63,66 +60,32 @@ exists in the `${TACHYON_HOME}` directory and that there is an instance of Tachy
 
 First, let's create a temporary directory in the local file system that will use for the example:
 
-```bash
-$ cd /tmp
-$ mkdir tachyon-demo
-$ touch tachyon-demo/hello
-```
+{% include Unified-and-Transparent-Namespace/mkdir.md %}
 
 Next, let's mount the directory created above into Tachyon and verify the mounted directory
 appears in Tachyon:
 
-```bash
-$ ${TACHYON_HOME}/bin/tachyon tfs mount /demo /tmp/tachyon-demo
-> Mounted /tmp/tachyon-demo at /demo
-$ ${TACHYON_HOME}/bin/tachyon tfs lsr /
-... # should contain /demo but not /demo/hello
-```
+{% include Unified-and-Transparent-Namespace/mount-demo.md %}
 
 Next, let's verify that the metadata for content not created through Tachyon is loaded into Tachyon
 the first time the content is accessed:
 
-```bash
-$ ${TACHYON_HOME}/bin/tachyon tfs ls /demo/hello
-... # should contain /demo/hello
-```
+{% include Unified-and-Transparent-Namespace/ls-demo-hello.md %}
 
 Next, let's create a file under the mounted directory and verify the file is created in the underlying
 file system:
 
-```bash
-$ ${TACHYON_HOME}/bin/tachyon tfs touch /demo/hello2
-> /demo/hello2 has been created
-$ ls /tmp/tachyon-demo
-> hello hello2
-```
+{% include Unified-and-Transparent-Namespace/create-file.md %}
 
 Next, let's rename a file in Tachyon and verify the file is renamed in the underlying file system:
 
-```bash
-$ ${TACHYON_HOME}/bin/tachyon tfs mv /demo/hello2 /demo/world
-> Renamed /demo/hello2 to /demo/world
-$ ls /tmp/tachyon-demo
-> hello world
-```
+{% include Unified-and-Transparent-Namespace/rename.md %}
 
 Next, let's delete a file in Tachyon and verify the file is deleted in the underlying file system:
 
-```bash
-$ ${TACHYON_HOME}/bin/tachyon tfs rm /demo/world
-> /demo/world has been removed
-$ ls /tmp/tachyon-demo
-> hello
-```
+{% include Unified-and-Transparent-Namespace/delete.md %}
 
 Finally, let's unmount the mounted directory and verify that the directory is removed from the
 Tachyon namespace, but its content is preserved in the underlying file system:
 
-```bash
-${TACHYON_HOME}/bin/tachyon tfs unmount /demo
-> Unmounted /demo
-$ ${TACHYON_HOME}/bin/tachyon tfs lsr /
-... # should not contain /demo
-$ ls /tmp/tachyon-demo
-> hello
-```
+{% include Unified-and-Transparent-Namespace/unmount.md %}


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1660
Add the Chinese version of documentation page 'Unified-and-Transparent-Namespace'
![1660](https://cloud.githubusercontent.com/assets/15154819/12644624/1a17417c-c5ff-11e5-91b7-0e4b3f0bca12.png)
