### PR TITLE
[Tachyon 1646] Add the Chinese version of documentation page 'Mounting-Tachyon-FS-with-FUSE'

### DIFF
--- a/docs/_data/table/Tachyon-FUSE-parameter.csv
+++ b/docs/_data/table/Tachyon-FUSE-parameter.csv
@@ -1,0 +1,7 @@
+parameter,defaultValue
+tachyon.fuse.maxwrite.bytes,131072
+tachyon.fuse.debug.enabled,false
+tachyon.fuse.cachedpaths.max,500
+tachyon.fuse.mount.default,/mnt/tachyon
+tachyon.fuse.fs.root,/mnt
+tachyon.fuse.fs.name,tachyon-fuse

--- a/docs/_data/table/cn/README.md
+++ b/docs/_data/table/cn/README.md
@@ -1,2 +1,0 @@
-This README file is used to let the empty folder can be put on github.
-Once there exists any file in this folder, delete the README.md

--- a/docs/_data/table/cn/Tachyon-FUSE-parameter.yml
+++ b/docs/_data/table/cn/Tachyon-FUSE-parameter.yml
@@ -1,15 +1,12 @@
 tachyon.fuse.maxwrite.bytes:
-  The desired granularity of FUSE write upcalls in bytes. Note that 128K is currently an upper
-  bound imposed by the linux kernel.
+  FUSE写操作的粒度（bytes），注意目前128KB是linux内核限制的上界。
 tachyon.fuse.debug.enabled:
-  Enable FUSE debug output. This output will be redirected in a `fuse.out` log file inside
-  `tachyon.logs.dir`.
+  允许FUSE调试输出， 该输出会被重定向到`tachyon.logs.dir`指定目录中的`fuse.out`日志文件。
 tachyon.fuse.cachedpaths.max:
-  Defines the size of the internal Tachyon-FUSE cache that maintains the most frequently used
-  translations between local file system paths and Tachyon file URIs.
+  定义Tachyon-FUSE内部缓存的大小，该缓存用于存储最频繁使用的本地文件系统路径与Tachyon文件URI的对应关系。
 tachyon.fuse.mount.default:
-  Default mount point, only used when the user does not specify something else at mount time.
+  默认挂载点，只有当用户在挂载时未指定其他值时使用。
 tachyon.fuse.fs.root:
-  Path, within the Tachyon namespace, that will be used as the root of the FUSE mount.
+  Tachyon文件系统中的路径，该路径被当作FUSE挂载的根路径。
 tachyon.fuse.fs.name:
-  Descriptive name used by FUSE to mount the file system.
+  FUSE挂载文件系统使用的描述性名称。

--- a/docs/_data/table/cn/Tachyon-FUSE-parameter.yml
+++ b/docs/_data/table/cn/Tachyon-FUSE-parameter.yml
@@ -1,0 +1,15 @@
+tachyon.fuse.maxwrite.bytes:
+  The desired granularity of FUSE write upcalls in bytes. Note that 128K is currently an upper
+  bound imposed by the linux kernel.
+tachyon.fuse.debug.enabled:
+  Enable FUSE debug output. This output will be redirected in a `fuse.out` log file inside
+  `tachyon.logs.dir`.
+tachyon.fuse.cachedpaths.max:
+  Defines the size of the internal Tachyon-FUSE cache that maintains the most frequently used
+  translations between local file system paths and Tachyon file URIs.
+tachyon.fuse.mount.default:
+  Default mount point, only used when the user does not specify something else at mount time.
+tachyon.fuse.fs.root:
+  Path, within the Tachyon namespace, that will be used as the root of the FUSE mount.
+tachyon.fuse.fs.name:
+  Descriptive name used by FUSE to mount the file system.

--- a/docs/_data/table/en/README.md
+++ b/docs/_data/table/en/README.md
@@ -1,2 +1,0 @@
-This README file is used to let the empty folder can be put on github.
-Once there exists any file in this folder, delete the README.md

