### PR TITLE
[TACHYON-1623] Remove ClientContext.reset

### DIFF
--- a/core/client-internal/pom.xml
+++ b/core/client-internal/pom.xml
@@ -49,4 +49,22 @@
       <artifactId>annotations</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Export test classes in a test-jar so that other projects can use them for testing -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/core/client-internal/src/main/java/tachyon/client/ClientContext.java
+++ b/core/client-internal/src/main/java/tachyon/client/ClientContext.java
@@ -45,6 +45,8 @@ public final class ClientContext {
 
   /**
    * Resets to the default Tachyon configuration and initializes the client context singleton.
+   *
+   * This method is useful for undoing changes to TachyonConf made by unit tests.
    */
   private static void reset() {
     sTachyonConf = new TachyonConf();
@@ -52,7 +54,11 @@ public final class ClientContext {
   }
 
   /**
-   * Initializes the client context singleton.
+   * Initializes the client context singleton, bringing all non-TachyonConf state into sync with
+   * the current TachyonConf.
+   *
+   * This method is useful for updating parts of {@link ClientContext} which depend on
+   * {@link TachyonConf} when {@link TachyonConf} is changed, e.g. the master hostname or port.
    */
   private static void init() {
     String masterHostname = Preconditions.checkNotNull(sTachyonConf.get(Constants.MASTER_HOSTNAME));

--- a/core/client-internal/src/main/java/tachyon/client/ClientContext.java
+++ b/core/client-internal/src/main/java/tachyon/client/ClientContext.java
@@ -24,11 +24,7 @@ import javax.annotation.concurrent.ThreadSafe;
 import com.google.common.base.Preconditions;
 
 import tachyon.Constants;
-import tachyon.client.block.BlockStoreContext;
-import tachyon.client.file.FileSystemContext;
-import tachyon.client.lineage.LineageContext;
 import tachyon.conf.TachyonConf;
-import tachyon.exception.PreconditionMessage;
 import tachyon.util.ThreadFactoryUtils;
 import tachyon.worker.ClientMetrics;
 
@@ -42,84 +38,54 @@ public final class ClientContext {
   private static TachyonConf sTachyonConf;
   private static InetSocketAddress sMasterAddress;
   private static ClientMetrics sClientMetrics;
-  private static boolean sInitialized;
 
   static {
-    sInitialized = false;
     reset();
   }
 
   /**
    * Initializes the client context singleton.
    */
-  public static synchronized void reset() {
-    reset(new TachyonConf());
-  }
-
-  /**
-   * Initializes the client context singleton with a given conf.
-   *
-   * @param conf the configuration of Tachyon
-   */
-  public static synchronized void reset(TachyonConf conf) {
-    sTachyonConf = conf;
+  private static void reset() {
+    sTachyonConf = new TachyonConf();
 
     String masterHostname = Preconditions.checkNotNull(sTachyonConf.get(Constants.MASTER_HOSTNAME));
     int masterPort = sTachyonConf.getInt(Constants.MASTER_RPC_PORT);
-
     sMasterAddress = new InetSocketAddress(masterHostname, masterPort);
+
     sClientMetrics = new ClientMetrics();
 
-    if (sExecutorService != null) {
-      sExecutorService.shutdownNow();
-    }
     sExecutorService = Executors.newFixedThreadPool(
         sTachyonConf.getInt(Constants.USER_BLOCK_WORKER_CLIENT_THREADS),
         ThreadFactoryUtils.build("block-worker-heartbeat-%d", true));
-    // If this isn't the first time setting the ClientContext, we should reset other contexts so
-    // that they can see the latest changes
-    if (sInitialized) {
-      BlockStoreContext.INSTANCE.reset();
-      FileSystemContext.INSTANCE.reset();
-      LineageContext.INSTANCE.reset();
-    }
-    sInitialized = true;
   }
 
   /**
    * @return the {@link TachyonConf} for the client process
    */
-  public static synchronized TachyonConf getConf() {
-    checkContextInitialized();
+  public static TachyonConf getConf() {
     return sTachyonConf;
   }
 
   /**
    * @return the {@link ClientMetrics} for this client
    */
-  public static synchronized ClientMetrics getClientMetrics() {
-    checkContextInitialized();
+  public static ClientMetrics getClientMetrics() {
     return sClientMetrics;
   }
 
   /**
    * @return the master address
    */
-  public static synchronized InetSocketAddress getMasterAddress() {
-    checkContextInitialized();
+  public static InetSocketAddress getMasterAddress() {
     return sMasterAddress;
   }
 
   /**
    * @return the executor service
    */
-  public static synchronized ExecutorService getExecutorService() {
-    checkContextInitialized();
+  public static ExecutorService getExecutorService() {
     return sExecutorService;
-  }
-
-  private static void checkContextInitialized() {
-    Preconditions.checkState(sInitialized, PreconditionMessage.CLIENT_CONTEXT_NOT_INITIALIZED);
   }
 
   private ClientContext() {} // prevent instantiation

--- a/core/client-internal/src/main/java/tachyon/client/ClientContext.java
+++ b/core/client-internal/src/main/java/tachyon/client/ClientContext.java
@@ -58,7 +58,8 @@ public final class ClientContext {
    * the current TachyonConf.
    *
    * This method is useful for updating parts of {@link ClientContext} which depend on
-   * {@link TachyonConf} when {@link TachyonConf} is changed, e.g. the master hostname or port.
+   * {@link TachyonConf} when {@link TachyonConf} is changed, e.g. the master hostname or port. This
+   * method requires that {@link sTachyonConf} has been initialized.
    */
   private static void init() {
     String masterHostname = Preconditions.checkNotNull(sTachyonConf.get(Constants.MASTER_HOSTNAME));

--- a/core/client-internal/src/main/java/tachyon/client/ClientContext.java
+++ b/core/client-internal/src/main/java/tachyon/client/ClientContext.java
@@ -44,11 +44,17 @@ public final class ClientContext {
   }
 
   /**
-   * Initializes the client context singleton.
+   * Resets to the default Tachyon configuration and initializes the client context singleton.
    */
   private static void reset() {
     sTachyonConf = new TachyonConf();
+    init();
+  }
 
+  /**
+   * Initializes the client context singleton.
+   */
+  private static void init() {
     String masterHostname = Preconditions.checkNotNull(sTachyonConf.get(Constants.MASTER_HOSTNAME));
     int masterPort = sTachyonConf.getInt(Constants.MASTER_RPC_PORT);
     sMasterAddress = new InetSocketAddress(masterHostname, masterPort);

--- a/core/client-internal/src/main/java/tachyon/hadoop/AbstractTFS.java
+++ b/core/client-internal/src/main/java/tachyon/hadoop/AbstractTFS.java
@@ -83,7 +83,6 @@ abstract class AbstractTFS extends org.apache.hadoop.fs.FileSystem {
   private Statistics mStatistics = null;
   private FileSystem mFileSystem = null;
   private String mTachyonHeader = null;
-  private final TachyonConf mTachyonConf = ClientContext.getConf();
 
   @Override
   public FSDataOutputStream append(Path cPath, int bufferSize, Progressable progress)
@@ -238,7 +237,7 @@ abstract class AbstractTFS extends org.apache.hadoop.fs.FileSystem {
 
   @Override
   public long getDefaultBlockSize() {
-    return mTachyonConf.getBytes(Constants.USER_BLOCK_SIZE_BYTES_DEFAULT);
+    return ClientContext.getConf().getBytes(Constants.USER_BLOCK_SIZE_BYTES_DEFAULT);
   }
 
   @Override
@@ -424,13 +423,14 @@ abstract class AbstractTFS extends org.apache.hadoop.fs.FileSystem {
 
     // Load TachyonConf if any and merge to the one in TachyonFS
     TachyonConf siteConf = ConfUtils.loadFromHadoopConfiguration(conf);
+    // These modifications to ClientContext are global, affecting every Tachyon client in this JVM.
+    // We assume here that this client is the only client.
     if (siteConf != null) {
-      mTachyonConf.merge(siteConf);
+      ClientContext.getConf().merge(siteConf);
     }
-    mTachyonConf.set(Constants.MASTER_HOSTNAME, uri.getHost());
-    mTachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
-    mTachyonConf.set(Constants.ZOOKEEPER_ENABLED, Boolean.toString(isZookeeperMode()));
-    ClientContext.reset(mTachyonConf);
+    ClientContext.getConf().set(Constants.MASTER_HOSTNAME, uri.getHost());
+    ClientContext.getConf().set(Constants.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
+    ClientContext.getConf().set(Constants.ZOOKEEPER_ENABLED, Boolean.toString(isZookeeperMode()));
 
     mFileSystem = FileSystem.Factory.get();
     mUri = URI.create(mTachyonHeader);

--- a/core/client-internal/src/test/java/tachyon/client/block/BlockMasterClientTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/block/BlockMasterClientTest.java
@@ -26,7 +26,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 import tachyon.Constants;
-import tachyon.client.ClientContext;
 import tachyon.exception.ExceptionMessage;
 import tachyon.thrift.BlockMasterClientService;
 
@@ -44,9 +43,6 @@ public class BlockMasterClientTest {
    */
   @Test
   public void unsupportedVersionTest() throws Exception {
-    // Client context needs to be initialized before the block store context can be used.
-    ClientContext.reset();
-
     BlockMasterClientService.Client mock = PowerMockito.mock(BlockMasterClientService.Client.class);
     PowerMockito.when(mock.getServiceVersion()).thenReturn(0L);
 

--- a/core/client-internal/src/test/java/tachyon/client/block/TachyonBlockStoreTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/block/TachyonBlockStoreTest.java
@@ -31,7 +31,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
-import tachyon.client.ClientContext;
 import tachyon.conf.TachyonConf;
 import tachyon.thrift.BlockInfo;
 import tachyon.thrift.BlockLocation;
@@ -97,7 +96,6 @@ public final class TachyonBlockStoreTest {
   public void before() throws Exception {
     mTestFile = mTestFolder.newFile("testFile");
 
-    ClientContext.reset();
     mBlockStoreContext = PowerMockito.mock(BlockStoreContext.class);
     Whitebox.setInternalState(BlockStoreContext.class, "INSTANCE", mBlockStoreContext);
     mBlockStore = TachyonBlockStore.get();

--- a/core/client-internal/src/test/java/tachyon/client/block/TachyonBlockStoreTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/block/TachyonBlockStoreTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -74,41 +75,37 @@ public final class TachyonBlockStoreTest {
   @Rule
   public TemporaryFolder mTestFolder = new TemporaryFolder();
 
-  private File mTestFile;
-  private TachyonBlockStore mBlockStore;
-  private BlockStoreContext mBlockStoreContext;
-  private BlockMasterClient mMasterClient;
-  private BlockWorkerClient mBlockWorkerClient;
+  private static BlockStoreContext sBlockStoreContext;
+  private static TachyonBlockStore sBlockStore;
+  private static BlockMasterClient sMasterClient;
+  private static BlockWorkerClient sBlockWorkerClient;
 
-  /**
-   * Sets up a testable {@link TachyonBlockStore}. Setup consists of the following:
-   *
-   * 1. The singleton {@link BlockStoreContext} is replaced with {@link #mBlockStoreContext}<br>
-   * 2. {@link #mBlockStoreContext} will return {@link #mMasterClient} and
-   *    {@link #mBlockWorkerClient} when asked for master/worker clients<br>
-   * 3. {@link #mTestFile} is created inside {@link #mTestFolder}<br>
-   * 4. {@link #mBlockWorkerClient} is made to understand that locking {@link #BLOCK_ID} should
-   *    return the path to {@link #mTestFile}.
-   *
-   * @throws Exception when acquiring a worker client fails
-   */
+  private File mTestFile;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    // Replace the singleton BlockStoreContext.INSTANCE with a mock we can control
+    sBlockStoreContext = PowerMockito.mock(BlockStoreContext.class);
+    Whitebox.setInternalState(BlockStoreContext.class, "INSTANCE", sBlockStoreContext);
+
+    // Mock block store should return our mock clients
+    sBlockWorkerClient = PowerMockito.mock(BlockWorkerClient.class);
+    Mockito.when(sBlockStoreContext.acquireWorkerClient(Mockito.anyString()))
+        .thenReturn(sBlockWorkerClient);
+    sMasterClient = PowerMockito.mock(BlockMasterClient.class);
+    Mockito.when(sBlockStoreContext.acquireMasterClient()).thenReturn(sMasterClient);
+
+    // Inform the block store that it should use the mock context
+    sBlockStore = TachyonBlockStore.get();
+    Whitebox.setInternalState(sBlockStore, "mContext", sBlockStoreContext);
+  }
+
   @Before
   public void before() throws Exception {
     mTestFile = mTestFolder.newFile("testFile");
-
-    mBlockStoreContext = PowerMockito.mock(BlockStoreContext.class);
-    Whitebox.setInternalState(BlockStoreContext.class, "INSTANCE", mBlockStoreContext);
-    mBlockStore = TachyonBlockStore.get();
-    Whitebox.setInternalState(mBlockStore, "mContext", mBlockStoreContext);
-
-    mMasterClient = PowerMockito.mock(BlockMasterClient.class);
-    Mockito.when(mBlockStoreContext.acquireMasterClient()).thenReturn(mMasterClient);
-
-    mBlockWorkerClient = PowerMockito.mock(BlockWorkerClient.class);
-    Mockito.when(mBlockWorkerClient.lockBlock(BLOCK_ID)).thenReturn(
+    // When a block lock for id BLOCK_ID is requested, a path to a temporary file is returned
+    Mockito.when(sBlockWorkerClient.lockBlock(BLOCK_ID)).thenReturn(
         new LockBlockResult(LOCK_ID, mTestFile.getAbsolutePath()));
-    Mockito.when(mBlockStoreContext.acquireWorkerClient(Mockito.anyString()))
-        .thenReturn(mBlockWorkerClient);
   }
 
   /**
@@ -119,17 +116,17 @@ public final class TachyonBlockStoreTest {
    */
   @Test
   public void getInStreamLocalTest() throws Exception {
-    Mockito.when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(BLOCK_INFO);
+    Mockito.when(sMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(BLOCK_INFO);
     PowerMockito.mockStatic(NetworkAddressUtils.class);
     Mockito.when(NetworkAddressUtils.getLocalHostName(Mockito.<TachyonConf>any()))
         .thenReturn(WORKER_HOSTNAME_LOCAL);
-    BufferedBlockInStream stream = mBlockStore.getInStream(BLOCK_ID);
+    BufferedBlockInStream stream = sBlockStore.getInStream(BLOCK_ID);
 
     Assert.assertTrue(stream instanceof LocalBlockInStream);
     Assert.assertEquals(BLOCK_ID, Whitebox.getInternalState(stream, "mBlockId"));
     Assert.assertEquals(BLOCK_LENGTH, Whitebox.getInternalState(stream, "mBlockSize"));
-    Mockito.verify(mBlockStoreContext).acquireMasterClient();
-    Mockito.verify(mBlockStoreContext).releaseMasterClient(mMasterClient);
+    Mockito.verify(sBlockStoreContext).acquireMasterClient();
+    Mockito.verify(sBlockStoreContext).releaseMasterClient(sMasterClient);
   }
 
   /**
@@ -140,18 +137,18 @@ public final class TachyonBlockStoreTest {
    */
   @Test
   public void getInStreamRemoteTest() throws Exception {
-    Mockito.when(mMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(BLOCK_INFO);
+    Mockito.when(sMasterClient.getBlockInfo(BLOCK_ID)).thenReturn(BLOCK_INFO);
     PowerMockito.mockStatic(NetworkAddressUtils.class);
     Mockito.when(NetworkAddressUtils.getLocalHostName(Mockito.<TachyonConf>any()))
         .thenReturn(WORKER_HOSTNAME_LOCAL + "_different");
-    BufferedBlockInStream stream = mBlockStore.getInStream(BLOCK_ID);
+    BufferedBlockInStream stream = sBlockStore.getInStream(BLOCK_ID);
 
     Assert.assertTrue(stream instanceof RemoteBlockInStream);
     Assert.assertEquals(BLOCK_ID, Whitebox.getInternalState(stream, "mBlockId"));
     Assert.assertEquals(BLOCK_LENGTH, Whitebox.getInternalState(stream, "mBlockSize"));
     Assert.assertEquals(new InetSocketAddress(WORKER_HOSTNAME_REMOTE, WORKER_DATA_PORT),
         Whitebox.getInternalState(stream, "mLocation"));
-    Mockito.verify(mBlockStoreContext).acquireMasterClient();
-    Mockito.verify(mBlockStoreContext).releaseMasterClient(mMasterClient);
+    Mockito.verify(sBlockStoreContext).acquireMasterClient();
+    Mockito.verify(sBlockStoreContext).releaseMasterClient(sMasterClient);
   }
 }

--- a/core/client-internal/src/test/java/tachyon/client/block/TachyonBlockStoreTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/block/TachyonBlockStoreTest.java
@@ -125,8 +125,6 @@ public final class TachyonBlockStoreTest {
     Assert.assertTrue(stream instanceof LocalBlockInStream);
     Assert.assertEquals(BLOCK_ID, Whitebox.getInternalState(stream, "mBlockId"));
     Assert.assertEquals(BLOCK_LENGTH, Whitebox.getInternalState(stream, "mBlockSize"));
-    Mockito.verify(sBlockStoreContext).acquireMasterClient();
-    Mockito.verify(sBlockStoreContext).releaseMasterClient(sMasterClient);
   }
 
   /**
@@ -148,7 +146,5 @@ public final class TachyonBlockStoreTest {
     Assert.assertEquals(BLOCK_LENGTH, Whitebox.getInternalState(stream, "mBlockSize"));
     Assert.assertEquals(new InetSocketAddress(WORKER_HOSTNAME_REMOTE, WORKER_DATA_PORT),
         Whitebox.getInternalState(stream, "mLocation"));
-    Mockito.verify(sBlockStoreContext).acquireMasterClient();
-    Mockito.verify(sBlockStoreContext).releaseMasterClient(sMasterClient);
   }
 }

--- a/core/client-internal/src/test/java/tachyon/client/file/BaseFileSystemTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/file/BaseFileSystemTest.java
@@ -69,7 +69,6 @@ public final class BaseFileSystemTest {
    */
   @Before
   public void before() {
-    ClientContext.reset();
     mFileSystem = new DummyTachyonFileSystem();
     mFileContext = PowerMockito.mock(FileSystemContext.class);
     Whitebox.setInternalState(mFileSystem, "mContext", mFileContext);

--- a/core/client-internal/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +33,6 @@ import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.Lists;
 
-import tachyon.client.ClientContext;
 import tachyon.client.ReadType;
 import tachyon.client.block.BlockInStream;
 import tachyon.client.block.BufferedBlockInStream;
@@ -110,14 +108,6 @@ public class FileInStreamTest {
     Whitebox.setInternalState(FileSystemContext.class, "INSTANCE", mContext);
     mTestStream =
         new FileInStream(mInfo, InStreamOptions.defaults().setReadType(ReadType.CACHE_PROMOTE));
-  }
-
-  /**
-   * Resets the context after a test ran.
-   */
-  @After
-  public void after() {
-    ClientContext.reset();
   }
 
   /**

--- a/core/client-internal/src/test/java/tachyon/client/file/FileInStreamTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/file/FileInStreamTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -108,6 +109,11 @@ public class FileInStreamTest {
     Whitebox.setInternalState(FileSystemContext.class, "INSTANCE", mContext);
     mTestStream =
         new FileInStream(mInfo, InStreamOptions.defaults().setReadType(ReadType.CACHE_PROMOTE));
+  }
+
+  @After
+  public void after() {
+    ClientTestUtils.resetClientContext();
   }
 
   /**

--- a/core/client-internal/src/test/java/tachyon/client/file/FileOutStreamTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/file/FileOutStreamTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -155,6 +156,11 @@ public class FileOutStreamTest {
         OutStreamOptions.defaults().setBlockSizeBytes(BLOCK_LENGTH)
             .setWriteType(WriteType.CACHE_THROUGH);
     mTestStream = createTestStream(FILE_NAME, options);
+  }
+
+  @After
+  public void after() {
+    ClientTestUtils.resetClientContext();
   }
 
   /**

--- a/core/client-internal/src/test/java/tachyon/client/file/FileOutStreamTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/file/FileOutStreamTest.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,10 +37,10 @@ import com.google.common.collect.Maps;
 
 import tachyon.Constants;
 import tachyon.TachyonURI;
-import tachyon.client.ClientContext;
 import tachyon.client.UnderStorageType;
 import tachyon.client.WriteType;
 import tachyon.client.block.BlockStoreContext;
+import tachyon.client.block.BlockWorkerClient;
 import tachyon.client.block.BlockWorkerInfo;
 import tachyon.client.block.BufferedBlockOutStream;
 import tachyon.client.block.TachyonBlockStore;
@@ -53,7 +52,6 @@ import tachyon.client.file.policy.LocalFirstPolicy;
 import tachyon.client.file.policy.RoundRobinPolicy;
 import tachyon.client.util.ClientMockUtils;
 import tachyon.client.util.ClientTestUtils;
-import tachyon.client.block.BlockWorkerClient;
 import tachyon.exception.ExceptionMessage;
 import tachyon.exception.PreconditionMessage;
 import tachyon.thrift.FileInfo;
@@ -157,14 +155,6 @@ public class FileOutStreamTest {
         OutStreamOptions.defaults().setBlockSizeBytes(BLOCK_LENGTH)
             .setWriteType(WriteType.CACHE_THROUGH);
     mTestStream = createTestStream(FILE_NAME, options);
-  }
-
-  /**
-   * Resets the context after a test ran.
-   */
-  @After
-  public void after() {
-    ClientContext.reset();
   }
 
   /**

--- a/core/client-internal/src/test/java/tachyon/client/file/FileSystemMasterClientTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/file/FileSystemMasterClientTest.java
@@ -26,7 +26,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 import tachyon.Constants;
-import tachyon.client.ClientContext;
 import tachyon.exception.ExceptionMessage;
 import tachyon.thrift.FileSystemMasterClientService;
 
@@ -44,9 +43,6 @@ public class FileSystemMasterClientTest {
    */
   @Test
   public void unsupportedVersionTest() throws Exception {
-    // Client context needs to be initialized before the file system context can be used.
-    ClientContext.reset();
-
     FileSystemMasterClientService.Client mock =
         PowerMockito.mock(FileSystemMasterClientService.Client.class);
     PowerMockito.when(mock.getServiceVersion()).thenReturn(0L);

--- a/core/client-internal/src/test/java/tachyon/client/file/options/InStreamOptionsTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/file/options/InStreamOptionsTest.java
@@ -24,7 +24,7 @@ import tachyon.client.ReadType;
 import tachyon.client.TachyonStorageType;
 import tachyon.client.file.policy.FileWriteLocationPolicy;
 import tachyon.client.file.policy.RoundRobinPolicy;
-import tachyon.conf.TachyonConf;
+import tachyon.client.util.ClientTestUtils;
 
 /**
  * Tests for the {@link InStreamOptions} class.
@@ -57,15 +57,18 @@ public class InStreamOptionsTest {
 
   /**
    * Tests that building a {@link InStreamOptions} with a modified configuration works.
+   * @throws Exception
    */
   @Test
   public void modifiedConfTest() {
-    TachyonConf conf = new TachyonConf();
-    conf.set(Constants.USER_FILE_READ_TYPE_DEFAULT, ReadType.NO_CACHE.toString());
-    ClientContext.reset(conf);
-
-    InStreamOptions options = InStreamOptions.defaults();
-    Assert.assertEquals(ReadType.NO_CACHE.getTachyonStorageType(), options.getTachyonStorageType());
-    ClientContext.reset();
+    ClientContext.getConf().set(Constants.USER_FILE_READ_TYPE_DEFAULT,
+        ReadType.NO_CACHE.toString());
+    try {
+      InStreamOptions options = InStreamOptions.defaults();
+      Assert.assertEquals(ReadType.NO_CACHE.getTachyonStorageType(),
+          options.getTachyonStorageType());
+    } finally {
+      ClientTestUtils.resetClientContext();
+    }
   }
 }

--- a/core/client-internal/src/test/java/tachyon/client/file/options/InStreamOptionsTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/file/options/InStreamOptionsTest.java
@@ -57,7 +57,6 @@ public class InStreamOptionsTest {
 
   /**
    * Tests that building a {@link InStreamOptions} with a modified configuration works.
-   * @throws Exception
    */
   @Test
   public void modifiedConfTest() {

--- a/core/client-internal/src/test/java/tachyon/client/file/options/OutStreamOptionsTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/file/options/OutStreamOptionsTest.java
@@ -28,7 +28,7 @@ import tachyon.client.WriteType;
 import tachyon.client.file.policy.FileWriteLocationPolicy;
 import tachyon.client.file.policy.LocalFirstPolicy;
 import tachyon.client.file.policy.RoundRobinPolicy;
-import tachyon.conf.TachyonConf;
+import tachyon.client.util.ClientTestUtils;
 
 /**
  * Tests for the {@link OutStreamOptions} class.
@@ -41,10 +41,9 @@ public class OutStreamOptionsTest {
   public void defaultsTest() {
     TachyonStorageType tachyonType = TachyonStorageType.STORE;
     UnderStorageType ufsType = UnderStorageType.SYNC_PERSIST;
-    TachyonConf conf = new TachyonConf();
-    conf.set(Constants.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB");
-    conf.set(Constants.USER_FILE_WRITE_TYPE_DEFAULT, WriteType.CACHE_THROUGH.toString());
-    ClientContext.reset(conf);
+    ClientContext.getConf().set(Constants.USER_BLOCK_SIZE_BYTES_DEFAULT, "64MB");
+    ClientContext.getConf().set(Constants.USER_FILE_WRITE_TYPE_DEFAULT,
+        WriteType.CACHE_THROUGH.toString());
 
     OutStreamOptions options = OutStreamOptions.defaults();
 
@@ -53,7 +52,7 @@ public class OutStreamOptionsTest {
     Assert.assertEquals(Constants.NO_TTL, options.getTtl());
     Assert.assertEquals(ufsType, options.getUnderStorageType());
     Assert.assertTrue(options.getLocationPolicy() instanceof LocalFirstPolicy);
-    ClientContext.reset();
+    ClientTestUtils.resetClientContext();
   }
 
   /**

--- a/core/client-internal/src/test/java/tachyon/client/lineage/LineageMasterClientTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/lineage/LineageMasterClientTest.java
@@ -26,7 +26,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 import tachyon.Constants;
-import tachyon.client.ClientContext;
 import tachyon.exception.ExceptionMessage;
 import tachyon.thrift.LineageMasterClientService;
 
@@ -44,9 +43,6 @@ public class LineageMasterClientTest {
    */
   @Test
   public void unsupportedVersionTest() throws Exception {
-    // Client context needs to be initialized before the lineage context can be used.
-    ClientContext.reset();
-
     LineageMasterClientService.Client mock =
         PowerMockito.mock(LineageMasterClientService.Client.class);
     PowerMockito.when(mock.getServiceVersion()).thenReturn(0L);

--- a/core/client-internal/src/test/java/tachyon/client/lineage/TachyonLineageTest.java
+++ b/core/client-internal/src/test/java/tachyon/client/lineage/TachyonLineageTest.java
@@ -34,7 +34,7 @@ import tachyon.Constants;
 import tachyon.TachyonURI;
 import tachyon.client.ClientContext;
 import tachyon.client.lineage.options.DeleteLineageOptions;
-import tachyon.conf.TachyonConf;
+import tachyon.client.util.ClientTestUtils;
 import tachyon.job.CommandLineJob;
 import tachyon.job.JobConf;
 
@@ -47,13 +47,10 @@ public final class TachyonLineageTest {
   private LineageContext mLineageContext;
   private LineageMasterClient mLineageMasterClient;
   private TachyonLineage mTachyonLineage;
-  private TachyonConf mTachyonConf;
 
   @Before
   public void before() throws Exception {
-    mTachyonConf = new TachyonConf();
-    mTachyonConf.set(Constants.USER_LINEAGE_ENABLED, "true");
-    ClientContext.reset(mTachyonConf);
+    ClientContext.getConf().set(Constants.USER_LINEAGE_ENABLED, "true");
     mLineageMasterClient = PowerMockito.mock(LineageMasterClient.class);
     mLineageContext = PowerMockito.mock(LineageContext.class);
     Mockito.when(mLineageContext.acquireMasterClient()).thenReturn(mLineageMasterClient);
@@ -64,7 +61,7 @@ public final class TachyonLineageTest {
 
   @After
   public void after() {
-    ClientContext.reset();
+    ClientTestUtils.resetClientContext();
   }
 
   @Test

--- a/core/client-internal/src/test/java/tachyon/client/util/ClientTestUtils.java
+++ b/core/client-internal/src/test/java/tachyon/client/util/ClientTestUtils.java
@@ -47,6 +47,7 @@ public final class ClientTestUtils {
   public static void resetClientContext() {
     try {
       Whitebox.invokeMethod(ClientContext.class, "reset");
+      resetContexts();
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
@@ -61,11 +62,15 @@ public final class ClientTestUtils {
   public static void reinitializeClientContext() {
     try {
       Whitebox.invokeMethod(ClientContext.class, "init");
-      BlockStoreContext.INSTANCE.reset();
-      FileSystemContext.INSTANCE.reset();
-      LineageContext.INSTANCE.reset();
+      resetContexts();
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
+  }
+
+  private static void resetContexts() {
+    BlockStoreContext.INSTANCE.reset();
+    FileSystemContext.INSTANCE.reset();
+    LineageContext.INSTANCE.reset();
   }
 }

--- a/core/client-internal/src/test/java/tachyon/client/util/ClientTestUtils.java
+++ b/core/client-internal/src/test/java/tachyon/client/util/ClientTestUtils.java
@@ -39,7 +39,8 @@ public final class ClientTestUtils {
   }
 
   /**
-   * Resets the {@link ClientContext} singleton.
+   * Reverts the client context configuration to the default value, and reinitializes all contexts
+   * while rely on this configuration.
    *
    * This method should only be used as a cleanup mechanism between tests. It should not be used
    * while any object may be using the {@link ClientContext}.

--- a/core/client-internal/src/test/java/tachyon/hadoop/TFSTest.java
+++ b/core/client-internal/src/test/java/tachyon/hadoop/TFSTest.java
@@ -39,10 +39,10 @@ import org.slf4j.LoggerFactory;
 
 import tachyon.Constants;
 import tachyon.client.ClientContext;
+import tachyon.client.file.FileSystem;
 import tachyon.client.file.FileSystemContext;
 import tachyon.client.file.FileSystemMasterClient;
-import tachyon.client.file.FileSystem;
-import tachyon.conf.TachyonConf;
+import tachyon.client.util.ClientTestUtils;
 
 /**
  * Unit tests for {@link TFS}.
@@ -57,8 +57,6 @@ import tachyon.conf.TachyonConf;
 @PowerMockIgnore("javax.security.*")
 public class TFSTest {
   private static final Logger LOG = LoggerFactory.getLogger(TFSTest.class.getName());
-
-  private TachyonConf mTachyonConf;
 
   private ClassLoader getClassLoader(Class<?> clazz) {
     // Power Mock makes this hard, so try to hack it
@@ -105,10 +103,9 @@ public class TFSTest {
     // when
     final URI uri = URI.create(Constants.HEADER_FT + "localhost:19998/tmp/path.txt");
 
-    mTachyonConf.set(Constants.MASTER_HOSTNAME, uri.getHost());
-    mTachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
-    mTachyonConf.set(Constants.ZOOKEEPER_ENABLED, "true");
-    ClientContext.reset(mTachyonConf);
+    ClientContext.getConf().set(Constants.MASTER_HOSTNAME, uri.getHost());
+    ClientContext.getConf().set(Constants.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
+    ClientContext.getConf().set(Constants.ZOOKEEPER_ENABLED, "true");
     mockMasterClient();
 
     final org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
@@ -117,7 +114,7 @@ public class TFSTest {
 
     PowerMockito.verifyStatic();
     FileSystem.Factory.get();
-    ClientContext.reset();
+    ClientTestUtils.resetClientContext();
   }
 
   /**
@@ -135,10 +132,9 @@ public class TFSTest {
     // when
     final URI uri = URI.create(Constants.HEADER + "localhost:19998/tmp/path.txt");
 
-    mTachyonConf.set(Constants.MASTER_HOSTNAME, uri.getHost());
-    mTachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
-    mTachyonConf.set(Constants.ZOOKEEPER_ENABLED, "false");
-    ClientContext.reset(mTachyonConf);
+    ClientContext.getConf().set(Constants.MASTER_HOSTNAME, uri.getHost());
+    ClientContext.getConf().set(Constants.MASTER_RPC_PORT, Integer.toString(uri.getPort()));
+    ClientContext.getConf().set(Constants.ZOOKEEPER_ENABLED, "false");
     mockMasterClient();
 
     final org.apache.hadoop.fs.FileSystem fs = org.apache.hadoop.fs.FileSystem.get(uri, conf);
@@ -147,7 +143,7 @@ public class TFSTest {
 
     PowerMockito.verifyStatic();
     FileSystem.Factory.get();
-    ClientContext.reset();
+    ClientTestUtils.resetClientContext();
   }
 
   private boolean isHadoop1x() {
@@ -181,7 +177,6 @@ public class TFSTest {
    */
   @Before
   public void setup() throws Exception {
-    mTachyonConf = new TachyonConf();
     mockUserGroupInformation();
 
     if (isHadoop1x()) {

--- a/core/server/pom.xml
+++ b/core/server/pom.xml
@@ -134,6 +134,7 @@
         <artifactId>maven-jspc-plugin</artifactId>
         <version>2.0.8</version>
       </plugin>
+      <!-- Export test classes in a test-jar so that other projects can use them for testing -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/examples/src/main/java/tachyon/examples/BasicNonByteBufferOperations.java
+++ b/examples/src/main/java/tachyon/examples/BasicNonByteBufferOperations.java
@@ -30,7 +30,6 @@ import tachyon.client.file.FileOutStream;
 import tachyon.client.file.FileSystem;
 import tachyon.client.file.options.CreateFileOptions;
 import tachyon.client.file.options.OpenFileOptions;
-import tachyon.conf.TachyonConf;
 import tachyon.exception.FileAlreadyExistsException;
 import tachyon.exception.TachyonException;
 
@@ -75,10 +74,9 @@ public final class BasicNonByteBufferOperations implements Callable<Boolean> {
 
   @Override
   public Boolean call() throws Exception {
-    TachyonConf tachyonConf = ClientContext.getConf();
-    tachyonConf.set(Constants.MASTER_HOSTNAME, mMasterLocation.getHost());
-    tachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(mMasterLocation.getPort()));
-    ClientContext.reset(tachyonConf);
+    ClientContext.getConf().set(Constants.MASTER_HOSTNAME, mMasterLocation.getHost());
+    ClientContext.getConf().set(Constants.MASTER_RPC_PORT,
+        Integer.toString(mMasterLocation.getPort()));
     FileSystem tachyonClient = FileSystem.Factory.get();
     write(tachyonClient);
     return read(tachyonClient);

--- a/examples/src/main/java/tachyon/examples/BasicOperations.java
+++ b/examples/src/main/java/tachyon/examples/BasicOperations.java
@@ -15,6 +15,29 @@
 
 package tachyon.examples;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.concurrent.Callable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tachyon.Constants;
+import tachyon.TachyonURI;
+import tachyon.Version;
+import tachyon.client.ClientContext;
+import tachyon.client.ReadType;
+import tachyon.client.WriteType;
+import tachyon.client.file.FileInStream;
+import tachyon.client.file.FileOutStream;
+import tachyon.client.file.FileSystem;
+import tachyon.client.file.options.CreateFileOptions;
+import tachyon.client.file.options.OpenFileOptions;
+import tachyon.exception.TachyonException;
+import tachyon.util.CommonUtils;
+import tachyon.util.FormatUtils;
+
 /**
  * Example to show the basic operations of Tachyon.
  */

--- a/examples/src/main/java/tachyon/examples/BasicOperations.java
+++ b/examples/src/main/java/tachyon/examples/BasicOperations.java
@@ -15,30 +15,6 @@
 
 package tachyon.examples;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.util.concurrent.Callable;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import tachyon.Constants;
-import tachyon.TachyonURI;
-import tachyon.Version;
-import tachyon.client.ClientContext;
-import tachyon.client.ReadType;
-import tachyon.client.WriteType;
-import tachyon.client.file.FileInStream;
-import tachyon.client.file.FileOutStream;
-import tachyon.client.file.FileSystem;
-import tachyon.client.file.options.CreateFileOptions;
-import tachyon.client.file.options.OpenFileOptions;
-import tachyon.conf.TachyonConf;
-import tachyon.exception.TachyonException;
-import tachyon.util.CommonUtils;
-import tachyon.util.FormatUtils;
-
 /**
  * Example to show the basic operations of Tachyon.
  */
@@ -66,10 +42,9 @@ public class BasicOperations implements Callable<Boolean> {
 
   @Override
   public Boolean call() throws Exception {
-    TachyonConf tachyonConf = ClientContext.getConf();
-    tachyonConf.set(Constants.MASTER_HOSTNAME, mMasterLocation.getHost());
-    tachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(mMasterLocation.getPort()));
-    ClientContext.reset(tachyonConf);
+    ClientContext.getConf().set(Constants.MASTER_HOSTNAME, mMasterLocation.getHost());
+    ClientContext.getConf().set(Constants.MASTER_RPC_PORT,
+        Integer.toString(mMasterLocation.getPort()));
     FileSystem fs = FileSystem.Factory.get();
     writeFile(fs);
     return readFile(fs);

--- a/examples/src/main/java/tachyon/examples/Performance.java
+++ b/examples/src/main/java/tachyon/examples/Performance.java
@@ -635,7 +635,6 @@ public class Performance {
 
     tachyonConf.set(Constants.MASTER_HOSTNAME, sMasterAddress.getHost());
     tachyonConf.set(Constants.MASTER_RPC_PORT, Integer.toString(sMasterAddress.getPort()));
-    ClientContext.reset(tachyonConf);
 
     if (testCase == 1) {
       sResultPrefix = "TachyonFilesWriteTest " + sResultPrefix;

--- a/examples/src/main/java/tachyon/examples/keyvalue/KeyValueStoreOperations.java
+++ b/examples/src/main/java/tachyon/examples/keyvalue/KeyValueStoreOperations.java
@@ -33,7 +33,6 @@ import tachyon.client.keyvalue.KeyValuePair;
 import tachyon.client.keyvalue.KeyValueStoreReader;
 import tachyon.client.keyvalue.KeyValueStoreWriter;
 import tachyon.client.keyvalue.KeyValueStores;
-import tachyon.client.util.ClientTestUtils;
 import tachyon.conf.TachyonConf;
 import tachyon.examples.Utils;
 import tachyon.util.io.BufferUtils;
@@ -65,7 +64,6 @@ public final class KeyValueStoreOperations implements Callable<Boolean> {
     TachyonConf tachyonConf = ClientContext.getConf();
     tachyonConf.set(Constants.KEY_VALUE_ENABLED, String.valueOf(true));
     tachyonConf.set(Constants.KEY_VALUE_PARTITION_SIZE_BYTES_MAX, String.valueOf(mPartitionLength));
-    ClientTestUtils.resetClientContext();
 
     KeyValueStores kvStores = KeyValueStores.Factory.create();
 

--- a/examples/src/main/java/tachyon/examples/keyvalue/KeyValueStoreOperations.java
+++ b/examples/src/main/java/tachyon/examples/keyvalue/KeyValueStoreOperations.java
@@ -33,6 +33,7 @@ import tachyon.client.keyvalue.KeyValuePair;
 import tachyon.client.keyvalue.KeyValueStoreReader;
 import tachyon.client.keyvalue.KeyValueStoreWriter;
 import tachyon.client.keyvalue.KeyValueStores;
+import tachyon.client.util.ClientTestUtils;
 import tachyon.conf.TachyonConf;
 import tachyon.examples.Utils;
 import tachyon.util.io.BufferUtils;
@@ -64,7 +65,7 @@ public final class KeyValueStoreOperations implements Callable<Boolean> {
     TachyonConf tachyonConf = ClientContext.getConf();
     tachyonConf.set(Constants.KEY_VALUE_ENABLED, String.valueOf(true));
     tachyonConf.set(Constants.KEY_VALUE_PARTITION_SIZE_BYTES_MAX, String.valueOf(mPartitionLength));
-    ClientContext.reset(tachyonConf);
+    ClientTestUtils.resetClientContext();
 
     KeyValueStores kvStores = KeyValueStores.Factory.create();
 

--- a/keyvalue/client-internal/pom.xml
+++ b/keyvalue/client-internal/pom.xml
@@ -34,6 +34,7 @@
       <groupId>org.tachyonproject</groupId>
       <artifactId>tachyon-core-client-internal</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
       <type>test-jar</type>
     </dependency>
   </dependencies>

--- a/keyvalue/client-internal/pom.xml
+++ b/keyvalue/client-internal/pom.xml
@@ -32,7 +32,7 @@
     <!-- Other projects' test-jars -->
     <dependency>
       <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon-client-unshaded</artifactId>
+      <artifactId>tachyon-core-client-internal</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
     </dependency>

--- a/keyvalue/client-internal/pom.xml
+++ b/keyvalue/client-internal/pom.xml
@@ -28,5 +28,13 @@
       <artifactId>tachyon-keyvalue-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Other projects' test-jars -->
+    <dependency>
+      <groupId>org.tachyonproject</groupId>
+      <artifactId>tachyon-client-unshaded</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
   </dependencies>
 </project>

--- a/keyvalue/client-internal/src/test/java/tachyon/client/keyvalue/BaseKeyValuePartitionWriterTest.java
+++ b/keyvalue/client-internal/src/test/java/tachyon/client/keyvalue/BaseKeyValuePartitionWriterTest.java
@@ -25,7 +25,7 @@ import org.junit.rules.ExpectedException;
 import tachyon.Constants;
 import tachyon.client.ByteArrayOutStream;
 import tachyon.client.ClientContext;
-import tachyon.conf.TachyonConf;
+import tachyon.client.util.ClientTestUtils;
 
 /**
  * Unit test of {@link BaseKeyValuePartitionWriter}.
@@ -130,15 +130,12 @@ public final class BaseKeyValuePartitionWriterTest {
   @Test
   public void canPutKeyValueTest() throws Exception {
     long size = mWriter.byteCount() + KEY1.length + VALUE1.length + 2 * Constants.BYTES_IN_INTEGER;
-    TachyonConf originalConf = ClientContext.getConf();
-    TachyonConf conf = new TachyonConf();
-    conf.set(Constants.KEY_VALUE_PARTITION_SIZE_BYTES_MAX, String.valueOf(size));
-    ClientContext.reset(conf);
+    ClientContext.getConf().set(Constants.KEY_VALUE_PARTITION_SIZE_BYTES_MAX, String.valueOf(size));
     mWriter = new BaseKeyValuePartitionWriter(mOutStream);
     Assert.assertTrue(mWriter.canPut(KEY1, VALUE1));
     mWriter.put(KEY1, VALUE1);
     Assert.assertFalse(mWriter.canPut(KEY1, VALUE1));
-    ClientContext.reset(originalConf);
+    ClientTestUtils.resetClientContext();
   }
 
   /**

--- a/keyvalue/server/pom.xml
+++ b/keyvalue/server/pom.xml
@@ -33,14 +33,5 @@
       <artifactId>tachyon-core-server</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <!-- Other projects' test-jars -->
-    <dependency>
-      <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon-client-unshaded</artifactId>
-      <version>${project.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/keyvalue/server/pom.xml
+++ b/keyvalue/server/pom.xml
@@ -25,14 +25,16 @@
     </dependency>
     <dependency>
       <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon-core-server</artifactId>
+      <artifactId>tachyon-keyvalue-client-internal</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon-keyvalue-client-internal</artifactId>
+      <artifactId>tachyon-core-server</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Other projects' test-jars -->
     <dependency>
       <groupId>org.tachyonproject</groupId>
       <artifactId>tachyon-client-unshaded</artifactId>

--- a/keyvalue/server/pom.xml
+++ b/keyvalue/server/pom.xml
@@ -30,8 +30,10 @@
     </dependency>
     <dependency>
       <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon-core-server</artifactId>
+      <artifactId>tachyon-client-unshaded</artifactId>
       <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/keyvalue/server/pom.xml
+++ b/keyvalue/server/pom.xml
@@ -25,6 +25,11 @@
     </dependency>
     <dependency>
       <groupId>org.tachyonproject</groupId>
+      <artifactId>tachyon-core-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.tachyonproject</groupId>
       <artifactId>tachyon-keyvalue-client-internal</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -40,6 +40,14 @@
       <artifactId>tachyon-core-server</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- Other projects' test-jars -->
+    <dependency>
+      <groupId>org.tachyonproject</groupId>
+      <artifactId>tachyon-client-unshaded</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
     <dependency>
       <groupId>org.tachyonproject</groupId>
       <artifactId>tachyon-core-server</artifactId>

--- a/minicluster/pom.xml
+++ b/minicluster/pom.xml
@@ -44,7 +44,7 @@
     <!-- Other projects' test-jars -->
     <dependency>
       <groupId>org.tachyonproject</groupId>
-      <artifactId>tachyon-client-unshaded</artifactId>
+      <artifactId>tachyon-core-client-internal</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
     </dependency>

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
@@ -22,6 +22,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import tachyon.Constants;
 import tachyon.client.ClientContext;
 import tachyon.client.file.FileSystem;
+import tachyon.client.util.ClientTestUtils;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.ConnectionFailedException;
 import tachyon.worker.NetAddress;
@@ -130,8 +131,8 @@ public final class LocalTachyonCluster extends AbstractLocalTachyonCluster {
 
     // We need to update client context with the most recent configuration so they know the correct
     // port to connect to master.
-    mClientConf = new TachyonConf(testConf.getInternalProperties());
-    ClientContext.reset(mClientConf);
+    ClientContext.getConf().merge(testConf);
+    ClientTestUtils.reinitializeClientContext();
   }
 
   @Override
@@ -148,7 +149,7 @@ public final class LocalTachyonCluster extends AbstractLocalTachyonCluster {
   protected void resetContext() {
     MasterContext.reset();
     WorkerContext.reset();
-    ClientContext.reset();
+    ClientTestUtils.resetClientContext();
   }
 
   @Override

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonCluster.java
@@ -47,7 +47,6 @@ import tachyon.worker.WorkerContext;
 @NotThreadSafe
 public final class LocalTachyonCluster extends AbstractLocalTachyonCluster {
   private LocalTachyonMaster mMaster;
-  private TachyonConf mClientConf;
 
   /**
    * @param workerCapacityBytes the capacity of the worker in bytes

--- a/minicluster/src/main/java/tachyon/master/LocalTachyonClusterMultiMaster.java
+++ b/minicluster/src/main/java/tachyon/master/LocalTachyonClusterMultiMaster.java
@@ -28,6 +28,7 @@ import com.google.common.base.Throwables;
 import tachyon.Constants;
 import tachyon.client.ClientContext;
 import tachyon.client.file.FileSystem;
+import tachyon.client.util.ClientTestUtils;
 import tachyon.conf.TachyonConf;
 import tachyon.exception.ConnectionFailedException;
 import tachyon.underfs.UnderFileSystem;
@@ -173,7 +174,8 @@ public class LocalTachyonClusterMultiMaster extends AbstractLocalTachyonCluster 
 
     runWorker();
     // The client context should reflect the updates to the conf.
-    ClientContext.reset(mWorkerConf);
+    ClientContext.getConf().merge(conf);
+    ClientTestUtils.reinitializeClientContext();
   }
 
   @Override

--- a/tests/src/test/java/tachyon/client/FileSystemUtilsIntegrationTest.java
+++ b/tests/src/test/java/tachyon/client/FileSystemUtilsIntegrationTest.java
@@ -15,7 +15,28 @@
 
 package tachyon.client;
 
-import src.test.java.tachyon.LocalTachyonClusterResource;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import tachyon.Constants;
+import tachyon.LocalTachyonClusterResource;
+import tachyon.TachyonURI;
+import tachyon.client.file.FileOutStream;
+import tachyon.client.file.FileSystem;
+import tachyon.client.file.FileSystemUtils;
+import tachyon.client.file.options.CreateFileOptions;
+import tachyon.client.util.ClientTestUtils;
+import tachyon.conf.TachyonConf;
+import tachyon.exception.TachyonException;
+import tachyon.util.CommonUtils;
+import tachyon.util.io.PathUtils;
 
 /**
  * Tests for {@link tachyon.client.file.FileSystemUtils}.

--- a/tests/src/test/java/tachyon/client/FileSystemUtilsIntegrationTest.java
+++ b/tests/src/test/java/tachyon/client/FileSystemUtilsIntegrationTest.java
@@ -15,27 +15,7 @@
 
 package tachyon.client;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import tachyon.Constants;
-import tachyon.LocalTachyonClusterResource;
-import tachyon.TachyonURI;
-import tachyon.client.file.FileOutStream;
-import tachyon.client.file.FileSystem;
-import tachyon.client.file.FileSystemUtils;
-import tachyon.client.file.options.CreateFileOptions;
-import tachyon.conf.TachyonConf;
-import tachyon.exception.TachyonException;
-import tachyon.util.CommonUtils;
-import tachyon.util.io.PathUtils;
+import src.test.java.tachyon.LocalTachyonClusterResource;
 
 /**
  * Tests for {@link tachyon.client.file.FileSystemUtils}.
@@ -144,17 +124,19 @@ public class FileSystemUtilsIntegrationTest {
       @Override
       public void run() {
         try {
-          final TachyonConf conf = ClientContext.getConf();
           // set the slow default polling period to a more sensible value, in order
           // to speed up the tests artificial waiting times
-          conf.set(Constants.USER_FILE_WAITCOMPLETED_POLL_MS, "100");
-          // The write will take at most 600ms I am waiting for at most 400ms - epsilon.
-          boolean completed = FileSystemUtils.waitCompleted(sFileSystem, uri, 300,
-              TimeUnit.MILLISECONDS);
-          Assert.assertFalse(completed);
-          completed = sFileSystem.getStatus(uri).isCompleted();
-          Assert.assertFalse(completed);
-          ClientContext.reset();
+          ClientContext.getConf().set(Constants.USER_FILE_WAITCOMPLETED_POLL_MS, "100");
+          try {
+            // The write will take at most 600ms I am waiting for at most 400ms - epsilon.
+            boolean completed = FileSystemUtils.waitCompleted(sFileSystem, uri, 300,
+                TimeUnit.MILLISECONDS);
+            Assert.assertFalse(completed);
+            completed = sFileSystem.getStatus(uri).isCompleted();
+            Assert.assertFalse(completed);
+          } finally {
+            ClientTestUtils.resetClientContext();
+          }
         } catch (Exception e) {
           e.printStackTrace();
           Assert.fail(e.getMessage());

--- a/tests/src/test/java/tachyon/security/BlockWorkerClientAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/tachyon/security/BlockWorkerClientAuthenticationIntegrationTest.java
@@ -30,6 +30,7 @@ import tachyon.Constants;
 import tachyon.LocalTachyonClusterResource;
 import tachyon.client.ClientContext;
 import tachyon.client.block.BlockWorkerClient;
+import tachyon.client.util.ClientTestUtils;
 import tachyon.security.MasterClientAuthenticationIntegrationTest.NameMatchAuthenticationProvider;
 import tachyon.worker.ClientMetrics;
 
@@ -92,18 +93,15 @@ public class BlockWorkerClientAuthenticationIntegrationTest {
     mThrown.expect(IOException.class);
     mThrown.expectMessage("Failed to connect to the worker");
 
-    BlockWorkerClient blockWorkerClient = new BlockWorkerClient(
-        mLocalTachyonClusterResource.get().getWorkerAddress(),
-        mExecutorService, ClientContext.getConf(),
-        1 /* fake session id */, true, new ClientMetrics());
-    try {
       Assert.assertFalse(blockWorkerClient.isConnected());
       // Using no-tachyon as loginUser to connect to Worker, the IOException will be thrown
       LoginUserTestUtils.resetLoginUser(ClientContext.getConf(), "no-tachyon");
       blockWorkerClient.connect();
     } finally {
-      blockWorkerClient.close();
-      ClientContext.reset();
+      if (blockWorkerClient != null) {
+        blockWorkerClient.close();
+      }
+      ClientTestUtils.resetClientContext();
     }
   }
 

--- a/tests/src/test/java/tachyon/security/BlockWorkerClientAuthenticationIntegrationTest.java
+++ b/tests/src/test/java/tachyon/security/BlockWorkerClientAuthenticationIntegrationTest.java
@@ -93,14 +93,17 @@ public class BlockWorkerClientAuthenticationIntegrationTest {
     mThrown.expect(IOException.class);
     mThrown.expectMessage("Failed to connect to the worker");
 
+    BlockWorkerClient blockWorkerClient = new BlockWorkerClient(
+        mLocalTachyonClusterResource.get().getWorkerAddress(),
+        mExecutorService, ClientContext.getConf(),
+        1 /* fake session id */, true, new ClientMetrics());
+    try {
       Assert.assertFalse(blockWorkerClient.isConnected());
       // Using no-tachyon as loginUser to connect to Worker, the IOException will be thrown
       LoginUserTestUtils.resetLoginUser(ClientContext.getConf(), "no-tachyon");
       blockWorkerClient.connect();
     } finally {
-      if (blockWorkerClient != null) {
-        blockWorkerClient.close();
-      }
+      blockWorkerClient.close();
       ClientTestUtils.resetClientContext();
     }
   }


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1623

Instead of resetting the client context to cause `TachyonConf` changes, it is enough to directly modify the current `TachyonConf`. This can be done by acting directly on `ClientContext.getConf()`.

In tests, it is often useful to reset the context so that changes to `TachyonConf` don't trample on other tests. The new `ClientTestUtils.resetClientContext` method fulfills this need, and is only available on the `src/test` side. Occasionally we want to modify configuration and then re-initialize contexts so that they pick up the conf change. `ClientTestUtils.reinitializeClientContext()` covers this use case, and re-initializes contexts without resetting the configuration.

This PR is the first of a few PRs which will remove public reset methods from all of our context singletons.