### PR TITLE
Update libthrift to 0.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <java.version>1.6</java.version>
     <jetty.version>7.6.15.v20140411</jetty.version>
     <junit.version>4.12</junit.version>
-    <libthrift.version>0.9.2</libthrift.version>
+    <libthrift.version>0.9.3</libthrift.version>
     <license.header.path>build/license/</license.header.path>
     <log4j.version>1.2.17</log4j.version>
     <metrics.version>3.1.0</metrics.version>


### PR DESCRIPTION
Auto-generated codes are using Thrift compiler 0.9.3. We may apply the same version to libthrift.