### PR TITLE
[TACHYON-1636] Add the Chinese version of documentation page 'Configuring-Tachyon-with-Swift'

### DIFF
--- a/docs/_includes/Configuring-Tachyon-with-Swift/copy-tachyon-env.md
+++ b/docs/_includes/Configuring-Tachyon-with-Swift/copy-tachyon-env.md
@@ -1,0 +1,3 @@
+```bash
+$ cp conf/tachyon-env.sh.template conf/tachyon-env.sh
+```

--- a/docs/_includes/Configuring-Tachyon-with-Swift/functional-tests.md
+++ b/docs/_includes/Configuring-Tachyon-with-Swift/functional-tests.md
@@ -1,0 +1,3 @@
+```bash
+$ mvn test -PswiftTest -pl tests
+```

--- a/docs/_includes/Configuring-Tachyon-with-Swift/heap-dump.md
+++ b/docs/_includes/Configuring-Tachyon-with-Swift/heap-dump.md
@@ -1,0 +1,2 @@
+  <argLine>-XX:+HeapDumpOnOutOfMemoryError 
+    -XX:HeapDumpPath=/location/dump</argLine>

--- a/docs/_includes/Configuring-Tachyon-with-Swift/runTests.md
+++ b/docs/_includes/Configuring-Tachyon-with-Swift/runTests.md
@@ -1,0 +1,3 @@
+```bash
+$ ./bin/tachyon runTests
+```

--- a/docs/_includes/Configuring-Tachyon-with-Swift/several-configurations.md
+++ b/docs/_includes/Configuring-Tachyon-with-Swift/several-configurations.md
@@ -1,0 +1,7 @@
+    -Dfs.swift.user=<swift-user>
+    -Dfs.swift.tenant=<swift-tenant>
+    -Dfs.swift.apikey=<swift-user-password>
+    -Dfs.swift.auth.url=<swift-auth-url>
+    -Dfs.swift.auth.port=<swift-auth-url-port>
+    -Dfs.swift.use.public.url=<swift-use-public>
+    -Dfs.swift.auth.method=<swift-auth-model>

--- a/docs/_includes/Configuring-Tachyon-with-Swift/start-tachyon.md
+++ b/docs/_includes/Configuring-Tachyon-with-Swift/start-tachyon.md
@@ -1,0 +1,4 @@
+```bash
+$ ./bin/tachyon format
+$ ./bin/tachyon-start.sh local
+```

--- a/docs/_includes/Configuring-Tachyon-with-Swift/stop-tachyon.md
+++ b/docs/_includes/Configuring-Tachyon-with-Swift/stop-tachyon.md
@@ -1,0 +1,3 @@
+```bash
+$ ./bin/tachyon-stop.sh all
+```

--- a/docs/_includes/Configuring-Tachyon-with-Swift/swift-files.md
+++ b/docs/_includes/Configuring-Tachyon-with-Swift/swift-files.md
@@ -1,0 +1,1 @@
+    swift://<SWIFT CONTAINER>/tachyon/data/default_tests_files/BasicFile_STORE_SYNC_PERSIST

--- a/docs/_includes/Configuring-Tachyon-with-Swift/underfs-address.md
+++ b/docs/_includes/Configuring-Tachyon-with-Swift/underfs-address.md
@@ -1,0 +1,3 @@
+```bash
+export TACHYON_UNDERFS_ADDRESS=swift://<swift-containter>
+```

--- a/docs/cn/Configuring-Tachyon-with-Swift.md
+++ b/docs/cn/Configuring-Tachyon-with-Swift.md
@@ -31,7 +31,7 @@ priority: 1
 `<swift-use-public>`的值为`true`或`false`。
 `<swift-auth-model>`的值为`keystone`、`tempauth`或`swiftauth`。
 
-在成功授权情况下，Keystone会返回两个访问URL：公共的和私有的。如果Tachyon是在公司网络中使用，并且Swift也在同一个网络中，建议设置`<swift-auth-model>`的值为`false`。<!--Is this a typo?-->
+在成功授权情况下，Keystone会返回两个访问URL：公共的和私有的。如果Tachyon是在公司网络中使用，并且Swift也在同一个网络中，建议设置`<swift-use-public>`的值为`false`。
 
 
 ## 访问IBM SoftLayer对象存储
@@ -64,6 +64,6 @@ priority: 1
 
 {% include Configuring-Tachyon-with-Swift/functional-tests.md %}
 
-若测试失败，日志记录在`tests/target/logs`下。可以通过以下命令激活堆转储：
+若测试失败，日志记录在`tests/target/logs`下。可以通过以下命令抓取堆状态备份：
 
 {% include Configuring-Tachyon-with-Swift/heap-dump.md %}