--- a/docs/_data/table/en/Tachyon-FUSE-parameter.yml
+++ b/docs/_data/table/en/Tachyon-FUSE-parameter.yml
@@ -1,0 +1,15 @@
+tachyon.fuse.maxwrite.bytes:
+  The desired granularity of FUSE write upcalls in bytes. Note that 128K is currently an upper
+  bound imposed by the linux kernel.
+tachyon.fuse.debug.enabled:
+  Enable FUSE debug output. This output will be redirected in a `fuse.out` log file inside
+  `tachyon.logs.dir`.
+tachyon.fuse.cachedpaths.max:
+  Defines the size of the internal Tachyon-FUSE cache that maintains the most frequently used
+  translations between local file system paths and Tachyon file URIs.
+tachyon.fuse.mount.default:
+  Default mount point, only used when the user does not specify something else at mount time.
+tachyon.fuse.fs.root:
+  Path, within the Tachyon namespace, that will be used as the root of the FUSE mount.
+tachyon.fuse.fs.name:
+  Descriptive name used by FUSE to mount the file system.

--- a/docs/_includes/Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-mount.md
+++ b/docs/_includes/Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-mount.md
@@ -1,0 +1,3 @@
+```bash
+$ bin/tachyon-fuse.sh mount <mount_point>
+```

--- a/docs/_includes/Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-stat.md
+++ b/docs/_includes/Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-stat.md
@@ -1,0 +1,3 @@
+```bash
+$ bin/tachyon-fuse.sh stat
+```

--- a/docs/_includes/Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-umount.md
+++ b/docs/_includes/Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-umount.md
@@ -1,0 +1,3 @@
+```bash
+$ bin/tachyon-fuse.sh umount
+```

--- a/docs/cn/Mounting-Tachyon-FS-with-FUSE.md
+++ b/docs/cn/Mounting-Tachyon-FS-with-FUSE.md
@@ -11,7 +11,7 @@ priority: 4
 
 Tachyon-FUSE是一个新的处于实验阶段的特性，该特性允许在一台Linux机器上的本地文件系统中挂载一个Tachyon分布式文件系统。通过使用该特性，标注的工具（例如`ls`、 `cat`以及`echo`）和传统的POSIX应用程序都能够访问Tachyon分布式文件系统中的数据。
 
-由于Tachyon固有的属性，例如它的write-once/read-many-times文件数据模型，该挂载的文件系统并不完全符合POSIX标准，有一定的局限性。因此，在使用该特性之前，请先阅读本页面余下的内容，从而了解该特性的作业以及局限。
+由于Tachyon固有的属性，例如它的write-once/read-many-times文件数据模型，该挂载的文件系统并不完全符合POSIX标准，有一定的局限性。因此，在使用该特性之前，请先阅读本页面余下的内容，从而了解该特性的作用以及局限。
 
 # 安装依赖
 
@@ -68,7 +68,7 @@ Tachyon-FUSE是基于标准的tachyon-client进行操作的。你也许想像使
 ## `open(const char* pathname, int flags, mode_t mode)`
 (see also `man 2 open`)
 
-如果`pathname`为一个Tachyon中不存在的文件，那么open操作只有在一下条件满足时才会成功：
+如果`pathname`为一个Tachyon中不存在的文件，那么open操作只有在以下条件满足时才会成功：
 
 1. `pathname`的基目录在Tachyon中存在;
 2. `O_CREAT`和`O_WRONLY`被传递到`flags`位字段中。
@@ -76,6 +76,7 @@ Tachyon-FUSE是基于标准的tachyon-client进行操作的。你也许想像使
 同样的，当(1)满足并且`pathname`不存在时，`creat(const char* pathname )`操作会成功。
 
 如果`pathname`为一个Tachyon中存在的文件，那么open操作只有当以下条件满足时才会成功：
