### PR TITLE
[DOCFIX] Remove a special invisible character in two md page files of Chinese version

### DIFF
--- a/docs/cn/Running-Tachyon-Locally.md
+++ b/docs/cn/Running-Tachyon-Locally.md
@@ -1,4 +1,4 @@
-﻿---
+---
 layout: global
 title: 本地运行Tachyon
 nickname: 本地机器上运行Tachyon

--- a/docs/cn/index.md
+++ b/docs/cn/index.md
@@ -1,4 +1,4 @@
-﻿---
+---
 layout: global
 title: 概览
 group: Home


### PR DESCRIPTION
A special invisible character was inserted in the two `md` page files, maybe due to the editor. Thus the `Overview` and `User Guide/Tachyon on local machine` pages don't have Chinese version in the language selector in http://tachyon-project.org/documentation/master/en/ because the two md files cannot be transferred to html files.
This special invisible character has been removed and can be seen by `git diff` command.
![docfix](https://cloud.githubusercontent.com/assets/15154819/13082804/2e3f1c3e-d50d-11e5-8663-9e92928c5870.png)


