### PR TITLE
[SMALLFIX] Increase flaky test timeout

### DIFF
--- a/core/server/src/test/java/tachyon/master/lineage/recompute/TestRecomputeExecutor.java
+++ b/core/server/src/test/java/tachyon/master/lineage/recompute/TestRecomputeExecutor.java
@@ -59,7 +59,7 @@ public final class TestRecomputeExecutor {
 
     RecomputeExecutor executor = new RecomputeExecutor(planner, fileSystemMaster);
     // wait for the executor to finish running
-    executor.heartbeatWithFuture().get(1, TimeUnit.SECONDS);
+    executor.heartbeatWithFuture().get(5, TimeUnit.SECONDS);
     executor.close();
 
     Mockito.verify(fileSystemMaster).resetFile(fileId);


### PR DESCRIPTION
This build has failed a few times with timeouts in this test. I took a look and couldn't find any particular race conditions (or get it to fail), but waiting only 1 second seems a little on the short side. Lets wait a bit longer and see if it's just slow or actually failing.

Example failure: https://amplab.cs.berkeley.edu/jenkins/view/Tachyon/job/Tachyon-Master/1900/PROFILE=developer,label=centos/console