### PR TITLE
[SMALLFIX] Javadoc fixes

### DIFF
--- a/core/server/src/main/java/tachyon/master/block/BlockMasterClientServiceHandler.java
+++ b/core/server/src/main/java/tachyon/master/block/BlockMasterClientServiceHandler.java
@@ -38,7 +38,7 @@ public class BlockMasterClientServiceHandler implements BlockMasterClientService
   /**
    * Creates a new instance of {@link BlockMasterClientServiceHandler}.
    *
-   * @param blockMaster the {@BlockMaster} the handler uses internally
+   * @param blockMaster the {@link BlockMaster} the handler uses internally
    */
   public BlockMasterClientServiceHandler(BlockMaster blockMaster) {
     Preconditions.checkNotNull(blockMaster);

--- a/examples/src/main/java/tachyon/examples/Utils.java
+++ b/examples/src/main/java/tachyon/examples/Utils.java
@@ -64,7 +64,7 @@ public final class Utils {
   }
 
   /**
-   * Provides the options to show in the usage for a {@link boolean}.
+   * Provides the options to show in the usage for a {@code boolean}.
    *
    * @param args the arguments to parse
    * @param index the index of the option
@@ -81,7 +81,7 @@ public final class Utils {
   }
 
   /**
-   * Provides the options to show in the usage for an {@link int}.
+   * Provides the options to show in the usage for an {@code int}.
    *
    * @param args the arguments to parse
    * @param index the index of the option


### PR DESCRIPTION
- javadoc can't link to primitives