--- a/docs/cn/Configuring-Tachyon-with-Swift.md
+++ b/docs/cn/Configuring-Tachyon-with-Swift.md
@@ -1,0 +1,69 @@
+---
+layout: global
+title: 在Swift上配置Tachyon
+nickname: Tachyon使用Swift
+group: Under Store
+priority: 1
+---
+
+该向导介绍如何配置Tachyon从而使用[Swift](http://docs.openstack.org/developer/swift/)作为底层文件系统。
+
+# 初始步骤
+
+首先，本地要有Tachyon二进制包。你可以自己[编译Tachyon](Building-Tachyon-Master-Branch.html)，或者[下载二进制包](Running-Tachyon-Locally.html)
+
+然后，由template文件创建配置文件：
+
+{% include Configuring-Tachyon-with-Swift/copy-tachyon-env.md %}
+
+# 配置Tachyon
+
+若要在Tachyon中使用Swift作为底层文件系统，一定要修改`conf/tachyon-env.sh`配置文件。首先要指定Swift的地址，在`conf/tachyon-env.sh`中添加：
+
+{% include Configuring-Tachyon-with-Swift/underfs-address.md %}
+
+其中`<swift-container>`是一个已有的Swift容器。
+
+以下的配置项也应包含在`conf/tachyon-env.sh`文件中：
+
+{% include Configuring-Tachyon-with-Swift/several-configurations.md %}
+  	
+`<swift-use-public>`的值为`true`或`false`。
+`<swift-auth-model>`的值为`keystone`、`tempauth`或`swiftauth`。
+
+在成功授权情况下，Keystone会返回两个访问URL：公共的和私有的。如果Tachyon是在公司网络中使用，并且Swift也在同一个网络中，建议设置`<swift-auth-model>`的值为`false`。<!--Is this a typo?-->
+
+
+## 访问IBM SoftLayer对象存储
+
+使用Swift的配置，也能够将IBM SoftLayer对象存储作为Tachyon底层文件系统，SoftLayer需要将`<swift-auth-model>`设置为`swiftauth`。
+ 
+# 在本地Swift上运行Tachyon
+
+配置完成后，你可以在本地启动Tachyon，观察是否正确运行：
+
+{% include Configuring-Tachyon-with-Swift/start-tachyon.md %}
+
+该命令应当会启动一个Tachyon master和一个Tachyon worker，可以在浏览器中访问[http://localhost:19999](http://localhost:19999)查看master Web UI。
+
+接着，你可以运行一个简单的示例程序：
+
+{% include Configuring-Tachyon-with-Swift/runTests.md %}
+
+运行成功后，访问你的Swift容器，其中应包含了由Tachyon创建的文件和目录。在该测试中，创建的文件名称应像下面这样：
+
+{% include Configuring-Tachyon-with-Swift/swift-files.md %}
+
+运行以下命令停止Tachyon：
+
+{% include Configuring-Tachyon-with-Swift/stop-tachyon.md %}
+
+# 对IBM SoftLayer进行功能测试
+
+在`tests/pom.xml`配置你的Swift或者SoftLayer账户，其中`authMethodKey`的值应为`keystone`、`tempauth`或`swiftauth`，要进行功能测试，运行：
+
+{% include Configuring-Tachyon-with-Swift/functional-tests.md %}
+
+若测试失败，日志记录在`tests/target/logs`下。可以通过以下命令激活堆转储：
+
+{% include Configuring-Tachyon-with-Swift/heap-dump.md %}

--- a/docs/en/Configuring-Tachyon-with-Swift.md
+++ b/docs/en/Configuring-Tachyon-with-Swift.md
@@ -17,9 +17,7 @@ First, the Tachyon binaries must be on your machine. You can either
 
 Then, if you haven't already done so, create your configuration file from the template:
 
-```bash
-$ cp conf/tachyon-env.sh.template conf/tachyon-env.sh
-```
+{% include Configuring-Tachyon-with-Swift/copy-tachyon-env.md %}
 
 # Configuring Tachyon
 
@@ -27,28 +25,19 @@ To configure Tachyon to use Swift as its under storage system, modifications to 
 `conf/tachyon-env.sh` file must be made. The first modification is to specify the Swift under
 storage system address. You specify it by modifying `conf/tachyon-env.sh` to include:
 
-```bash
-export TACHYON_UNDERFS_ADDRESS=swift://<swift-containter>
-```
+{% include Configuring-Tachyon-with-Swift/underfs-address.md %}
 
 Where `<swift-container>` is an existing Swift container.
 
 The following configuration should be provided in the `conf/tachyon-env.sh`
 
-
- 	-Dfs.swift.user=<swift-user>
-  	-Dfs.swift.tenant=<swift-tenant>
-  	-Dfs.swift.apikey=<swift-user-password>
-  	-Dfs.swift.auth.url=<swift-auth-url>
-  	-Dfs.swift.auth.port=<swift-auth-url-port>
-  	-Dfs.swift.use.public.url=<swift-use-public>
-  	-Dfs.swift.auth.method=<swift-auth-model>
+{% include Configuring-Tachyon-with-Swift/several-configurations.md %}
   	
 Possible values of `<swift-use-public>` are `true`, `false`.
 Possible values of `<swift-auth-model>` are `keystone`,
 `tempauth`, `swiftauth`
 
-On the successfull authentication, Keystone will return two access URLs: public and private. If Tachyon is used inside company network and Swift is located on the same network it is adviced to set value of `<swift-auth-model>`  to `false`.
+On the successful authentication, Keystone will return two access URLs: public and private. If Tachyon is used inside company network and Swift is located on the same network it is adviced to set value of `<swift-auth-model>`  to `false`.
 
 
 ## Accessing IBM SoftLayer object store
@@ -60,39 +49,31 @@ SoftLayer requires `<swift-auth-model>` to be configured as `swiftauth`
 
 After everything is configured, you can start up Tachyon locally to see that everything works.
 
-```bash
-$ ./bin/tachyon format
-$ ./bin/tachyon-start.sh local
-```
+{% include Configuring-Tachyon-with-Swift/start-tachyon.md %}
 
 This should start a Tachyon master and a Tachyon worker. You can see the master UI at
 [http://localhost:19999](http://localhost:19999).
 
 Next, you can run a simple example program:
 
-```bash
-$ ./bin/tachyon runTests
-```
+{% include Configuring-Tachyon-with-Swift/runTests.md %}
 
 After this succeeds, you can visit your Swift container to verify the files and directories created
 by Tachyon exist. For this test, you should see files named like:
 
-    swift://<SWIFT CONTAINER>/tachyon/data/default_tests_files/BasicFile_STORE_SYNC_PERSIST
+{% include Configuring-Tachyon-with-Swift/swift-files.md %}
 
 To stop Tachyon, you can run:
 
-```bash
-$ ./bin/tachyon-stop.sh all
-```
+{% include Configuring-Tachyon-with-Swift/stop-tachyon.md %}
+
 # Running functional test with IBM SoftLayer
 
 Configure your Swift or SoftLayer account in the `tests/pom.xml`, where `authMethodKey` should be `keystone` or `tempauth` or `swiftauth`.
 To run functional tests execute
 
-```bash
-$ mvn test -PswiftTest -pl tests
-```
+{% include Configuring-Tachyon-with-Swift/functional-tests.md %}
+
 In case of failures, logs located under `tests/target/logs`. You may also activate heap dump via
 
-	<argLine>-XX:+HeapDumpOnOutOfMemoryError 
-		-XX:HeapDumpPath=/location/dump</argLine>
+{% include Configuring-Tachyon-with-Swift/heap-dump.md %}

--- a/docs/en/Configuring-Tachyon-with-Swift.md
+++ b/docs/en/Configuring-Tachyon-with-Swift.md
@@ -37,7 +37,7 @@ Possible values of `<swift-use-public>` are `true`, `false`.
 Possible values of `<swift-auth-model>` are `keystone`,
 `tempauth`, `swiftauth`
 
-On the successful authentication, Keystone will return two access URLs: public and private. If Tachyon is used inside company network and Swift is located on the same network it is adviced to set value of `<swift-auth-model>`  to `false`.
+On the successful authentication, Keystone will return two access URLs: public and private. If Tachyon is used inside company network and Swift is located on the same network it is adviced to set value of `<swift-use-public>`  to `false`.
 
 
 ## Accessing IBM SoftLayer object store


### PR DESCRIPTION
https://tachyon.atlassian.net/browse/TACHYON-1636
In `Configuring-Tachyon-with-Swift.md`, it writes "it is adviced to set value of `<swift-auth-model>`  to `false`". However, possible values of `<swift-auth-model>` are `keystone`, `tempauth`, `swiftauth`. Is this a typo and what it wants to say is setting value of `<swift-use-public>` to `false`?
![1636](https://cloud.githubusercontent.com/assets/15154819/12710417/7214a5e6-c8f1-11e5-94e9-2e52ba25b3b0.png)
