### PR TITLE
[SMALLFIX] Fix references to tier count configuration

### DIFF
--- a/conf/tachyon-env.sh.swift
+++ b/conf/tachyon-env.sh.swift
@@ -95,7 +95,7 @@ CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export TACHYON_JAVA_OPTS+="
   -Dlog4j.configuration=file:${CONF_DIR}/log4j.properties
-  -Dtachyon.worker.tieredstore.level.max=1
+  -Dtachyon.worker.tieredstore.levels=1
   -Dtachyon.worker.tieredstore.level0.alias=MEM
   -Dtachyon.worker.tieredstore.level0.dirs.path=${TACHYON_RAM_FOLDER}
   -Dtachyon.worker.tieredstore.level0.dirs.quota=${TACHYON_WORKER_MEMORY_SIZE}

--- a/conf/tachyon-env.sh.template
+++ b/conf/tachyon-env.sh.template
@@ -98,7 +98,7 @@ CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export TACHYON_JAVA_OPTS+="
   -Dlog4j.configuration=file:${CONF_DIR}/log4j.properties
-  -Dtachyon.worker.tieredstore.level.max=1
+  -Dtachyon.worker.tieredstore.levels=1
   -Dtachyon.worker.tieredstore.level0.alias=MEM
   -Dtachyon.worker.tieredstore.level0.dirs.path=${TACHYON_RAM_FOLDER}
   -Dtachyon.worker.tieredstore.level0.dirs.quota=${TACHYON_WORKER_MEMORY_SIZE}

--- a/deploy/vagrant/provision/roles/lib/files/tachyon_tiered.sh
+++ b/deploy/vagrant/provision/roles/lib/files/tachyon_tiered.sh
@@ -7,11 +7,11 @@ for disk in $DISK; do
  TIERED_PATH=/$disk,$TIERED_PATH
  quota=`df -h | grep "/$disk" | awk '{print $2}'`
  TIERED_QUOTA=${quota}B,$TIERED_QUOTA
-done 
+done
 
 [[ "$TIERED_PATH" == "" ]] && exit 0
 
-sed -i "s/tachyon.worker.tieredstore.level.max=1/tachyon.worker.tieredstore.level.max=2/g" /tachyon/conf/tachyon-env.sh
+sed -i "s/tachyon.worker.tieredstore.levels=1/tachyon.worker.tieredstore.levels=2/g" /tachyon/conf/tachyon-env.sh
 
 sed -i "/export TACHYON_JAVA_OPTS+=\"/ a\
   -Dtachyon.worker.tieredstore.level1.dirs.quota=$TIERED_QUOTA

--- a/docs/en/Tiered-Storage-on-Tachyon.md
+++ b/docs/en/Tiered-Storage-on-Tachyon.md
@@ -149,7 +149,7 @@ Tiered storage can be enabled in Tachyon using
 [configuration parameters](Configuration-Settings.html). By default, Tachyon only enables a single,
 memory tier. To specify additional tiers for Tachyon, use the following configuration parameters:
 
-    tachyon.worker.tieredstore.level.max
+    tachyon.worker.tieredstore.levels
     tachyon.worker.tieredstore.level{x}.alias
     tachyon.worker.tieredstore.level{x}.dirs.quota
     tachyon.worker.tieredstore.level{x}.dirs.path
@@ -158,7 +158,7 @@ memory tier. To specify additional tiers for Tachyon, use the following configur
 For example, if you wanted to configure Tachyon to have two tiers -- memory and hard disk drive --
 you could use a configuration similar to:
 
-    tachyon.worker.tieredstore.level.max=2
+    tachyon.worker.tieredstore.levels
     tachyon.worker.tieredstore.level0.alias=MEM
     tachyon.worker.tieredstore.level0.dirs.path=/mnt/ramdisk
     tachyon.worker.tieredstore.level0.dirs.quota=100GB
@@ -170,7 +170,7 @@ you could use a configuration similar to:
 
 Here is the explanation of the example configuration:
 
-* `tachyon.worker.tieredstore.level.max=2` configures 2 tiers in Tachyon
+* `tachyon.worker.tieredstore.levels=2` configures 2 tiers in Tachyon
 * `tachyon.worker.tieredstore.level0.alias=MEM` configures the first (top) tier to be a memory tier
 * `tachyon.worker.tieredstore.level0.dirs.path=/mnt/ramdisk` defines `/mnt/ramdisk` to be the file
 path to the first tier
@@ -186,8 +186,8 @@ file paths of the second tier
 the second layer to be 0.1
 
 There are a few restrictions to defining the tiers. First of all, there can be at most 3 tiers.
-Also, at most 1 tier can refer to a specific alias. For example, at most 1 tier can have the 
-alias HDD. If you want Tachyon to use multiple hard drives for the HDD tier, you can configure that 
+Also, at most 1 tier can refer to a specific alias. For example, at most 1 tier can have the
+alias HDD. If you want Tachyon to use multiple hard drives for the HDD tier, you can configure that
 by using multiple paths for `tachyon.worker.tieredstore.level{x}.dirs.path`.
 
 Additionally, the specific evictor and allocator strategies can be configured. Those configuration
@@ -207,7 +207,7 @@ These are the configuration parameters for tiered storage.
 <table class="table table-striped">
 <tr><th>Parameter</th><th>Default Value</th><th>Description</th></tr>
 <tr>
-  <td>tachyon.worker.tieredstore.level.max</td>
+  <td>tachyon.worker.tieredstore.levels</td>
   <td>1</td>
   <td>
   The maximum number of storage tiers in Tachyon. Currently, Tachyon supports 1, 2, or 3 tiers.

--- a/integration/bin/tachyon-worker-mesos.sh
+++ b/integration/bin/tachyon-worker-mesos.sh
@@ -18,7 +18,7 @@ mkdir -p "${TACHYON_LOGS_DIR}"
   -Dtachyon.logger.type="WORKER_LOGGER" \
   -Dtachyon.logs.dir="${TACHYON_LOGS_DIR}" \
   -Dtachyon.master.hostname="${TACHYON_MASTER_ADDRESS}" \
-  -Dtachyon.worker.tieredstore.level.max=1 \
+  -Dtachyon.worker.tieredstore.levels=1 \
   -Dtachyon.worker.tieredstore.level0.alias=MEM \
   -Dtachyon.worker.tieredstore.level0.dirs.path="/mnt/ramdisk" \
   -Dtachyon.worker.tieredstore.level0.dirs.quota="${TACHYON_WORKER_MEMORY_SIZE}" \


### PR DESCRIPTION
The configuration constant defined in `Constants` is `tachyon.worker.tieredstore.levels`. After this change `tachyon.worker.tieredstore.level.max` will no longer appear in our codebase.