### PR TITLE
Revert "[TACHYON-1685] Delete temporary directories created in integration tests"

### DIFF
--- a/minicluster/src/main/java/tachyon/master/AbstractLocalTachyonCluster.java
+++ b/minicluster/src/main/java/tachyon/master/AbstractLocalTachyonCluster.java
@@ -290,9 +290,6 @@ public abstract class AbstractLocalTachyonCluster {
     stopTFS();
     stopUFS();
 
-    // Deletes the tachyon home dir for this test to save disk space.
-    UnderFileSystemUtils.deleteDir(mTachyonHome, mMasterConf);
-
     resetContext();
     resetLoginUser();
   }


### PR DESCRIPTION
Reverts amplab/tachyon#2617

This commit seems to have broken the hdfs builds, e.g. https://amplab.cs.berkeley.edu/jenkins/view/Tachyon/job/Tachyon-Master/1892/PROFILE=hdfs1Test,label=centos/console