### PR TITLE
[SMALLFIX-DOC-MAPREDUCE-CHANGENUMBER]number 2 main alternatives in sequence

### DIFF
--- a/docs/en/Running-Hadoop-MapReduce-on-Tachyon.md
+++ b/docs/en/Running-Hadoop-MapReduce-on-Tachyon.md
@@ -100,7 +100,7 @@ the Tachyon client jar is to use the distributed cache, via the `-libjars` comma
 Another way to distribute the client jar is to manually distribute it to all the Hadoop nodes.
 Below are instructions for the 2 main alternatives:
 
-1. **Using the -libjars command line option.**
+1.**Using the -libjars command line option.**
 You can run a job by using the `-libjars` command line option when using `hadoop jar ...`, 
 specifying
 `/<PATH_TO_TACHYON>/core/client/target/tachyon-client-{{site.TACHYON_RELEASED_VERSION}}-jar-with-dependencies.jar`
@@ -111,7 +111,7 @@ the nodes. For example, the following command adds the Tachyon client jar to the
 $ hadoop jar hadoop-examples-1.2.1.jar wordcount -libjars /<PATH_TO_TACHYON>/core/client/target/tachyon-client-{{site.TACHYON_RELEASED_VERSION}}-jar-with-dependencies.jar <INPUT FILES> <OUTPUT DIRECTORY>`
 ```
 
-1. **Distributing the jars to all nodes manually.**
+2.**Distributing the jars to all nodes manually.**
 For installing Tachyon on each node, you must place the client jar
 `tachyon-client-{{site.TACHYON_RELEASED_VERSION}}-jar-with-dependencies.jar`
 (located in the `/<PATH_TO_TACHYON>/core/client/target/` directory), in the `$HADOOP_HOME/lib`


### PR DESCRIPTION
http://www.tachyon-project.org/documentation/master/en/Running-Hadoop-MapReduce-on-Tachyon.html
There are 2 main alternatives for distributing the Tachyon client jar. However, The 2nd approach has same number as the 1st. So I think the number of "Distributing the jars to all nodes manually" should be 2.