+
 1. `O_RDONLY`被传递到`flags`位字段中。
 
 注意，无论哪种情况，目前Tachyon-FUSE会忽略`mode`参数。
@@ -97,7 +98,7 @@ Seek操作只支持用于读的文件，即在指定`O_RDONLY` flags方式下被
 
 # 性能考虑
 
-由于FUSE和JNR的配合使用，与直接使用tachyon-client相比，使用挂载文件系统的性能会相当差。也就是说，如果你在乎的更多是性能而不是这个功能，那么不应当使用Tachyon-FUSE。
+由于FUSE和JNR的配合使用，与直接使用tachyon-client相比，使用挂载文件系统的性能会相对较差。也就是说，如果你在乎的更多是性能而不是这个功能，那么不应当使用Tachyon-FUSE。
 
 大多数性能问题的原因在于，每次进行`read`或`write`操作时，内存中都存在若干个副本，并且FUSE将写操作的最大粒度设置为128KB。其性能可以利用kernel 3.15引入的FUSE回写(write-backs)缓存策略从而得到大幅提高（但该特性目前尚不被libfuse 2.x用户空间库支持）。
 

--- a/docs/cn/Mounting-Tachyon-FS-with-FUSE.md
+++ b/docs/cn/Mounting-Tachyon-FS-with-FUSE.md
@@ -1,0 +1,121 @@
+---
+layout: global
+title: 使用FUSE挂载Tachyon (Beta)
+nickname: Tachyon-FUSE
+group: Features
+priority: 4
+---
+
+* Table of Contents
+{:toc}
+
+Tachyon-FUSE是一个新的处于实验阶段的特性，该特性允许在一台Linux机器上的本地文件系统中挂载一个Tachyon分布式文件系统。通过使用该特性，标注的工具（例如`ls`、 `cat`以及`echo`）和传统的POSIX应用程序都能够访问Tachyon分布式文件系统中的数据。
+
+由于Tachyon固有的属性，例如它的write-once/read-many-times文件数据模型，该挂载的文件系统并不完全符合POSIX标准，有一定的局限性。因此，在使用该特性之前，请先阅读本页面余下的内容，从而了解该特性的作业以及局限。
+
+# 安装依赖
+
+* Linux kernel 2.6.9及以上
+* JDK 1.8及以上
+* libfuse 2.9.3及以上
+  (2.8.3也能够工作，但会提示一些警告)
+
+# 构建
+
+在编译Tachyon源码过程中，只有当maven的`buildFuse`设置开启时，tachyon-fuse才会被构建。当使用JDK 1.8及以上编译Tachyon源码时该设置会自动开启。
+
+为了保持与JAVA 6和7的兼容性，预编译的tachyon二进制文件并不支持tachyon-fuse，因此若需要在部署中使用tachyon-fuse，你需要自己构建Tachyon。
+
+最好的方式是从Tachyon [GitHub repository](https://github.com/amplab/tachyon)处获取你需要的分支的源码，或者直接从[source distribution](https://github.com/amplab/tachyon/releases)处获取，请参考[该页面](Building-Tachyon-Master-Branch.html)进行构建。
+
+# 用法
+
+## 挂载Tachyon-FUSE
+
+在完成配置以及启动Tachyon集群后，在需要挂载Tachyon的节点上启动Shell并进入`$TACHYON_HOME`目录，再运行
+
+{% include Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-mount.md %}
+
+该命令会启动一个后台java进程，用于将Tachyon挂载到`<mount_point>`指定的路径。注意`<mount_point>`必须是本地文件系统中的一个空文件夹，并且该用户拥有该挂载点及对其的读写权限。另外，目前每个节点上只能挂载一个Tachyon-FUSE。
+
+## 卸载Tachyon-FUSE
+
+要卸载Tachyon-FUSE时，在该节点上启动Shell并进入`$TACHYON_HOME`目录，再运行：
+
+{% include Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-umount.md %}
+
+该命令将终止tachyon-fuse java后台进程，并卸载该文件系统。
+
+## 检查Tachyon-FUSE是否在运行
+
+{% include Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-stat.md %}
+
+## 可选配置
+
+Tachyon-FUSE是基于标准的tachyon-client进行操作的。你也许想像使用其他应用的client一样，自定义该tachyon-client的行为。
+
+一种方法是编辑`$TACHYON_HOME/bin/tachyon-fuse.sh`配置文件，将特定的配置项添加到`TACHYON_JAVA_OPTS`变量中。
+
+# 操作前提和状态
+
+目前，tachyon-fuse支持大多数基本文件系统的操作。然而，由于Tachyon某些内在的特性，一定要清楚：
+
+* 文件只能顺序地写入一次，并且无法修改;
+* 由于以上的限制，文件只有只读访问方法。
+
+下面说明作用于文件系统的UNIX系统调用受到的限制条件。
+
+## `open(const char* pathname, int flags, mode_t mode)`
+(see also `man 2 open`)
+
+如果`pathname`为一个Tachyon中不存在的文件，那么open操作只有在一下条件满足时才会成功：
+
+1. `pathname`的基目录在Tachyon中存在;
+2. `O_CREAT`和`O_WRONLY`被传递到`flags`位字段中。
+
+同样的，当(1)满足并且`pathname`不存在时，`creat(const char* pathname )`操作会成功。
+
+如果`pathname`为一个Tachyon中存在的文件，那么open操作只有当以下条件满足时才会成功：
+1. `O_RDONLY`被传递到`flags`位字段中。
+
+注意，无论哪种情况，目前Tachyon-FUSE会忽略`mode`参数。
+
+## `read(int fd, void* buf, size_t count)`
+(see also `man 2 read`)
+
+只有当`fd`指向的文件已经在指定`O_RDONLY` flags方式下被打开时，read操作才会成功。
+
+## `lseek(int fd, off_t off, int whence)`
+(see also `man 2 lseek`)
+
+Seek操作只支持用于读的文件，即在指定`O_RDONLY` flags方式下被打开的文件。
+
+## `write(int fd, const void* buf, size_t count)`
+(see also `man 2 write`)
+
+只有当`fd`指向的文件已经在指定`O_WRONLY` flags方式下被打开时，write操作才会成功。
+
+# 性能考虑
+
+由于FUSE和JNR的配合使用，与直接使用tachyon-client相比，使用挂载文件系统的性能会相当差。也就是说，如果你在乎的更多是性能而不是这个功能，那么不应当使用Tachyon-FUSE。
+
+大多数性能问题的原因在于，每次进行`read`或`write`操作时，内存中都存在若干个副本，并且FUSE将写操作的最大粒度设置为128KB。其性能可以利用kernel 3.15引入的FUSE回写(write-backs)缓存策略从而得到大幅提高（但该特性目前尚不被libfuse 2.x用户空间库支持）。
+
+# Tachyon-FUSE配置参数
+
+以下是Tachyon-FUSE的配置参数。
+
+<table class="table table-striped">
+<tr><th>参数</th><th>默认值</th><th>描述</th></tr>
+{% for item in site.data.table.Tachyon-FUSE-parameter %}
+  <tr>
+    <td>{{ item.parameter }}</td>
+    <td>{{ item.defaultValue }}</td>
+    <td>{{ site.data.table.en.Tachyon-FUSE-parameter.[item.parameter] }}</td>
+  </tr>
+{% endfor %}
+</table>
+
+# 致谢
+
+该项目使用[jnr-fuse](https://github.com/SerCeMan/jnr-fuse)以支持基于Java的FUSE。

--- a/docs/cn/Mounting-Tachyon-FS-with-FUSE.md
+++ b/docs/cn/Mounting-Tachyon-FS-with-FUSE.md
@@ -111,7 +111,7 @@ Seek操作只支持用于读的文件，即在指定`O_RDONLY` flags方式下被
   <tr>
     <td>{{ item.parameter }}</td>
     <td>{{ item.defaultValue }}</td>
-    <td>{{ site.data.table.en.Tachyon-FUSE-parameter.[item.parameter] }}</td>
+    <td>{{ site.data.table.cn.Tachyon-FUSE-parameter.[item.parameter] }}</td>
   </tr>
 {% endfor %}
 </table>

--- a/docs/en/Mounting-Tachyon-FS-with-FUSE.md
+++ b/docs/en/Mounting-Tachyon-FS-with-FUSE.md
@@ -20,12 +20,14 @@ limitations.  Please, read the rest of this document before using this feature t
 what it can and cannot do for you.
 
 # Requirements
+
 * Linux kernel 2.6.9 or newer
 * JDK 1.8 or newer
 * libfuse 2.9.3 or newer
   (2.8.3 has been reported to also work - with some warnings)
 
 # Building
+
 tachyon-fuse is only built with Tachyon when the `buildFuse` maven profile is active. This
 profile will be automatically activated by maven when it is detected that you are building
 Tachyon with a JDK version 8 or newer.
@@ -37,37 +39,39 @@ deployment.
 The best way to do so is to either clone the Tachyon [GitHub
 repository](https://github.com/amplab/tachyon) and choose your favourite branch from git, or to
 grab a [source distribution](https://github.com/amplab/tachyon/releases) directly. Please, refer to
-[this page](http://tachyon-project.org/documentation/master/Building-Tachyon-Master-Branch.html))
+[this page](Building-Tachyon-Master-Branch.html))
 for building instructions.
 
 # Usage
 
 ## Mount Tachyon-FUSE
+
 After having properly configured and started the tachyon cluster, and from the node where you
 wish to mount Tachyon, point a shell to your `$TACHYON_HOME` and run:
-```bash
-$ bin/tachyon-fuse.sh mount <mount_point>
-```
+
+{% include Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-mount.md %}
+
 This will spawn a background user-space java process (tachyon-fuse) that will mount the file
-system on the specified *<mount_point>*. Note that *<mount_point>* must be an existing and empty
+system on the specified `<mount_point>`. Note that `<mount_point>` must be an existing and empty
 path in your local file system hierarchy and that the user that runs the `tachyon-fuse.sh`
 script must own the mount point and have read and write permissions on it. Also note that,
 currently, you are limited to have only one Tachyon-FUSE mount per node.
 
 ## Unmount Tachyon-FUSE
+
 To umount a previoulsy mounted Tachyon-FUSE file sytem, on the node where the file system is
 mounted, point a shell to your `$TACHYON_HOME` and run:
-```bash
-$ bin/tachyon-fuse.sh umount
-```
+
+{% include Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-umount.md %}
+
 This will stop the background tachyon-fuse java process and unmount the file system.
 
 ## Check if Tachyon-FUSE is running
-```bash
-$ bin/tachyon-fuse.sh stat
-```
+
+{% include Mounting-Tachyon-FS-with-FUSE/tachyon-fuse-stat.md %}
 
 ## Optional configuration steps
+
 Tachyon-FUSE is based on the standard java tachyon-client to perform its operations. You might
 want to customize the behaviour of the tachyon client used by Tachyon-FUSE the same way you
 would for any other client application.
@@ -76,8 +80,10 @@ One possibility, for example, is to edit `$TACHYON_HOME/bin/tachyon-fuse.sh` and
 specific tachyon client options in the `TACHYON_JAVA_OPTS` variable.
 
 # Operational assumptions and status
+
 Currently, most basic file system operations are supported. However, due to Tachyon implicit
 characteristics, please, be aware that:
+
 * Files can be written only once, only sequentially, and never modified.
 * Due to the above, any further access to a file must be read-only.
 
@@ -89,6 +95,7 @@ file system:
 
 If `pathname` indicates the path of a non-existing regular file in Tachyon, then an open will
 only succeed if:
+
 1. The base directory of `pathname` exists in Tachyon;
 2. `O_CREAT` and `O_WRONLY` are passed among the `flags` bitfield.
 
@@ -97,6 +104,7 @@ Equivalently, `creat(const char* pathname )` calls will succeed as long as (1) h
 
 If `pathname`, instead, points to an existing regular file in Tachyon, then an open call will
 only succeed if:
+
 1. `O_RDONLY` is passed among the `flags` bitfield.
 
 Note that, in either cases, the `mode` parameter is currently ignored by Tachyon-FUSE.
@@ -120,6 +128,7 @@ A write system call will only succeed when `fd` refers to a Tachyon file that ha
 opened  with the `O_WRONLY` flag.
 
 # Performance considerations
+
 Due to the conjunct use of FUSE and JNR, the performance of the mounted file system is expected
 to be considerably worse than what you would see by using the `tachyon-client` directly. In other
 words, if you are concerned about performance rather then functionality, then Tachyon-FUSE is
@@ -136,53 +145,15 @@ These are the configuration parameters for Tachyon-FUSE.
 
 <table class="table table-striped">
 <tr><th>Parameter</th><th>Default Value</th><th>Description</th></tr>
-<tr>
-  <td>tachyon.fuse.maxwrite.bytes</td>
-  <td>131072</td>
-  <td>
-  The desired granularity of FUSE write upcalls in bytes. Note that 128K is currently an upper
-  bound imposed by the linux kernel.
-  </td>
-</tr>
-<tr>
-  <td>tachyon.fuse.debug.enabled</td>
-  <td>false</td>
-  <td>
-  Enable FUSE debug output. This output will be redirected in a `fuse.out` log file inside
-  `tachyon.logs.dir`.
-  </td>
-</tr>
-<tr>
-  <td>tachyon.fuse.cachedpaths.max</td>
-  <td>500</td>
-  <td>
-  Defines the size of the internal Tachyon-FUSE cache that maintains the most frequently used
-  translations between local file system paths and Tachyon file URIs.
-  </td>
-</tr>
-<tr>
-  <td>tachyon.fuse.mount.default</td>
-  <td>/mnt/tachyon</td>
-  <td>
-  Default mount point, only used when the user does not specify something else at mount time.
-  </td>
-</tr>
-<tr>
-  <td>tachyon.fuse.fs.root</td>
-  <td>/mnt</td>
-  <td>
-  Path, within the Tachyon namespace, that will be used as the root of the FUSE mount.
-  </td>
-</tr>
-<tr>
-  <td>tachyon.fuse.fs.name</td>
-  <td>tachyon-fuse</td>
-  <td>
-  Descriptive name used by FUSE to mount the file system.
-  </td>
-</tr>
+{% for item in site.data.table.Tachyon-FUSE-parameter %}
+  <tr>
+    <td>{{ item.parameter }}</td>
+    <td>{{ item.defaultValue }}</td>
+    <td>{{ site.data.table.en.Tachyon-FUSE-parameter.[item.parameter] }}</td>
+  </tr>
+{% endfor %}
 </table>
 
 # Acknowledgements
-This project uses [jnr-fuse](https://github.com/SerCeMan/jnr-fuse) for FUSE on Java.
 
+This project uses [jnr-fuse](https://github.com/SerCeMan/jnr-fuse) for FUSE on Java.


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1646
Add the Chinese version of documentation page 'Mounting-Tachyon-FS-with-FUSE'
Also correct some md grammar mistakes in `Mounting-Tachyon-FS-with-FUSE.md` in `en/`
Most tables in the site have three columns, with first two (i.e. property name and default value) being language-independent and last one (description) being language-specific. I extract the language-independent parts into a `.csv` file and write the language-specific parts in a `.yml` file.